### PR TITLE
43545 frontend [ workflows ] Add workflow id to workflow template name variables

### DIFF
--- a/frontend/src/public/components/TemplateEdit/TaskForm/utils/getTaskVariables.tsx
+++ b/frontend/src/public/components/TemplateEdit/TaskForm/utils/getTaskVariables.tsx
@@ -102,6 +102,13 @@ export const useWorkflowNameVariables = (kickoff?: Pick<IKickoff, 'fields'>) => 
         richSubtitle: null,
         type: EExtraFieldType.String,
       },
+      {
+        apiName: 'workflow-id',
+        title: formatMessage({ id: 'kickoff.system-varibale-workflow-id' }),
+        subtitle: formatMessage({ id: 'kickoff.system-varibale' }),
+        richSubtitle: null,
+        type: EExtraFieldType.Number,
+      },
     ],
     [formatMessage],
   );

--- a/frontend/src/public/lang/locales/en_US.ts
+++ b/frontend/src/public/lang/locales/en_US.ts
@@ -922,7 +922,7 @@ export const enMessages = {
   'kickoff.system-varibale': 'System',
   'kickoff.system-varibale-date': 'Date',
   'kickoff.system-varibale-template-name': 'Template name',
-
+  'kickoff.system-varibale-workflow-id': 'Workflow id',
   'sorting.date-asc': 'Oldest first',
   'sorting.date-desc': 'Newest first',
   'sorting.overdue': 'Overdue first',

--- a/frontend/src/public/lang/locales/ru_RU.ts
+++ b/frontend/src/public/lang/locales/ru_RU.ts
@@ -867,7 +867,7 @@ export const ruMessages = {
   'kickoff.system-varibale': 'Системная',
   'kickoff.system-varibale-date': 'Дата',
   'kickoff.system-varibale-template-name': 'Имя шаблона',
-
+  'kickoff.system-varibale-workflow-id': 'ID процесса',
   'sorting.date-asc': 'Сначала старые',
   'sorting.date-desc': 'Сначала новые',
   'sorting.overdue': 'Сначала просроченные',


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add `workflow-id` variable to `useWorkflowNameVariables` for workflow template naming in [getTaskVariables.tsx](https://github.com/pneumaticapp/pneumaticworkflow/pull/69/files#diff-7d0f062f2e6c13329c4fad399f4f3b3408d24533d00dd22ea4976086ca3e5c34)
Extend `CUSTOM_VARIABLES` to include system variable `workflow-id` (`EExtraFieldType.Number`) and add locale strings `kickoff.system-varibale-workflow-id` in en_US and ru_RU.

#### 📍Where to Start
Start with `useWorkflowNameVariables` in [getTaskVariables.tsx](https://github.com/pneumaticapp/pneumaticworkflow/pull/69/files#diff-7d0f062f2e6c13329c4fad399f4f3b3408d24533d00dd22ea4976086ca3e5c34).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized e29057f.
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->