### PR TITLE
43989 backend [ mail ] fix config email provider

### DIFF
--- a/backend/src/settings.py
+++ b/backend/src/settings.py
@@ -269,8 +269,8 @@ class Common(Configuration):
         'Pneumatic <no-reply@pneumatic.app>',
     )
     EMAIL_DATE_FORMAT = '%a, %d %b %Y %I:%M:%S %p UTC'
+    EMAIL_PROVIDER = env.get('EMAIL_PROVIDER')
     if env.get('EMAIL') == 'yes':
-        EMAIL_PROVIDER = env.get('EMAIL_PROVIDER')
         if EMAIL_PROVIDER == EmailProvider.CUSTOMERIO:
             EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
             CUSTOMERIO_WEBHOOK_API_VERSION = env.get('CIO_WEBHOOK_API_VERSION')


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Gate email configuration on env `EMAIL == 'yes'` and require explicit `EmailProvider` selection in `backend/src/settings.py`
Add a top-level `EMAIL` flag check and split provider handling so `EmailProvider.CUSTOMERIO` configures console backend with `CUSTOMERIO_*` keys and `EmailProvider.SMTP` configures SMTP settings; remove the implicit SMTP fallback in [settings.py](https://github.com/pneumaticapp/pneumaticworkflow/pull/96/files#diff-4ebb2dca867e34d3dc6650f04231a53436b5bf1745e9efd5dfba4581bb791c66).

#### 📍Where to Start
Start in the Common Configuration section that initializes email settings in [settings.py](https://github.com/pneumaticapp/pneumaticworkflow/pull/96/files#diff-4ebb2dca867e34d3dc6650f04231a53436b5bf1745e9efd5dfba4581bb791c66), focusing on the new `EMAIL` gate and the `EMAIL_PROVIDER` conditionals.

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 0e80212. 1 file reviewed, 3 issues evaluated, 1 issue filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>backend/src/settings.py — 0 comments posted, 3 evaluated, 1 filtered</summary>

- [line 273](https://github.com/pneumaticapp/pneumaticworkflow/blob/0e80212584add94b6234e852bf1ff34027e966e2/backend/src/settings.py#L273): When `EMAIL='yes'` but `EMAIL_PROVIDER` is neither `'customerio'` nor `'smtp'` (e.g., `None`, empty string, or a typo), `EMAIL_BACKEND` is never set. The old code had an `else` clause that defaulted to SMTP backend, but the new code uses `elif`, leaving `EMAIL_BACKEND` undefined. This will cause Django to use its default email backend or raise an `AttributeError` when trying to send emails, depending on how the application accesses the setting. <b>[ Already posted ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->