### PR TITLE
39415 Markdown [Frontend] The dot in the link is converted to a duplicate attachment

### DIFF
--- a/frontend/src/public/components/RichEditor/utils/handlePasteAttachments.ts
+++ b/frontend/src/public/components/RichEditor/utils/handlePasteAttachments.ts
@@ -1,5 +1,4 @@
 import { EditorState } from 'draft-js';
-// tslint:disable-next-line: match-default-export-name
 import createAttachmentPlugin from './AttachmentsPlugin';
 
 import { uploadFiles } from '../../../utils/uploadFiles';
@@ -18,11 +17,12 @@ export const handlePasteAttachments = async (
 ) => {
   onStartUpload();
   const text = e.clipboardData?.getData('text/plain') || '';
+
   const textImageUrls: TEditorAttachment[] = (text
     .match(urlRegex)
     ?.map((url) => {
       const fileType = getAttachmentTypeByUrl(url);
-      if (!fileType) {
+      if (fileType !== 'image' && fileType !== 'video') {
         return null;
       }
 
@@ -35,6 +35,7 @@ export const handlePasteAttachments = async (
 
     return fileTypesRegExps.some((regEx) => regEx.test(i.type));
   });
+
   const uploadedImages: TEditorAttachment[] = await uploadFiles(
     pastedImages.map((image) => image.getAsFile()).filter(Boolean) as File[],
     accountId,


### PR DESCRIPTION
## 1. Description (Problem)

When pasting text containing a URL into the **RichEditor** (text field with attachment support), links with a dot in the path (e.g. `https://example.com/document.pdf`, `https://site.com/page.html`) were incorrectly recognized as attachments and added to the editor as inline attachments.

Root cause: the `getAttachmentTypeByUrl` function returns a type for any URL with a file extension — `'image'`, `'video'`, or `'file'` (fallback). The old check `if (!fileType)` only filtered out URLs without a recognized extension (when the function returned `null`), but allowed URLs with type `'file'` (PDF, HTML, DOC, etc.) through. As a result, such links were turned into duplicate attachments.

---

## 2. Context

- Component: **RichEditor** — a Draft.js-based text editor used in task descriptions, comments, and other places where attachments are supported.
- Affected logic: paste event handling (`handlePasteAttachments`) — parsing URLs from pasted text and creating attachments from them.

---

## 3. Solution

Changed the file type check when parsing URLs from pasted text: instead of `if (!fileType)` (which allows everything except `null`), now uses `if (fileType !== 'image' && fileType !== 'video')`. This way, only links to images (JPG, JPEG, PNG, GIF) and videos (MP4, MOV, WMV, etc.) are added as attachments from pasted URLs, while links to other file types and links without an extension are ignored.

This aligns with the original intent: the variable is named `textImageUrls`, and only images and videos make sense to display as inline attachments in the editor.

---

## 5. What to test

### 5.1 Preconditions

- Dev environment, authenticated user.
- Any place in the application where **RichEditor** with attachment support is used (e.g. template step description, task comment).
- Prepare a set of URLs for pasting:
  - Image URL: `https://example.com/photo.jpg`
  - Video URL: `https://example.com/clip.mp4`
  - File URL: `https://example.com/document.pdf`
  - URL without a file extension: `https://example.com/some-page`
  - URL with a dot in the path but no file extension: `https://example.com/path.to/resource`

### 5.2 Positive scenarios

1. - [ ] Paste an image URL (`https://example.com/photo.jpg`) → the URL is added as an inline attachment (image preview is displayed).
2. - [ ] Paste a video URL (`https://example.com/clip.mp4`) → the URL is added as an inline attachment (video preview is displayed).
3. - [ ] Paste text containing multiple URLs — including an image and a regular link → only the image URL is added as an attachment; the rest remain as text.
4. - [ ] Paste an image file from the clipboard (not a URL, but a file via Ctrl+V) → the file is uploaded and added as an attachment (existing behavior, should not break).

### 5.3 Negative scenarios and edge cases

1. - [ ] Paste a PDF file URL (`https://example.com/document.pdf`) → an attachment should **not** be created; the URL remains part of the text.
2. - [ ] Paste an HTML page URL (`https://example.com/page.html`) → an attachment should **not** be created.
3. - [ ] Paste a URL without an extension (`https://example.com/some-page`) → an attachment should **not** be created.
4. - [ ] Paste a URL with a dot in the path but no file extension (`https://example.com/path.to/resource`) → an attachment should **not** be created.

### 5.4 Verification points

- **UI:** after pasting a URL, verify that an attachment is displayed only for images and videos.
- **UI:** ensure that non-visual URLs remain as plain text and do not create duplicate attachment blocks.

---

## 7. Testing affected areas

The `handlePasteAttachments` function is used in all **RichEditor** instances where attachments are supported. Verify that pasting images and videos still works in the following places:

- [ ] Template step description.
- [ ] Task comments, if RichEditor with attachments is used there.
- [ ] Any other fields with RichEditor + attachments.

Minimum check: paste an image URL → verify that the attachment was created.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Restrict `frontend/src/public/components/RichEditor/utils/handlePasteAttachments.ts::handlePasteAttachments` to convert pasted plain-text URLs into attachments only when `getAttachmentTypeByUrl(url)` returns `image` or `video` to address duplicate attachment creation from links with dots
Tighten the attachment type filter in [handlePasteAttachments.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/109/files#diff-00ee051c39a4984fea19339484cb80f56bd9c19b8ef2a590deed690d22f88a30) to accept only `image` and `video` from `getAttachmentTypeByUrl(url)`; discard all other types.

#### 📍Where to Start
Start with the URL type check inside `handlePasteAttachments` in [handlePasteAttachments.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/109/files#diff-00ee051c39a4984fea19339484cb80f56bd9c19b8ef2a590deed690d22f88a30).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 924353f.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->