### PR TITLE
🔧 45763 backend [ digest ] Fix KeyError "workflow-starter"

### DIFF
--- a/backend/src/reports/services/tasks.py
+++ b/backend/src/reports/services/tasks.py
@@ -58,12 +58,19 @@ class SendTasksDigest(SendDigest):
         task_name: str,
         template: TemplateForTasksDigest,
     ):
-        api_name = VAR_PATTERN.findall(task_name)
-        if api_name:
-            task_name = insert_fields_values_to_text(
-                text=task_name,
-                fields_values={api_name[0]: template.fields[api_name[0]]},
-            )
+        api_names = VAR_PATTERN.findall(task_name)
+        if api_names:
+            fields_values = {}
+            for api_name in api_names:
+                if api_name in template.fields:
+                    fields_values[api_name] = template.fields[api_name]
+                elif api_name == 'template-name':
+                    fields_values[api_name] = template.template_name
+            if fields_values:
+                task_name = insert_fields_values_to_text(
+                    text=task_name,
+                    fields_values=fields_values,
+                )
         return task_name
 
     def _add_template_data(

--- a/backend/src/reports/tests/test_tasks/test_tasks_digest.py
+++ b/backend/src/reports/tests/test_tasks/test_tasks_digest.py
@@ -1,3 +1,8 @@
+# ruff: noqa: UP031
+from unittest.mock import PropertyMock
+from src.reports.entities import TemplateForTasksDigest
+from src.reports.services.tasks import SendTasksDigest
+
 from datetime import timedelta
 
 import pytest
@@ -35,6 +40,8 @@ def replica_mock(mocker):
 
 
 class TestSendTasksDigest:
+
+    # Deprecated cumulative tests
 
     def test_send(self, mocker, api_client):
 
@@ -712,3 +719,374 @@ class TestSendTasksDigest:
             },
             logo_lg=None,
         )
+
+
+def test_replace_api_name__no_vars__unchanged(mocker):
+
+    """task_name has no template variables —
+    string must be returned as-is."""
+
+    # arrange
+    fields_mock = mocker.patch.object(
+        TemplateForTasksDigest,
+        'fields',
+        new_callable=PropertyMock,
+        return_value={},
+    )
+    service = SendTasksDigest.__new__(SendTasksDigest)
+    template = TemplateForTasksDigest(
+        template_id=1,
+        template_name='Onboarding',
+    )
+    task_name = 'Review documents'
+
+    # act
+    result = service._replace_api_name(
+        task_name=task_name,
+        template=template,
+    )
+
+    # assert
+    assert result == 'Review documents'
+    fields_mock.assert_not_called()
+
+
+def test_replace_api_name__single_field_var__replaced(mocker):
+
+    """task_name has one field api_name variable —
+    substituted with field label."""
+
+    # arrange
+    insert_fields_values_to_text_mock = mocker.patch(
+        'src.reports.services.tasks.insert_fields_values_to_text',
+        return_value='Review Contract',
+    )
+    service = SendTasksDigest.__new__(SendTasksDigest)
+    template = TemplateForTasksDigest(
+        template_id=1,
+        template_name='Onboarding',
+    )
+    template._fields = {'field-abc123': 'Contract'}
+    task_name = 'Review {{ field-abc123 }}'
+
+    # act
+    result = service._replace_api_name(
+        task_name=task_name,
+        template=template,
+    )
+
+    # assert
+    assert result == 'Review Contract'
+    insert_fields_values_to_text_mock.assert_called_once_with(
+        text='Review {{ field-abc123 }}',
+        fields_values={'field-abc123': 'Contract'},
+    )
+
+
+def test_replace_api_name__multiple_field_vars__all_replaced(mocker):
+
+    """task_name has multiple field variables —
+    all are substituted."""
+
+    # arrange
+    insert_fields_values_to_text_mock = mocker.patch(
+        'src.reports.services.tasks.insert_fields_values_to_text',
+        return_value='Alpha and Beta',
+    )
+    service = SendTasksDigest.__new__(SendTasksDigest)
+    template = TemplateForTasksDigest(
+        template_id=1,
+        template_name='Onboarding',
+    )
+    template._fields = {'field-aaa': 'Alpha', 'field-bbb': 'Beta'}
+    task_name = '{{ field-aaa }} and {{ field-bbb }}'
+
+    # act
+    result = service._replace_api_name(
+        task_name=task_name,
+        template=template,
+    )
+
+    # assert
+    assert result == 'Alpha and Beta'
+    insert_fields_values_to_text_mock.assert_called_once_with(
+        text='{{ field-aaa }} and {{ field-bbb }}',
+        fields_values={'field-aaa': 'Alpha', 'field-bbb': 'Beta'},
+    )
+
+
+def test_replace_api_name__template_name__replaced(mocker):
+
+    """task_name has {{ template-name }} —
+    substituted with template.template_name."""
+
+    # arrange
+    fields_mock = mocker.patch.object(
+        TemplateForTasksDigest,
+        'fields',
+        new_callable=PropertyMock,
+        return_value={},
+    )
+    insert_fields_values_to_text_mock = mocker.patch(
+        'src.reports.services.tasks.insert_fields_values_to_text',
+        return_value='Task of Onboarding',
+    )
+    service = SendTasksDigest.__new__(SendTasksDigest)
+    template = TemplateForTasksDigest(
+        template_id=1,
+        template_name='Onboarding',
+    )
+    task_name = 'Task of {{ template-name }}'
+
+    # act
+    result = service._replace_api_name(
+        task_name=task_name,
+        template=template,
+    )
+
+    # assert
+    assert result == 'Task of Onboarding'
+    fields_mock.assert_called()
+    insert_fields_values_to_text_mock.assert_called_once_with(
+        text='Task of {{ template-name }}',
+        fields_values={'template-name': 'Onboarding'},
+    )
+
+
+@pytest.mark.parametrize(
+    'system_var',
+    ('date', 'workflow-starter', 'workflow-id'),
+)
+def test_replace_api_name__system_var__not_replaced(
+    mocker,
+    system_var,
+):
+
+    # arrange
+    fields_mock = mocker.patch.object(
+        TemplateForTasksDigest,
+        'fields',
+        new_callable=PropertyMock,
+        return_value={},
+    )
+    insert_fields_values_to_text_mock = mocker.patch(
+        'src.reports.services.tasks.insert_fields_values_to_text',
+        return_value='Deadline: date',
+    )
+    service = SendTasksDigest.__new__(SendTasksDigest)
+    template = TemplateForTasksDigest(
+        template_id=1,
+        template_name='Onboarding',
+    )
+    task_name = 'Deadline: {{ %s }}' % system_var
+
+    # act
+    result = service._replace_api_name(
+        task_name=task_name,
+        template=template,
+    )
+
+    # assert
+    assert result == 'Deadline: {{ %s }}' % system_var
+    fields_mock.assert_called()
+    insert_fields_values_to_text_mock.assert_not_called()
+
+
+def test_replace_api_name__field_and_template_name_var__both_replaced(mocker):
+
+    """task_name mixes a field var and {{ template-name }} —
+    both substituted correctly."""
+
+    # arrange
+    insert_fields_values_to_text_mock = mocker.patch(
+        'src.reports.services.tasks.insert_fields_values_to_text',
+        return_value='Contract for Sales',
+    )
+    service = SendTasksDigest.__new__(SendTasksDigest)
+    template = TemplateForTasksDigest(
+        template_id=1,
+        template_name='Sales',
+    )
+    template._fields = {'field-abc123': 'Contract'}
+    task_name = '{{ field-abc123 }} for {{ template-name }}'
+
+    # act
+    result = service._replace_api_name(
+        task_name=task_name,
+        template=template,
+    )
+
+    # assert
+    assert result == 'Contract for Sales'
+    insert_fields_values_to_text_mock.assert_called_once_with(
+        text='{{ field-abc123 }} for {{ template-name }}',
+        fields_values={
+            'field-abc123': 'Contract',
+            'template-name': 'Sales',
+        },
+    )
+
+
+def test_replace_api_name__unknown_var__not_replaced(mocker):
+
+    """task_name has api_name absent from template.fields —
+    falls back to var name."""
+
+    # arrange
+    fields_mock = mocker.patch.object(
+        TemplateForTasksDigest,
+        'fields',
+        new_callable=PropertyMock,
+        return_value={},
+    )
+    insert_fields_values_to_text_mock = mocker.patch(
+        'src.reports.services.tasks.insert_fields_values_to_text',
+        return_value='Review field-unknown',
+    )
+    service = SendTasksDigest.__new__(SendTasksDigest)
+    template = TemplateForTasksDigest(
+        template_id=1,
+        template_name='Onboarding',
+    )
+    task_name = 'Review {{ field-unknown }}'
+
+    # act
+    result = service._replace_api_name(
+        task_name=task_name,
+        template=template,
+    )
+
+    # assert
+    assert result == 'Review {{ field-unknown }}'
+    fields_mock.assert_called()
+    insert_fields_values_to_text_mock.assert_not_called()
+
+
+def test_replace_api_name__repeated_var__deduplicated(mocker):
+
+    """Same variable appears twice — fields_values has one entry,
+    both occurrences substituted."""
+
+    # arrange
+    insert_fields_values_to_text_mock = mocker.patch(
+        'src.reports.services.tasks.insert_fields_values_to_text',
+        return_value='Doc and Doc',
+    )
+    service = SendTasksDigest.__new__(SendTasksDigest)
+    template = TemplateForTasksDigest(
+        template_id=1,
+        template_name='Onboarding',
+    )
+    template._fields = {'field-abc123': 'Doc'}
+    task_name = '{{ field-abc123 }} and {{ field-abc123 }}'
+
+    # act
+    result = service._replace_api_name(
+        task_name=task_name,
+        template=template,
+    )
+
+    # assert
+    assert result == 'Doc and Doc'
+    insert_fields_values_to_text_mock.assert_called_once_with(
+        text='{{ field-abc123 }} and {{ field-abc123 }}',
+        fields_values={'field-abc123': 'Doc'},
+    )
+
+
+def test_replace_api_name__var_extra_spaces__replaced(mocker):
+
+    """VAR_PATTERN strips inner whitespace —
+    {{ field-abc123 }} with extra spaces is resolved."""
+
+    # arrange
+    insert_fields_values_to_text_mock = mocker.patch(
+        'src.reports.services.tasks.insert_fields_values_to_text',
+        return_value='Budget',
+    )
+    service = SendTasksDigest.__new__(SendTasksDigest)
+    template = TemplateForTasksDigest(
+        template_id=1,
+        template_name='Onboarding',
+    )
+    template._fields = {'field-abc123': 'Budget'}
+    task_name = '{{  field-abc123  }}'
+
+    # act
+    result = service._replace_api_name(
+        task_name=task_name,
+        template=template,
+    )
+
+    # assert
+    assert result == 'Budget'
+    insert_fields_values_to_text_mock.assert_called_once_with(
+        text='{{  field-abc123  }}',
+        fields_values={'field-abc123': 'Budget'},
+    )
+
+
+def test_replace_api_name__field_value_none__replaced_with_empty(mocker):
+
+    """Field value is None —
+    insert_fields_values_to_text replaces var with empty string."""
+
+    # arrange
+    insert_fields_values_to_text_mock = mocker.patch(
+        'src.reports.services.tasks.insert_fields_values_to_text',
+        return_value='Review ',
+    )
+    service = SendTasksDigest.__new__(SendTasksDigest)
+    template = TemplateForTasksDigest(
+        template_id=1,
+        template_name='Onboarding',
+    )
+    template._fields = {'field-abc123': None}
+    task_name = 'Review {{ field-abc123 }}'
+
+    # act
+    result = service._replace_api_name(
+        task_name=task_name,
+        template=template,
+    )
+
+    # assert
+    assert result == 'Review '
+    insert_fields_values_to_text_mock.assert_called_once_with(
+        text='Review {{ field-abc123 }}',
+        fields_values={'field-abc123': None},
+    )
+
+
+def test_replace_api_name__empty_task_name__unchanged(mocker):
+
+    """task_name is empty string — no variables found,
+    original value returned unchanged."""
+
+    # arrange
+    fields_mock = mocker.patch.object(
+        TemplateForTasksDigest,
+        'fields',
+        new_callable=PropertyMock,
+        return_value={},
+    )
+    insert_fields_values_to_text_mock = mocker.patch(
+        'src.reports.services.tasks.insert_fields_values_to_text',
+    )
+    service = SendTasksDigest.__new__(SendTasksDigest)
+    template = TemplateForTasksDigest(
+        template_id=1,
+        template_name='Onboarding',
+    )
+    task_name = ''
+
+    # act
+    result = service._replace_api_name(
+        task_name=task_name,
+        template=template,
+    )
+
+    # assert
+    assert result == ''
+    fields_mock.assert_not_called()
+    insert_fields_values_to_text_mock.assert_not_called()


### PR DESCRIPTION
# Problem

People who get the regular email summary of their tasks sometimes saw step titles that did not read the way they do in the product. When a step title was meant to combine several pieces of information—such as answers collected at the start and the name of the underlying process—only one part might appear, or the title could look incomplete or confusing. Titles that rely on standard, automatic values (for example the current date, who launched the work, or an internal reference) were also not reflected consistently in that email.

# Fix / Solution

Update the tasks digest pipeline so step titles are resolved the same way as elsewhere: walk every `{{ … }}` token in the title, substitute values from kickoff field data where a matching field exists, substitute `template-name` from the template’s display name, and leave other system variable tokens unchanged when they are not backed by kickoff data. Call the text substitution helper once with the full map of resolved values instead of only handling the first token.

# Release notes

**Task summary email:** Digest email was sent correctly if system variables are used for the step title.

# Changes

## API

- No REST API endpoints were added or changed. Behavior change applies to the backend tasks digest (email content built for periodic digest jobs).

## Web-client

- No web-client changes.

# Test cases

## API

Primary verification is end-to-end: template → running workflow → tasks digest send → email content. REST endpoints for templates and workflows are used as today; this task does not add or change those contracts.

| Authorization | Test case | Expected result |
| --- | --- | --- |
| Authenticated user (account member who can create templates and run workflows; recipient of the digest) | **Main scenario:** (1) Create an active **template** whose **step name** includes at least one **system variable** (e.g. process name, date, who started the process, or a combination with start-form fields). (2) **Start a workflow** from that template and complete kickoff as needed so data exists for any referenced fields. (3) Ensure activity falls into the digest window for that user, then **trigger the tasks digest** the same way the environment normally does (scheduled job or supported manual run). (4) Open the **tasks digest email** for that user. | The **step title** in the email reads correctly: values from the start form and the process name appear where the template uses them; purely automatic parts behave like in the template; titles are not cut off, duplicated incorrectly, or left with raw placeholders. |
| Authenticated user | **Variation:** Repeat the main scenario with a step name that uses **several** placeholders (e.g. a start-form field plus the process name). | Every applicable part is filled in the email; the line matches what users see in the product for that step. |
| N/A (automated regression) | Run the existing **unit and integration** tests for the tasks digest service (including `_replace_api_name` and `send_tasks_digest` flows). | All tests pass; no regressions in digest structure or counts. |


## Web-client

| Browser | Device | Authorization | Test scenario | Expected result |
| --- | --- | --- | --- | --- |
| Chrome | Desktop browser | User signed into the product (template editor / run workflow) | **Main scenario (UI path):** (1) Create or edit a **template** so a **step name** contains a **system variable** (and optionally start-form variables). (2) **Run a workflow** from that template and fill kickoff. (3) After the **tasks digest** is sent for your user, open your **mailbox** (e.g. webmail in the same browser). | In the digest email, the **step name** matches expectations: correct process name, dates, starter, and field values where used; no broken titles. |
| Chrome | Desktop browser | Same user as digest recipient | **API-only setup, email in browser:** If the template/workflow were created via API or another tool, open **webmail** and verify the digest message after send. | Same as above: step titles in the email are **correct and readable**. |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to task name placeholder substitution in the tasks digest email pipeline, with extensive new unit coverage. Main risk is altered rendering of task titles in digest emails if placeholder resolution differs from previous behavior.
> 
> **Overview**
> Fixes tasks digest task-title rendering by updating `SendTasksDigest._replace_api_name` to resolve *all* `{{ ... }}` placeholders in a task name in one pass: substitute matching kickoff field values, substitute `{{ template-name }}` from the template display name, and leave unknown/system variables unchanged.
> 
> Adds focused unit tests covering no-vars, single/multiple vars, `template-name`, system vars passthrough, mixed vars, unknown vars, repeated vars, whitespace handling, `None` values, and empty names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c66c7bafb36bf900b6115f2f48bdd9ca96ae14e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `_replace_api_name` to support system variables and multiple substitutions in task names
> - Updates `SendTasksDigest._replace_api_name` in [tasks.py](https://github.com/pneumaticapp/pneumaticworkflow/pull/196/files#diff-852b4d5d79addf13b4fb331071210480c566687755ed87be4fcab8f2cc14e5dd) to collect all variables via `VAR_PATTERN` and build a `fields_values` dict in a single pass, replacing all matched variables at once.
> - Adds special-case handling for `{{ template-name }}`, mapping it to `template.template_name`.
> - Unknown and system variables (e.g. `date`, `workflow-starter`) are now silently skipped instead of raising a `KeyError`.
> - Adds 11 focused unit tests covering edge cases including empty input, `None` field values, repeated variables, and extra whitespace in variable syntax.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c66c7ba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->