### PR TITLE
34224 [frontend] Switch to new workflow delete API. Part 1

### DIFF
--- a/frontend/.storybook/initData.ts
+++ b/frontend/.storybook/initData.ts
@@ -86,7 +86,6 @@ window['__pneumaticConfig'] = {
         revertTask: '/v2/tasks/:id/revert',
         workflowLog: '/workflows/:id/events',
         taskWorkflowLog: '/v2/tasks/:id/events',
-        deleteWorkflow: '/workflows/:id/close',
         finishWorkflow: '/workflows/:id/finish',
         continueWorkflow: '/workflows/:id/resume',
         returnWorkflowToTask: '/workflows/:id/return-to',

--- a/frontend/config/common.json
+++ b/frontend/config/common.json
@@ -84,7 +84,6 @@
       "revertTask": "/v2/tasks/:id/revert",
       "workflowLog": "/workflows/:id/events",
       "taskWorkflowLog": "/v2/tasks/:id/events",
-      "deleteWorkflow": "/workflows/:id/close",
       "finishWorkflow": "/workflows/:id/finish",
       "continueWorkflow": "/workflows/:id/resume",
       "returnWorkflowToTask": "/workflows/:id/return-to",

--- a/frontend/src/public/api/deleteWorkflow.ts
+++ b/frontend/src/public/api/deleteWorkflow.ts
@@ -2,11 +2,13 @@ import { commonRequest } from './commonRequest';
 import { getBrowserConfigEnv } from '../utils/getConfig';
 
 export function deleteWorkflow(id: number) {
-  const { api: { urls }} = getBrowserConfigEnv();
+  const {
+    api: { urls },
+  } = getBrowserConfigEnv();
 
   return commonRequest(
-    urls.deleteWorkflow.replace(':id', String(id)),
-    { method: 'POST' },
+    urls.workflow.replace(':id', String(id)),
+    { method: 'DELETE' },
     { shouldThrow: true, responseType: 'empty' },
   );
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Switch frontend workflow deletion to use the new DELETE `/workflows/:id` API as part 1 of the migration
Update `public/api.deleteWorkflow` to send a DELETE to `urls.workflow` and remove `deleteWorkflow` URL entries from configuration. See [initData.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/57/files#diff-e9f87f5618bd83913e4af5b858ad5b29485201847482d84e89b4e10b7ae3db60), [common.json](https://github.com/pneumaticapp/pneumaticworkflow/pull/57/files#diff-239fd95ee1c9d1457b29aa7fddcd41885d31436523ab68b12bf86ffaba384117), and [deleteWorkflow.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/57/files#diff-29538cab0bfa980ee274ac70e65d8a32f14992efdf3fdc995af72a7508258899).

#### 📍Where to Start
Start with the `public/api.deleteWorkflow` function in [deleteWorkflow.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/57/files#diff-29538cab0bfa980ee274ac70e65d8a32f14992efdf3fdc995af72a7508258899).

----

<!-- MACROSCOPE_FOOTER_START -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 3dc1747. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
No issues evaluated.


</details>
<!-- MACROSCOPE_FOOTER_END -->
<!-- Macroscope's pull request summary ends here -->