### PR TITLE
43580 use pre-builded images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,7 @@ services:
   backend:
     build:
       context: ./backend
+    image: pneumaticworkflow/pneumatic-backend:${TAG:-stable}
     container_name: pneumatic-backend
     command: >
       sh -c "python manage.py migrate &&
@@ -82,6 +83,7 @@ services:
   celery:
     build:
       context: ./backend
+    image: pneumaticworkflow/pneumatic-celery:${TAG:-stable}
     container_name: pneumatic-celery
     env_file:
       - ./config/project.env
@@ -102,6 +104,7 @@ services:
   celery-beat:
     build:
       context: ./backend
+    image: pneumaticworkflow/pneumatic-celery-beat:${TAG:-stable}
     container_name: pneumatic-celery-beat
     env_file:
       - ./config/project.env
@@ -121,6 +124,7 @@ services:
   frontend:
     build:
       context: ./frontend
+    image: pneumaticworkflow/pneumatic-frontend:${TAG:-stable}
     container_name: pneumatic-frontend
     env_file:
       - ./config/project.env
@@ -139,8 +143,7 @@ services:
     restart: always
 
   nginx:
-    build:
-      context: ./nginx
+    image: nginx:1.25.4
     container_name: pneumatic-nginx
     env_file:
       - ./config/project.env


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Use pre-built images in docker-compose and pin nginx to `nginx:1.25.4` in [docker-compose.yml](https://github.com/pneumaticapp/pneumaticworkflow/pull/72/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3)
Switch services to explicit pre-built images with `${TAG:-stable}` tags and replace local nginx build with the `nginx:1.25.4` image in [docker-compose.yml](https://github.com/pneumaticapp/pneumaticworkflow/pull/72/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3).

#### 📍Where to Start
Start with the service definitions in [docker-compose.yml](https://github.com/pneumaticapp/pneumaticworkflow/pull/72/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3), focusing on the `backend`, `celery`, `celery-beat`, `frontend`, and `nginx` entries.

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 4d86f89.
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->