### PR TITLE
42989 tasks [Frontend] Allow setting the due date in the past

### DIFF
--- a/frontend/src/public/components/DueIn/DueIn.tsx
+++ b/frontend/src/public/components/DueIn/DueIn.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useIntl } from 'react-intl';
 import classnames from 'classnames';
-import moment from 'moment-timezone';
 
 import { useSelector } from 'react-redux';
 import { getLanguage } from '../../redux/selectors/user';
@@ -12,12 +11,9 @@ import { getDate, getTime } from '../../utils/strings';
 import { Button, InputField, Tooltip } from '../UI';
 import { DatePickerCustom } from '../UI/form/DatePicker';
 import { setTimeForDate } from './utils/setTimeForDate';
-import { checkMinTimeForDate } from './utils/checkMinTimeForDate';
 import { IDueInProps } from './types';
 
 import styles from './DueIn.css';
-
-
 
 export function DueIn({
   dateCompleted,
@@ -60,13 +56,6 @@ export function DueIn({
 
     try {
       const dateWithTime = setTimeForDate(selectedDate, timeString, timezone, dateFmt);
-      const isValidMinTime = checkMinTimeForDate(dateWithTime, timezone);
-
-      if (!isValidMinTime) {
-        setTimeError(formatMessage({ id: 'due-date.time-too-early' }));
-        return;
-      }
-
       onSave(dateWithTime);
       dropdownRef.current?.closeDropdown();
     } catch (error) {
@@ -123,13 +112,7 @@ export function DueIn({
         placement="bottom-end"
       >
         <div className={styles['datepicker']}>
-          <DatePickerCustom
-            selected={selectedDate}
-            onChange={(date) => setSelectedDate(date)}
-            inline
-            showTimeInput
-            minDate={moment.tz(timezone).format('YYYY-MM-DD')}
-          />
+          <DatePickerCustom selected={selectedDate} onChange={(date) => setSelectedDate(date)} inline showTimeInput />
         </div>
 
         {withTime && (
@@ -173,4 +156,3 @@ export function DueIn({
     </div>
   );
 }
-


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Allow setting past due dates in the DueIn React component by removing minimum date and time validation
Remove the minimum date constraint and associated time validation from the DueIn React component in [DueIn.tsx](https://github.com/pneumaticapp/pneumaticworkflow/pull/28/files#diff-090c79059b8493d73bbf57d8ddadce219c13544e1e8b8021aae8bd434bb6f76a). The date picker no longer receives a `minDate` prop, and the `onSave` handler no longer checks a computed minimum or sets a `time-too-early` error. Minor prop formatting changes consolidate DatePickerCustom props into a single line without functional impact beyond the removed constraint.

#### 📍Where to Start
Start in the `DueIn` component render and `onSave` handler in [DueIn.tsx](https://github.com/pneumaticapp/pneumaticworkflow/pull/28/files#diff-090c79059b8493d73bbf57d8ddadce219c13544e1e8b8021aae8bd434bb6f76a), focusing on the removal of the `minDate` prop passed to `DatePickerCustom` and the deleted minimum time checks.

----

_[Macroscope](https://app.macroscope.com) summarized b4ea56d._
<!-- Macroscope's pull request summary ends here -->