### PR TITLE
30250 frontend [ auth ] Add SSO authorization

### DIFF
--- a/frontend/src/server/__tests__/server.test.ts
+++ b/frontend/src/server/__tests__/server.test.ts
@@ -3,7 +3,6 @@ const utils = jest.requireActual('../../public/utils/getConfig');
 jest.mock('mini-css-extract-plugin', () => {
   const plugin = () => {};
   plugin.loader = {};
-
   return plugin;
 });
 
@@ -11,21 +10,16 @@ jest.mock('webpack', () => {
   const plugin = () => {};
   plugin.HotModuleReplacementPlugin = () => {};
   plugin.DefinePlugin = () => {};
-
   return plugin;
 });
 
 jest.mock('fork-ts-checker-webpack-plugin', () => {
   const plugin = () => {};
   plugin.loader = {};
-
   return plugin;
 });
-const getConfig = jest.fn();
-jest.mock('../../public/utils/getConfig', () => ({
-  getConfig,
-}));
-let mockConfig: any = { api: { urls: {} } };
+
+let mockConfig: any;
 jest.mock('../utils/request');
 jest.mock('express');
 jest.mock('webpack-dev-middleware');
@@ -37,10 +31,11 @@ jest.mock('../../public/utils/getConfig', () => ({
 }));
 jest.mock('../../../webpack.config.js');
 
-import * as express from 'express';
-import { initServer } from '../server';
+let express: typeof import('express');
+let app: any;
+let router: any;
 
-const app: any = {
+const createAppMock = () => ({
   use: jest.fn(),
   set: jest.fn(),
   get: jest.fn(),
@@ -48,36 +43,86 @@ const app: any = {
   post: jest.fn(),
   listen: jest.fn(),
   delete: jest.fn(),
-};
-const router: any = {
+});
+
+const createRouterMock = () => ({
   get: jest.fn(),
+});
+
+const initMockConfig = () => {
+  const realConfig = utils.getConfig();
+  return {
+    ...realConfig,
+    api: {
+      ...realConfig.api,
+      urls: realConfig.api?.urls || {},
+    },
+  };
+};
+
+const setupMocks = () => {
+  express = jest.requireMock('express');
+  app = createAppMock();
+  router = createRouterMock();
+  (express as unknown as jest.Mock).mockReturnValue(app);
+  (express.Router as unknown as jest.Mock).mockReturnValue(router);
+  
+  if (!mockConfig || !mockConfig.api?.urls) {
+    mockConfig = initMockConfig();
+  }
+  
+  const getConfigMock = jest.requireMock('../../public/utils/getConfig');
+  getConfigMock.getConfig = jest.fn(() => mockConfig);
 };
 
 describe('server', () => {
+  const originalEnv = process.env;
+
   describe('initServer', () => {
     beforeEach(() => {
       jest.resetAllMocks();
       jest.resetModules();
-      (express as unknown as jest.Mock).mockReturnValueOnce(app);
-      (express.Router as unknown as jest.Mock).mockReturnValueOnce(router);
-      mockConfig = { ...utils.getConfig(), ...mockConfig };
+      process.env = { ...originalEnv };
+      mockConfig = initMockConfig();
+      setupMocks();
     });
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
+    const setEnvAndGetInitServer = (env: Record<string, string | undefined>) => {
+      Object.assign(process.env, env);
+      jest.resetModules();
+      setupMocks();
+      return jest.requireActual('../server');
+    };
 
     it('starts the server for the production environment', () => {
       const log = jest.spyOn(console, 'info');
+
+      const { initServer } = setEnvAndGetInitServer({
+        NODE_ENV: 'production',
+        SSO_AUTH: 'no',
+      });
 
       initServer();
       const appListenCallback = app.listen.mock.calls[0][1];
       appListenCallback();
 
-      expect(app.use).toHaveBeenCalledTimes(6);
-      expect(app.get).toHaveBeenCalledTimes(8);
+      expect(app.use).toHaveBeenCalledTimes(4);
+      expect(app.get).toHaveBeenCalledTimes(7);
       expect(log).toHaveBeenCalledWith('App listening on port 8000');
     });
 
     it('returns port 8000 if not specified in the config', () => {
       const log = jest.spyOn(console, 'info');
-      mockConfig = { api: {}, port: undefined };
+      mockConfig = { ...mockConfig, port: undefined };
+
+      const { initServer } = setEnvAndGetInitServer({
+        NODE_ENV: 'production',
+        SSO_AUTH: 'no',
+      });
 
       initServer();
       const [appListenPort, appListenCallback] = app.listen.mock.calls[0];
@@ -88,9 +133,51 @@ describe('server', () => {
     });
 
     it('starts the server for the development environment', () => {
+      const { initServer } = setEnvAndGetInitServer({
+        NODE_ENV: 'development',
+        SSO_AUTH: 'no',
+      });
+
       initServer();
+
       expect(app.use).toHaveBeenCalledTimes(6);
+      expect(app.get).toHaveBeenCalledTimes(7);
+    });
+
+    it('adds Auth0 SSO route when SSO_AUTH is enabled and SSO_PROVIDER is Auth0', () => {
+      const { initServer } = setEnvAndGetInitServer({
+        NODE_ENV: 'production',
+        SSO_AUTH: 'yes',
+        SSO_PROVIDER: 'auth0',
+      });
+
+      initServer();
+
       expect(app.get).toHaveBeenCalledTimes(8);
+    });
+
+    it('adds Okta SSO route when SSO_AUTH is enabled and SSO_PROVIDER is Okta', () => {
+      const { initServer } = setEnvAndGetInitServer({
+        NODE_ENV: 'production',
+        SSO_AUTH: 'yes',
+        SSO_PROVIDER: 'okta',
+      });
+
+      initServer();
+      
+      expect(app.get).toHaveBeenCalledTimes(8);
+    });
+
+    it('does not add SSO routes when SSO_AUTH is disabled', () => {
+      const { initServer } = setEnvAndGetInitServer({
+        NODE_ENV: 'production',
+        SSO_AUTH: 'no',
+        SSO_PROVIDER: 'auth0',
+      });
+
+      initServer();
+
+      expect(app.get).toHaveBeenCalledTimes(7);
     });
   });
 });

--- a/frontend/src/server/server.ts
+++ b/frontend/src/server/server.ts
@@ -100,7 +100,7 @@ export function initServer() {
   app.get(ERoutes.AccountVerificationLink, verificateAccountMiddleware);
   app.get(ERoutes.OAuthGoogle, oAuthHandler(urls.getGoogleAuthUri, urls.getGoogleAuthToken));
   app.get(ERoutes.OAuthMicrosoft, oAuthHandler(urls.getMicrosoftAuthUri, urls.getMicrosoftAuthToken));
-  
+
   if (isSSOAuth && envSSOProvider === SSOProvider.Auth0) { 
     app.get(ERoutes.OAuthSSOAuth0, oAuthHandler(urls.getSSOAuthUri, urls.getSSOAuthToken));
   }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add SSO authorization to frontend server by conditionally registering Auth0 and Okta routes in `server.initServer` with environment-driven behavior
Refactor tests to dynamically load config and environment, add helpers to mock Express and config, and add SSO route registration tests asserting `app.get` counts (7 when disabled, 8 when enabled for Auth0 or Okta). Update production and development expectations for `app.use` and `app.get`. No functional changes in [frontend/src/server/server.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/95/files#diff-7cab5667329c51ead37087f81b807caf14dc776c53bd4623a70233e3a527245d).

#### 📍Where to Start
Start with the SSO route registration logic inside `initServer` in [frontend/src/server/server.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/95/files#diff-7cab5667329c51ead37087f81b807caf14dc776c53bd4623a70233e3a527245d), then review the test harness setup in [frontend/src/server/__tests__/server.test.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/95/files#diff-598df658d2534c36a04138a95a212618d054607a059114711dee7c93d74f1a0a) to see how env and config drive route counts.

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized dab7baf.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->