### PR TITLE
46275 frontend [ workflows ] print a workflow log

### DIFF
--- a/frontend/src/public/assets/css/print/print.css
+++ b/frontend/src/public/assets/css/print/print.css
@@ -17,18 +17,16 @@
   
     * {
       print-color-adjust: exact;
-    }
-
-    * {
-        scrollbar-width: none;
+      -webkit-print-color-adjust: exact;
+      scrollbar-width: none;
     }
     
     *::-webkit-scrollbar {
-    display: none;
+      display: none;
     }
 
     .no-print {
-        display: none !important;
+      display: none !important;
     }
 }
   

--- a/frontend/src/public/assets/css/print/print.css
+++ b/frontend/src/public/assets/css/print/print.css
@@ -1,0 +1,34 @@
+/* stylelint-disable declaration-no-important */
+@media print {
+    html,
+    body {
+      overflow: visible !important;
+      height: auto !important;
+    }
+  
+    [id='pneumatic-frontend'] {
+      overflow: visible !important;
+      height: auto !important;
+    }
+  
+    main .container-fluid .row {
+      display: flex !important;
+    }
+  
+    * {
+      print-color-adjust: exact;
+    }
+
+    * {
+        scrollbar-width: none;
+    }
+    
+    *::-webkit-scrollbar {
+    display: none;
+    }
+
+    .no-print {
+        display: none !important;
+    }
+}
+  

--- a/frontend/src/public/assets/css/style.css
+++ b/frontend/src/public/assets/css/style.css
@@ -2,6 +2,7 @@
 // Table of Contents
 // -------------------
 // 00. Variables
+// 00.1. Print
 // 01. Library
 // 02. Reset style
 // 03. Base style
@@ -13,6 +14,12 @@
 // =================== */
 
 @import './variables/color';
+
+/* ===================
+// 00.1. Print
+// =================== */
+
+@import './print/print.css';
 
 /* ===================
 // 01. Library

--- a/frontend/src/public/components/TaskCard/TaskCard.tsx
+++ b/frontend/src/public/components/TaskCard/TaskCard.tsx
@@ -365,7 +365,7 @@ export function TaskCard({
           <UsersDropdown
               isMulti
               controlSize="sm"
-              className={styles['responsible']}
+              className={classnames(styles['responsible'], 'no-print')} 
               placeholder={formatMessage({ id: 'user.search-field-placeholder' })}
               options={[...performerGroupDropdownOption, ...performerDropdownOption]}
               value={[...performerDropdownValue, ...performerGroupDropdownValue]}
@@ -379,7 +379,7 @@ export function TaskCard({
         )}
 
         {viewMode !== ETaskCardViewMode.Guest && !task.isReadOnlyViewer && (
-          <GuestController ref={guestsControllerRef} taskId={task.id} className={styles['guest-dropdown']} />
+          <GuestController ref={guestsControllerRef} taskId={task.id} className={classnames(styles['guest-dropdown'], 'no-print')} />
         )}
       </>
     );
@@ -497,7 +497,7 @@ export function TaskCard({
     );
 
     return (
-      <div className={styles['buttons']}>
+      <div className={classnames(styles['buttons'], 'no-print')}>
         <div className={styles['buttons__complete']}>
           {isEmbeddedWorkflowsComplete ? (
             renderCompleteButton(!isEmbeddedWorkflowsComplete)

--- a/frontend/src/public/components/Workflows/WorkflowLog/WorkflowLog.tsx
+++ b/frontend/src/public/components/Workflows/WorkflowLog/WorkflowLog.tsx
@@ -222,7 +222,7 @@ export const WorkflowLog = ({
     }
 
     return (
-      <div className={styles['comment-field']}>
+      <div className={classnames(styles['comment-field'], 'no-print')}>
         <PopupCommentFieldContainer sendComment={sendComment} taskId={taskId} mentions={mentions} />
       </div>
     );

--- a/frontend/src/public/components/Workflows/WorkflowLog/WorkflowLogEvents/WorkflowLogTaskComment/WorkflowLogTaskComment.tsx
+++ b/frontend/src/public/components/Workflows/WorkflowLog/WorkflowLogEvents/WorkflowLogTaskComment/WorkflowLogTaskComment.tsx
@@ -158,7 +158,7 @@ export function WorkflowLogTaskComment({
     if (currentUserId !== userId || workflowStatus === EWorkflowStatus.Finished) return null;
 
     return (
-      <div className={styles['comment__actions']}>
+      <div className={classnames(styles['comment__actions'], 'no-print')}>
         {renderDeleteButton()}
         {!isDelete && (
           <button
@@ -327,7 +327,7 @@ export function WorkflowLogTaskComment({
           <Tooltip
             visible={isShowTooltipEmoji}
             size="auto"
-            containerClassName={classnames(styles['comment__footer-item'], styles['is-add-emoji'])}
+            containerClassName={classnames(styles['comment__footer-item'], styles['is-add-emoji'], 'no-print')}
             content={
               isShowEmoji && (
                 <Picker

--- a/frontend/src/public/layout/MainLayout/MainLayout.css
+++ b/frontend/src/public/layout/MainLayout/MainLayout.css
@@ -5,27 +5,3 @@
   flex-direction: column;
   height: 100%;
 }
-
-/* Print styles need !important to override global #pneumatic-frontend and framework CSS. */
-/* stylelint-disable declaration-no-important */
-@media print {
-  html,
-  body {
-    overflow: visible !important;
-    height: auto !important;
-  }
-
-  [id='pneumatic-frontend'] {
-    overflow: visible !important;
-    height: auto !important;
-  }
-
-  main .container-fluid .row {
-    display: flex !important;
-  }
-
-  * {
-    print-color-adjust: exact;
-  }
-}
-/* stylelint-enable declaration-no-important */

--- a/frontend/src/public/layout/MainLayout/MainLayout.css
+++ b/frontend/src/public/layout/MainLayout/MainLayout.css
@@ -5,3 +5,27 @@
   flex-direction: column;
   height: 100%;
 }
+
+/* Print styles need !important to override global #pneumatic-frontend and framework CSS. */
+/* stylelint-disable declaration-no-important */
+@media print {
+  html,
+  body {
+    overflow: visible !important;
+    height: auto !important;
+  }
+
+  [id='pneumatic-frontend'] {
+    overflow: visible !important;
+    height: auto !important;
+  }
+
+  main .container-fluid .row {
+    display: flex !important;
+  }
+
+  * {
+    print-color-adjust: exact;
+  }
+}
+/* stylelint-enable declaration-no-important */

--- a/frontend/stylelint/config.js
+++ b/frontend/stylelint/config.js
@@ -255,7 +255,7 @@ module.exports = {
         // Property
         // 'property-blacklist': array|string,
         'property-case': 'lower',
-        'property-no-unknown': [true, { ignoreProperties: ['composes', 'field-sizing'] }],
+        'property-no-unknown': [true, { ignoreProperties: ['composes', 'field-sizing', 'print-color-adjust'] }],
         'property-no-vendor-prefix': true,
         // 'property-whitelist': array|string,
         // Keyframe declaration


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds print-only CSS and applies a `no-print` class to hide interactive UI elements during printing, with no changes to data flow or backend behavior.
> 
> **Overview**
> Adds print support by introducing `@media print` styles (`print.css`) that force printable layout (no scrollbars, visible overflow, exact color adjustment) and hide elements marked `no-print`.
> 
> Applies the `no-print` class to interactive controls in `TaskCard` and workflow log/comment UI (comment input, comment actions, emoji picker) so printed workflow logs exclude controls. Updates stylelint to allow the `print-color-adjust` property.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bdab6ce4712bfb23ccc1bc384deadb47c6a148e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add print support for workflow logs by hiding interactive UI elements
> - Adds a new [print.css](https://github.com/pneumaticapp/pneumaticworkflow/pull/208/files#diff-cf6da59d66290b93e63bb1b153b3f5bcbd044ac42291bb6963cd8ddb16f00cdc) stylesheet with `@media print` rules: preserves colors, hides scrollbars, fixes layout overflow, and hides elements with class `no-print`.
> - Applies `no-print` to interactive elements in `TaskCard` (performer dropdowns, action buttons), `WorkflowLog` (comment input), and `WorkflowLogTaskComment` (action controls, emoji tooltip) so they are hidden when printing.
> - Updates [stylelint/config.js](https://github.com/pneumaticapp/pneumaticworkflow/pull/208/files#diff-6ca362bbd5d164c9177013106be9cfa130aec5ae6d35b8fe31f68cf76b035dd3) to allow the `print-color-adjust` property.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5bdab6c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->