### PR TITLE
43588 backend [ auth ] Remove repeated requests for access rights

### DIFF
--- a/backend/src/authentication/services/google.py
+++ b/backend/src/authentication/services/google.py
@@ -329,8 +329,7 @@ class GoogleAuthService(
             'response_type': 'code',
             'state': state,
             'access_type': 'offline',
-            'prompt': 'consent',
-            'include_granted_scopes': 'false',
+            'include_granted_scopes': 'true',
         }
 
         query_string = urllib.parse.urlencode(params)

--- a/backend/src/authentication/tests/test_services/test_google_service.py
+++ b/backend/src/authentication/tests/test_services/test_google_service.py
@@ -109,7 +109,6 @@ class TestGoogleAuthService:
         assert 'response_type=code' in auth_uri
         assert 'state=' in auth_uri
         assert 'access_type=offline' in auth_uri
-        assert 'prompt=consent' in auth_uri
         set_cache_mock.assert_called_once()
 
     def test_parse_profile_data__complete_profile__returns_all_data(self):


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Remove repeated requests for access rights by setting `GoogleAuthService.build_authorization_url` to include `include_granted_scopes=true` and omit the `prompt` parameter
Update the Google OAuth authorization URL builder to drop `prompt=consent` and set `include_granted_scopes=true` in [google.py](https://github.com/pneumaticapp/pneumaticworkflow/pull/74/files#diff-c1129ca15f31702eee71dc55c302638b9779d5400a377f0a13b1e99e22f197b0); adjust the corresponding URI expectation in tests in [test_google_service.py](https://github.com/pneumaticapp/pneumaticworkflow/pull/74/files#diff-c2bf926f39344fa3aff54f324dd1f29bea6e8152d0951e8c130c99b7c3da38ab).

#### 📍Where to Start
Start with the URL construction logic in `GoogleAuthService` within [backend/src/authentication/services/google.py](https://github.com/pneumaticapp/pneumaticworkflow/pull/74/files#diff-c1129ca15f31702eee71dc55c302638b9779d5400a377f0a13b1e99e22f197b0).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 9e5faa9.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->