### PR TITLE
44963 fix updating dataset item

### DIFF
--- a/backend/src/datasets/serializers.py
+++ b/backend/src/datasets/serializers.py
@@ -22,7 +22,7 @@ class DatasetItemSerializer(
             'order',
         )
 
-    id = IntegerField(read_only=True)
+    id = IntegerField(required=False)
     value = CharField(max_length=200)
     order = IntegerField(default=0)
 
@@ -64,7 +64,7 @@ class DatasetSerializer(
             'items',
         )
 
-    id = IntegerField(read_only=True)
+    id = IntegerField(required=False)
     name = CharField(max_length=200)
     description = CharField(allow_blank=True, default='')
     date_created_tsp = TimeStampField(

--- a/backend/src/datasets/tests/test_views/test_datasets/test_partial_update.py
+++ b/backend/src/datasets/tests/test_views/test_datasets/test_partial_update.py
@@ -1,3 +1,4 @@
+
 import pytest
 from datetime import timedelta
 
@@ -333,6 +334,56 @@ def test_partial_update__full_data__ok(mocker, api_client):
         name='Updated Name',
         description='Updated description',
         items=items,
+    )
+
+
+def test_partial_update__update_and_create_items__ok(mocker, api_client):
+
+    # arrange
+    account = create_test_account()
+    user = create_test_owner(account=account)
+    dataset = create_test_dataset(
+        account=account,
+        name='Old Name',
+        items_count=1,
+    )
+    item = dataset.items.all().first()
+    data_set_service_init_mock = mocker.patch.object(
+        DataSetService,
+        attribute='__init__',
+        return_value=None,
+    )
+    partial_update_mock = mocker.patch(
+        'src.datasets.services.'
+        'dataset.DataSetService.partial_update',
+        return_value=dataset,
+    )
+    api_client.token_authenticate(user=user)
+
+    # act
+    response = api_client.patch(
+        path=f'/datasets/{dataset.id}',
+        data={
+            'items': [
+                {'id': item.id, 'value': item.value, 'order': item.order},
+                {'value': 2, 'order': 2},
+            ],
+        },
+    )
+
+    # assert
+    assert response.status_code == 200
+    data_set_service_init_mock.assert_called_once_with(
+        user=user,
+        instance=dataset,
+        is_superuser=False,
+        auth_type=AuthTokenType.USER,
+    )
+    partial_update_mock.assert_called_once_with(
+        items=[
+            {'id': item.id, 'value': item.value, 'order': item.order},
+            {'value': '2', 'order': 2},
+        ],
     )
 
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Makes `id` fields writable/optional in dataset serializers, which changes API validation and could allow clients to submit primary keys in update/create payloads. While intended to enable mixed update/create of nested items, it may have side effects if unexpected `id` values are provided.
> 
> **Overview**
> Enables partial updates of datasets where `items` can include both existing records (identified by `id`) and new records in the same request by making `DatasetSerializer.id` and `DatasetItemSerializer.id` *optional* rather than read-only.
> 
> Adds a regression test asserting that `PATCH /datasets/{id}` forwards a mixed `items` payload (update + create) through to `DataSetService.partial_update` and returns 200.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53f0e7b6a9f26ca7c96a265b064c6bd82a80f083. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->