### PR TITLE
hotfix docker [storage] set GOOGLE_APPLICATION_CREDENTIALS env variable

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -107,6 +107,7 @@ services:
       PUSH_PROVIDER: ${PUSH_PROVIDER}
       STORAGE: ${STORAGE:-no}
       STORAGE_PROVIDER: ${STORAGE_PROVIDER}
+      GOOGLE_APPLICATION_CREDENTIALS: /pneumatic_backend/google_api_credentials.json
       SENTRY_DSN: ${SENTRY_DSN}
       POSTGRES_HOST: ${POSTGRES_HOST:-postgres}
       POSTGRES_USER: ${POSTGRES_USER:-postgres_user}
@@ -187,6 +188,7 @@ services:
       PUSH_PROVIDER: ${PUSH_PROVIDER}
       STORAGE: ${STORAGE:-no}
       STORAGE_PROVIDER: ${STORAGE_PROVIDER}
+      GOOGLE_APPLICATION_CREDENTIALS: /pneumatic_backend/google_api_credentials.json
       SENTRY_DSN: ${SENTRY_DSN}
       POSTGRES_HOST: ${POSTGRES_HOST:-postgres}
       POSTGRES_USER: ${POSTGRES_USER:-postgres_user}

--- a/docker-compose.src.yml
+++ b/docker-compose.src.yml
@@ -107,6 +107,7 @@ services:
       PUSH_PROVIDER: ${PUSH_PROVIDER}
       STORAGE: ${STORAGE:-no}
       STORAGE_PROVIDER: ${STORAGE_PROVIDER}
+      GOOGLE_APPLICATION_CREDENTIALS: /pneumatic_backend/google_api_credentials.json
       SENTRY_DSN: ${SENTRY_DSN}
       POSTGRES_HOST: ${POSTGRES_HOST:-postgres}
       POSTGRES_USER: ${POSTGRES_USER:-postgres_user}
@@ -193,6 +194,7 @@ services:
       PUSH_PROVIDER: ${PUSH_PROVIDER}
       STORAGE: ${STORAGE:-no}
       STORAGE_PROVIDER: ${STORAGE_PROVIDER}
+      GOOGLE_APPLICATION_CREDENTIALS: /pneumatic_backend/google_api_credentials.json
       SENTRY_DSN: ${SENTRY_DSN}
       POSTGRES_HOST: ${POSTGRES_HOST:-postgres}
       POSTGRES_USER: ${POSTGRES_USER:-postgres_user}
@@ -273,6 +275,7 @@ services:
       PUSH_PROVIDER: ${PUSH_PROVIDER}
       STORAGE: ${STORAGE:-no}
       STORAGE_PROVIDER: ${STORAGE_PROVIDER}
+      GOOGLE_APPLICATION_CREDENTIALS: /pneumatic_backend/google_api_credentials.json
       SENTRY_DSN: ${SENTRY_DSN}
       POSTGRES_HOST: ${POSTGRES_HOST:-postgres}
       POSTGRES_USER: ${POSTGRES_USER:-postgres_user}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,6 +108,7 @@ services:
       PUSH_PROVIDER: ${PUSH_PROVIDER}
       STORAGE: ${STORAGE:-no}
       STORAGE_PROVIDER: ${STORAGE_PROVIDER}
+      GOOGLE_APPLICATION_CREDENTIALS: /pneumatic_backend/google_api_credentials.json
       SENTRY_DSN: ${SENTRY_DSN}
       POSTGRES_HOST: ${POSTGRES_HOST:-postgres}
       POSTGRES_USER: ${POSTGRES_USER:-postgres_user}
@@ -194,6 +195,7 @@ services:
       PUSH_PROVIDER: ${PUSH_PROVIDER}
       STORAGE: ${STORAGE:-no}
       STORAGE_PROVIDER: ${STORAGE_PROVIDER}
+      GOOGLE_APPLICATION_CREDENTIALS: /pneumatic_backend/google_api_credentials.json
       SENTRY_DSN: ${SENTRY_DSN}
       POSTGRES_HOST: ${POSTGRES_HOST:-postgres}
       POSTGRES_USER: ${POSTGRES_USER:-postgres_user}
@@ -275,6 +277,7 @@ services:
       PUSH_PROVIDER: ${PUSH_PROVIDER}
       STORAGE: ${STORAGE:-no}
       STORAGE_PROVIDER: ${STORAGE_PROVIDER}
+      GOOGLE_APPLICATION_CREDENTIALS: /pneumatic_backend/google_api_credentials.json
       SENTRY_DSN: ${SENTRY_DSN}
       POSTGRES_HOST: ${POSTGRES_HOST:-postgres}
       POSTGRES_USER: ${POSTGRES_USER:-postgres_user}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Set GOOGLE_APPLICATION_CREDENTIALS to /pneumatic_backend/google_api_credentials.json in docker-compose files to hotfix backend storage configuration
Add the `GOOGLE_APPLICATION_CREDENTIALS=/pneumatic_backend/google_api_credentials.json` environment variable to relevant services in Docker Compose configurations.

#### 📍Where to Start
Start with the environment sections in [backend/docker-compose.yml](https://github.com/pneumaticapp/pneumaticworkflow/pull/93/files#diff-d213f1afed07cb75db7bfc90e0329ebd44bfcd3f4afcfbbef08f042eed694f78), then review corresponding entries in [docker-compose.yml](https://github.com/pneumaticapp/pneumaticworkflow/pull/93/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3) and [docker-compose.src.yml](https://github.com/pneumaticapp/pneumaticworkflow/pull/93/files#diff-f11168a69acca5524406d63f8be3493d9ca6df2b7f36502a45741fa7eee098aa).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 4fbc57e.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->