### PR TITLE
Revise README for .env file setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,9 @@ git clone https://github.com/pneumaticapp/pneumaticworkflow.git
 ```
 or, you can simply download the [project's master folder](https://github.com/pneumaticapp/pneumaticworkflow/archive/refs/heads/master.zip) and unzip it
 
-### Edit the configuration files if necessary
+### Create a .env config file
 
-
-If you want to be accessing Pneumatic over the Internet and the machine you plan to be running it on has an external IP address/domain name, all you need to do is create an .env file in the root directory of the project (touch .env) and add these lines to it:
+Cd into the project's directory and run the ```./start.sh``` script, passing it the address of your server as the sole argument(```./start.sh your-address```). If no argument is passed the script will use localhost as the default address and create a .env file setting the following parameters:
 
 <pre>
   # Without SSL
@@ -103,7 +102,6 @@ If you want to be accessing Pneumatic over the Internet and the machine you plan
   WSS_URL=ws://your-address:8001
 </pre>
 
-save the .env file and you're good to go.
 
 ### Run Pneumatic
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ git clone https://github.com/pneumaticapp/pneumaticworkflow.git
 ```
 or, you can simply download the [project's master folder](https://github.com/pneumaticapp/pneumaticworkflow/archive/refs/heads/master.zip) and unzip it
 
-### Create a .env config file
+### Automatically create a .env config file and run
 
 Cd into the project's directory, run ```chmod +x start.sh```, and then run the ```./start.sh``` script, passing it the address of your server as the sole argument(```./start.sh your-address```). If no argument is passed the script will use localhost as the default address and create a .env file setting the following parameters:
 
@@ -102,17 +102,11 @@ Cd into the project's directory, run ```chmod +x start.sh```, and then run the `
   WSS_URL=ws://your-address:8001
 </pre>
 
+The script will then proceed to run ```docker compose up -d ```
 
-### Run Pneumatic
-
-To run Pneumatic cd into the project's directory and run the command
-
-```
-docker compose up -d
-```
 This will run it in detached mode, if you want to see what's happening omit the -d flag.
 
-Alternatively, you can run the Pneumatic containers from Docker Desktop.
+Alternatively, you can create a .env file with the required parameters manually and run pneumatic either in terminal by executing the ```docker compose up -d``` command in your project's directory or from docker desktop.
 
 Note, that the way it's currently configured, Pneumatic's frontend takes a while to get up and running.
 But you can almost immediately check that your backend is up by going to `http://your-address:8001/admin`

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ or, you can simply download the [project's master folder](https://github.com/pne
 
 ### Create a .env config file
 
-Cd into the project's directory and run the ```./start.sh``` script, passing it the address of your server as the sole argument(```./start.sh your-address```). If no argument is passed the script will use localhost as the default address and create a .env file setting the following parameters:
+Cd into the project's directory, run ```chmod +x start.sh```, and then run the ```./start.sh``` script, passing it the address of your server as the sole argument(```./start.sh your-address```). If no argument is passed the script will use localhost as the default address and create a .env file setting the following parameters:
 
 <pre>
   # Without SSL


### PR DESCRIPTION
Updated README to include instructions for creating a .env config file and clarified usage of the start.sh script.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; the only impact is on onboarding guidance for running the project locally or on a server.
> 
> **Overview**
> Updates `README.md` setup instructions to prefer running `chmod +x start.sh` and `./start.sh [address]` to auto-generate a `.env` (defaulting to `localhost`) and then start containers via `docker compose up -d`.
> 
> Also clarifies the manual fallback: users may still create `.env` themselves and run Docker Compose (or Docker Desktop) directly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 207a9bdc2a81db9fe97d01b7b8a2b94f8e3c3b81. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Revise README to document `start.sh` for automatic `.env` creation and Docker Compose startup
> Update [README.md](https://github.com/pneumaticapp/pneumaticworkflow/pull/155/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) to direct users to run `chmod +x start.sh` and `./start.sh your-address` (defaults to `localhost`), which creates a `.env` with predefined variables and runs `docker compose up -d`; retain brief manual alternative instructions and remove prior manual setup sections.
>
> #### 📍Where to Start
> Start with the README changes in [README.md](https://github.com/pneumaticapp/pneumaticworkflow/pull/155/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 207a9bd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->