### PR TITLE
Fix 401/403/404 logged as app errors instead of user errors in production [Sentry #18P]

### DIFF
--- a/frontend/src/public/api/__tests__/isUserError.test.ts
+++ b/frontend/src/public/api/__tests__/isUserError.test.ts
@@ -1,0 +1,16 @@
+// <reference types="jest" />
+import { isUserError, USER_ERROR_STATUSES } from '../isUserError';
+
+describe('isUserError', () => {
+  it.each([401, 403, 404])('status %d returns true (user error)', (status) => {
+    expect(isUserError(status)).toBe(true);
+  });
+
+  it.each([400, 500, 502, 503])('status %d returns false (app/server error)', (status) => {
+    expect(isUserError(status)).toBe(false);
+  });
+
+  it('USER_ERROR_STATUSES contains only 401, 403, 404', () => {
+    expect(USER_ERROR_STATUSES).toEqual([401, 403, 404]);
+  });
+});

--- a/frontend/src/public/api/commonRequest.ts
+++ b/frontend/src/public/api/commonRequest.ts
@@ -94,7 +94,7 @@ axiosInstance.interceptors.response.use(
 
     const data = error.response?.data;
     const payload = typeof data === 'string' ? { error: data } : data ?? {};
-    return Promise.reject(Object.assign(new Error(), payload, { status: error.response?.status }));
+    return Promise.reject(Object.assign(new Error(), payload, { status: error.response?.status, loggedByInterceptor: true }));
   },
 );
 
@@ -130,9 +130,12 @@ export async function commonRequest<T>(
     }
 
     return response.data as T;
-  } catch (error) {
+  } catch (error: any) {
     if (shouldThrow) {
       throw error;
+    }
+    if (!error.loggedByInterceptor) {
+      logger.error(error);
     }
     return undefined as unknown as T;
   }

--- a/frontend/src/public/api/commonRequest.ts
+++ b/frontend/src/public/api/commonRequest.ts
@@ -9,6 +9,7 @@ import { identifyAppPartOnClient } from '../utils/identifyAppPart/identifyAppPar
 import { getCurrentToken } from '../utils/auth';
 import { envBackendURL } from '../constants/enviroment';
 import { isRequestCanceled } from '../utils/isRequestCanceled';
+import { isUserError } from './isUserError';
 
 export type TRequestType = 'public' | 'local';
 export type TResponseType = 'json' | 'text' | 'empty';
@@ -80,7 +81,11 @@ axiosInstance.interceptors.response.use(
     }
 
     if (error.response) {
-      logger.error('Response Error:', error.response.data);
+      if (isUserError(error.response.status)) {
+        logger.info('Response Error:', error.response.data);
+      } else {
+        logger.error('Response Error:', error.response.data);
+      }
     } else if (error.request) {
       logger.error('Request Error:', error.request);
     } else {

--- a/frontend/src/public/api/commonRequest.ts
+++ b/frontend/src/public/api/commonRequest.ts
@@ -134,7 +134,6 @@ export async function commonRequest<T>(
     if (shouldThrow) {
       throw error;
     }
-    logger.error(error);
     return undefined as unknown as T;
   }
 }

--- a/frontend/src/public/api/isUserError.ts
+++ b/frontend/src/public/api/isUserError.ts
@@ -1,0 +1,5 @@
+export const USER_ERROR_STATUSES = [401, 403, 404];
+
+export function isUserError(status: number): boolean {
+  return USER_ERROR_STATUSES.includes(status);
+}


### PR DESCRIPTION
### Problem
The axios response interceptor in `commonRequest.ts` logs ALL HTTP errors (including 401, 403, 404) as `logger.error`, which triggers `Sentry.captureException`. This floods Sentry with expected user errors (unauthorized, forbidden, not found) that are not application bugs.

### Context
- **Sentry issue:** [#18P](https://pneumatic.sentry.io/issues/PNEUMATIC-FRONTEND-PROD-18P) — Permission denied logged as error (104 events, 20 users)
- **Environment:** production (pneumatic-frontend-prod)

> [!NOTE]
> Issues #116 (PR #5 — "Not found" mixed bag) and #18Y/#184/#181/#17Z/#17K/#17H/#17E/#17D (PR #7 — public forms auth credentials) **have been moved to separate investigations**, as they require additional analysis of error sources beyond log filtering.

### Solution
Introduced status-code-based log level filtering in the axios response interceptor. HTTP statuses 401 (Unauthorized), 403 (Forbidden), and 404 (Not Found) are now logged as `logger.info` (console only, no Sentry), while all other errors (400, 5xx) remain as `logger.error` (Sentry capture).

Also removed duplicate `logger.error(error)` from the `commonRequest` catch block — the interceptor already logs the error, so the catch block was sending the same error to Sentry a second time.

### Implementation Details

**New file: `isUserError.ts`**
```typescript
export const USER_ERROR_STATUSES = [401, 403, 404];

export function isUserError(status: number): boolean {
  return USER_ERROR_STATUSES.includes(status);
}
```

**Modified: `commonRequest.ts`** (response interceptor)
```diff
     if (error.response) {
-      logger.error('Response Error:', error.response.data);
+      if (isUserError(error.response.status)) {
+        logger.info('Response Error:', error.response.data);
+      } else {
+        logger.error('Response Error:', error.response.data);
+      }
     }
```

**Modified: `commonRequest.ts`** (catch block — removed duplicate logging)
```diff
   } catch (error) {
     if (shouldThrow) {
       throw error;
     }
-    logger.error(error);
     return undefined as unknown as T;
   }
```

### Testing

#### Positive scenarios
- [ ] **401 Unauthorized:** Open the app with an expired token → API returns 401 → verify NO new error event in Sentry, only console.info
- [ ] **403 Forbidden:** Attempt an action without sufficient permissions → API returns 403 → verify NO new error event in Sentry
- [ ] **404 Not Found:** Navigate to a non-existent resource (e.g., `/workflows/99999999`) → API returns 404 → verify NO new error event in Sentry

#### Negative / edge cases
- [ ] **400 Bad Request:** Submit invalid form data → API returns 400 → verify error IS still sent to Sentry (app bug, not user error)
- [ ] **500 Internal Server Error:** Trigger a server error → verify error IS still sent to Sentry
- [ ] **Network error (no response):** Disconnect network → verify `logger.error('Request Error:')` still fires

#### Automated tests
- `frontend/src/public/api/__tests__/isUserError.test.ts` — 8 tests, all passing
- Full test suite: 93 suites, 488 tests — all passing, no regressions

---

Closes https://pneumatic.sentry.io/issues/PNEUMATIC-FRONTEND-PROD-18P/

---

> [!NOTE]
> **Low Risk:** Only changes client-side logging severity in the Axios response interceptor for a small set of HTTP statuses and removes a redundant catch-all `logger.error`, without altering request/response behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only client-side error logging/annotation in the Axios interceptor and suppresses duplicate logs, without altering request/response behavior.
> 
> **Overview**
> Reduces noise in production error reporting by treating HTTP `401/403/404` as *user/expected* failures: the Axios response interceptor now logs these as `logger.info` while continuing to log other response failures as `logger.error`.
> 
> Adds `isUserError`/`USER_ERROR_STATUSES` to centralize the status list, tags rejected errors with `loggedByInterceptor` to avoid duplicate logging in `commonRequest`, and includes Jest coverage for the new helper.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c1106ec8756b02f1c784f26e9a12502dee1ca2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix 401/403/404 HTTP errors logged as app errors instead of user errors
> - Adds `isUserError` utility in [isUserError.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/189/files#diff-9500ce9d5f52147d7a3c8ae7c3b46337a4cb25d7ce32538afff683089dca04a4) that identifies 401, 403, and 404 as user errors.
> - Updates the axios response interceptor in [commonRequest.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/189/files#diff-7d429e9cf8c4d29682c46cd3b707ccee5ef9388cdcddfbdbe8be6b034c1378aa) to log 401/403/404 responses at `info` level instead of `error`, reducing noise in Sentry.
> - Marks interceptor-logged errors with `loggedByInterceptor: true` to prevent duplicate logging in the `commonRequest` catch clause.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8c1106e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->