### PR TITLE
46269 backend [ users ] Hierarchical approval workflow

### DIFF
--- a/backend/src/processes/enums.py
+++ b/backend/src/processes/enums.py
@@ -71,12 +71,14 @@ class PerformerType:
     GROUP = 'group'
     WORKFLOW_STARTER = 'workflow_starter'
     FIELD = 'field'
+    MANAGER = 'manager'
 
     choices = (
         (USER, USER),
         (GROUP, GROUP),
         (WORKFLOW_STARTER, WORKFLOW_STARTER),
         (FIELD, FIELD),
+        (MANAGER, MANAGER),
     )
 
     filter_choices = (

--- a/backend/src/processes/messages/template.py
+++ b/backend/src/processes/messages/template.py
@@ -284,3 +284,30 @@ MSG_PT_0069 = _('Permission denied. You do not have access to this template.')
 MSG_PT_0070 = _(
     'Permission denied. You are not a template owner or viewer.',
 )
+MSG_PT_0071 = _(
+    'You should set the source step for performer '
+    'with the type "manager".',
+)
+MSG_PT_0072 = lambda name: format_lazy(
+    _(
+        'Task "{name}": Manager performer '
+        'cannot reference its own step.',
+    ),
+    name=name,
+)
+MSG_PT_0073 = lambda name, step_name: format_lazy(
+    _(
+        'Task "{name}": Manager performer references '
+        'a non-existent step "{step_name}".',
+    ),
+    name=name,
+    step_name=step_name,
+)
+MSG_PT_0074 = lambda name, step_name: format_lazy(
+    _(
+        'Task "{name}": Disable "Required completion by all" '
+        'on step "{step_name}" to use Manager performer.',
+    ),
+    name=name,
+    step_name=step_name,
+)

--- a/backend/src/processes/migrations/0252_add_manager_performer_type.py
+++ b/backend/src/processes/migrations/0252_add_manager_performer_type.py
@@ -1,0 +1,29 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('processes', '0251_add_skip_for_starter'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='rawperformertemplate',
+            name='source_task_api_name',
+            field=models.CharField(
+                blank=True,
+                max_length=200,
+                null=True,
+            ),
+        ),
+        migrations.AddField(
+            model_name='rawperformer',
+            name='source_task_api_name',
+            field=models.CharField(
+                blank=True,
+                max_length=200,
+                null=True,
+            ),
+        ),
+    ]

--- a/backend/src/processes/models/mixins.py
+++ b/backend/src/processes/models/mixins.py
@@ -288,6 +288,7 @@ class TaskRawPerformersMixin:
         group: Optional[UserGroup] = None,
         field=None,
         performer_type: PerformerType = PerformerType.USER,
+        source_task_api_name: Optional[str] = None,
     ) -> int:
 
         """ Delete a raw_performer
@@ -309,6 +310,7 @@ class TaskRawPerformersMixin:
             user=user,
             group=group,
             field=field,
+            source_task_api_name=source_task_api_name,
         ).delete()[0]
 
     def delete_raw_performers(self):

--- a/backend/src/processes/models/mixins.py
+++ b/backend/src/processes/models/mixins.py
@@ -40,6 +40,11 @@ class RawPerformerMixin(models.Model):
         on_delete=models.CASCADE,
         null=True,
     )
+    source_task_api_name = models.CharField(
+        max_length=200,
+        null=True,
+        blank=True,
+    )
 
 
 class WorkflowMixin(models.Model):
@@ -289,7 +294,10 @@ class TaskRawPerformersMixin:
             and returns the number of objects deleted """
 
         if (
-            performer_type != PerformerType.WORKFLOW_STARTER
+            performer_type not in (
+                PerformerType.WORKFLOW_STARTER,
+                PerformerType.MANAGER,
+            )
             and user is None and group is None and field is None
         ):
             raise Exception(

--- a/backend/src/processes/models/workflows/task.py
+++ b/backend/src/processes/models/workflows/task.py
@@ -164,11 +164,13 @@ class Task(
         """ Creates and returns a raw performer for a task with given data
             Optionally updates the performers after create raw performers """
 
-        if (
-            performer_type not in (
-                PerformerType.WORKFLOW_STARTER,
-                PerformerType.MANAGER,
-            )
+        if performer_type == PerformerType.MANAGER:
+            if not source_task_api_name:
+                raise Exception(
+                    'Manager performer requires source_task_api_name',
+                )
+        elif (
+            performer_type != PerformerType.WORKFLOW_STARTER
             and not group_id
             and not user
             and not user_id

--- a/backend/src/processes/models/workflows/task.py
+++ b/backend/src/processes/models/workflows/task.py
@@ -6,6 +6,7 @@ from django.contrib.auth import get_user_model
 from django.db import models
 from django.utils import timezone
 
+from src.accounts.enums import UserStatus
 from src.accounts.models import (
     AccountBaseMixin,
     Notification,
@@ -361,7 +362,9 @@ class Task(
             .first()
         )
         if complete_event and complete_event.user:
-            return complete_event.user.manager
+            manager = complete_event.user.manager
+            if manager and manager.status == UserStatus.ACTIVE:
+                return manager
         return None
 
     def update_performers(

--- a/backend/src/processes/models/workflows/task.py
+++ b/backend/src/processes/models/workflows/task.py
@@ -355,6 +355,7 @@ class Task(
             .filter(
                 workflow_id=self.workflow_id,
                 task__api_name=source_api_name,
+                task__status=TaskStatus.COMPLETED,
                 type=WorkflowEventType.TASK_COMPLETE,
             )
             .select_related('user__manager')

--- a/backend/src/processes/models/workflows/task.py
+++ b/backend/src/processes/models/workflows/task.py
@@ -406,6 +406,7 @@ class Task(
             defaultdict(list),
             defaultdict(list),
         )
+        raw_performers_for_update = []
         for raw_performer_ in raw_performers:
             if raw_performer_.type == PerformerType.USER:
                 user_ids[raw_performer_.user_id].append(raw_performer_)
@@ -417,11 +418,12 @@ class Task(
                 user = self.get_default_performer()
                 user_ids[user.id].append(raw_performer_)
             elif raw_performer_.type == PerformerType.MANAGER:
-                manager_user = self._resolve_manager(
-                    raw_performer_,
-                )
+                manager_user = self._resolve_manager(raw_performer_)
                 if manager_user:
                     user_ids[manager_user.id].append(raw_performer_)
+                elif raw_performer_.task_performer_id is not None:
+                    raw_performer_.task_performer_id = None
+                    raw_performers_for_update.append(raw_performer_)
 
         if api_names:
             user_fields = self.workflow.get_fields(
@@ -436,7 +438,6 @@ class Task(
                 elif field.group_id:
                     group_ids[field.group_id].extend(api_names[field.api_name])
 
-        raw_performers_for_update = []
         created_performers_user_ids = []
         created_performers_group_ids = []
         if user_ids:
@@ -534,7 +535,9 @@ class Task(
             left pointing to the performer) """
 
         task_performer_ids = list(
-            self.raw_performers.values_list('task_performer_id', flat=True),
+            self.raw_performers
+            .exclude(task_performer_id=None)
+            .values_list('task_performer_id', flat=True),
         )
         performers_to_delete = (
             TaskPerformer.objects

--- a/backend/src/processes/models/workflows/task.py
+++ b/backend/src/processes/models/workflows/task.py
@@ -18,6 +18,7 @@ from src.processes.enums import (
     FieldType,
     PerformerType,
     TaskStatus,
+    WorkflowEventType,
 )
 from src.processes.models.mixins import (
     ApiNameMixin,
@@ -156,6 +157,7 @@ class Task(
         field=None,
         api_name: Optional[str] = None,
         performer_type: PerformerType = PerformerType.USER,
+        source_task_api_name: Optional[str] = None,
     ):  # -> RawPerformer
 
         """ Creates and returns a raw performer for a task with given data
@@ -182,6 +184,7 @@ class Task(
             group_id=group_id,
             user_id=user_id,
             field=field,
+            source_task_api_name=source_task_api_name,
         )
         raw_performer.save()
         return raw_performer
@@ -345,20 +348,20 @@ class Task(
         source_api_name = raw_performer.source_task_api_name
         if not source_api_name:
             return None
-        performer: Optional[TaskPerformer] = (
-            TaskPerformer.objects
+        from src.processes.models.workflows.event import WorkflowEvent
+        complete_event = (
+            WorkflowEvent.objects
             .filter(
-                task__workflow_id=self.workflow_id,
+                workflow_id=self.workflow_id,
                 task__api_name=source_api_name,
-                task__status=TaskStatus.COMPLETED,
-                date_completed__isnull=False,
+                type=WorkflowEventType.TASK_COMPLETE,
             )
             .select_related('user__manager')
-            .order_by('-date_completed')
+            .order_by('-created')
             .first()
         )
-        if performer and performer.user:
-            return performer.user.manager
+        if complete_event and complete_event.user:
+            return complete_event.user.manager
         return None
 
     def update_performers(

--- a/backend/src/processes/models/workflows/task.py
+++ b/backend/src/processes/models/workflows/task.py
@@ -406,6 +406,7 @@ class Task(
             defaultdict(list),
             defaultdict(list),
         )
+        raw_performers_for_update = []
         for raw_performer_ in raw_performers:
             if raw_performer_.type == PerformerType.USER:
                 user_ids[raw_performer_.user_id].append(raw_performer_)
@@ -422,6 +423,9 @@ class Task(
                 )
                 if manager_user:
                     user_ids[manager_user.id].append(raw_performer_)
+                elif raw_performer_.task_performer_id is not None:
+                    raw_performer_.task_performer_id = None
+                    raw_performers_for_update.append(raw_performer_)
 
         if api_names:
             user_fields = self.workflow.get_fields(
@@ -436,7 +440,6 @@ class Task(
                 elif field.group_id:
                     group_ids[field.group_id].extend(api_names[field.api_name])
 
-        raw_performers_for_update = []
         created_performers_user_ids = []
         created_performers_group_ids = []
         if user_ids:

--- a/backend/src/processes/models/workflows/task.py
+++ b/backend/src/processes/models/workflows/task.py
@@ -1,6 +1,6 @@
 # ruff: noqa: PLC0415
 from collections import defaultdict
-from typing import List, Optional, Set, Tuple
+from typing import TYPE_CHECKING, List, Optional, Set, Tuple
 
 from django.contrib.auth import get_user_model
 from django.db import models
@@ -30,6 +30,9 @@ from src.processes.querysets import (
     TaskPerformerQuerySet,
     TasksQuerySet,
 )
+
+if TYPE_CHECKING:
+    from src.processes.models.workflows.raw_performer import RawPerformer
 
 UserModel = get_user_model()
 
@@ -122,6 +125,7 @@ class Task(
         group_id: Optional[int] = None,
         user_id: Optional[int] = None,
         field=None,  # Optional[TaskField]
+        source_task_api_name: Optional[str] = None,
     ):  # -> RawPerformer
 
         """ Returns new a raw performer object with given data """
@@ -134,6 +138,7 @@ class Task(
             field=field,
             api_name=api_name,
             type=performer_type,
+            source_task_api_name=source_task_api_name,
         )
         if user:
             result.user = user
@@ -157,7 +162,10 @@ class Task(
             Optionally updates the performers after create raw performers """
 
         if (
-            performer_type != PerformerType.WORKFLOW_STARTER
+            performer_type not in (
+                PerformerType.WORKFLOW_STARTER,
+                PerformerType.MANAGER,
+            )
             and not group_id
             and not user
             and not user_id
@@ -261,6 +269,7 @@ class Task(
                 'user_id': e.user_id,
                 'group_id': e.group_id,
                 'api_name': e.api_name,
+                'source_task_api_name': e.source_task_api_name,
                 'field': {
                     'api_name': e.field.api_name,
                 } if e.type == PerformerType.FIELD else None,
@@ -309,6 +318,11 @@ class Task(
                         group_id=raw_performer_template.get('group_id'),
                         field=field,
                         api_name=raw_performer_template['api_name'],
+                        source_task_api_name=(
+                            raw_performer_template.get(
+                                'source_task_api_name',
+                            )
+                        ),
                     ),
                 )
         if new_raw_performers:
@@ -317,6 +331,35 @@ class Task(
             RawPerformer.objects.filter(
                 api_name__in=deleted_raw_performer_api_names,
             ).delete()
+
+    def _resolve_manager(
+        self,
+        raw_performer: 'RawPerformer',
+    ) -> Optional[UserModel]:
+
+        """ Resolve manager performer: find the user who completed
+            the source step and return their manager.
+            Returns None if source step not completed
+            or completer has no manager. """
+
+        source_api_name = raw_performer.source_task_api_name
+        if not source_api_name:
+            return None
+        performer: Optional[TaskPerformer] = (
+            TaskPerformer.objects
+            .filter(
+                task__workflow_id=self.workflow_id,
+                task__api_name=source_api_name,
+                task__status=TaskStatus.COMPLETED,
+                date_completed__isnull=False,
+            )
+            .select_related('user__manager')
+            .order_by('-date_completed')
+            .first()
+        )
+        if performer and performer.user:
+            return performer.user.manager
+        return None
 
     def update_performers(
         self,
@@ -364,6 +407,12 @@ class Task(
             elif raw_performer_.type == PerformerType.WORKFLOW_STARTER:
                 user = self.get_default_performer()
                 user_ids[user.id].append(raw_performer_)
+            elif raw_performer_.type == PerformerType.MANAGER:
+                manager_user = self._resolve_manager(
+                    raw_performer_,
+                )
+                if manager_user:
+                    user_ids[manager_user.id].append(raw_performer_)
 
         if api_names:
             user_fields = self.workflow.get_fields(

--- a/backend/src/processes/models/workflows/task.py
+++ b/backend/src/processes/models/workflows/task.py
@@ -556,6 +556,7 @@ class Task(
         group: Optional[UserGroup] = None,
         field=None,
         performer_type: PerformerType = PerformerType.USER,
+        source_task_api_name: Optional[str] = None,
     ):
 
         """ Delete a raw_performer
@@ -567,6 +568,7 @@ class Task(
             user=user,
             group=group,
             field=field,
+            source_task_api_name=source_task_api_name,
         )
         if deleted_count:
             self._delete_orphaned_performers()

--- a/backend/src/processes/serializers/templates/raw_performer.py
+++ b/backend/src/processes/serializers/templates/raw_performer.py
@@ -20,6 +20,10 @@ from src.processes.messages.template import (
     MSG_PT_0035,
     MSG_PT_0036,
     MSG_PT_0056,
+    MSG_PT_0071,
+    MSG_PT_0072,
+    MSG_PT_0073,
+    MSG_PT_0074,
 )
 from src.processes.models.templates.fields import FieldTemplate
 from src.processes.models.templates.raw_performer import RawPerformerTemplate
@@ -57,6 +61,7 @@ class RawPerformerSerializer(
             'api_name',
             'user_id',
             'group_id',
+            'source_task_api_name',
         }
 
     api_name = CharField(max_length=200, required=False)
@@ -153,6 +158,46 @@ class RawPerformerSerializer(
                 api_name=task.api_name,
             )
 
+    def additional_validate_raw_performers_type_manager(
+        self,
+        data: Dict[str, Any],
+    ):
+        task = self.context['task']
+        source_id = data.get('source_id')
+        if not source_id:
+            self.raise_validation_error(
+                message=MSG_PT_0071,
+                api_name=task.api_name,
+            )
+        elif source_id == task.api_name:
+            self.raise_validation_error(
+                message=MSG_PT_0072(name=task.name),
+                api_name=task.api_name,
+            )
+
+        # Cross-step validation via template tasks context
+        template_tasks = self.context.get('template_tasks')
+        if template_tasks is None:
+            return
+
+        source_task_data = template_tasks.get(source_id)
+        if not source_task_data:
+            self.raise_validation_error(
+                message=MSG_PT_0073(
+                    name=task.name,
+                    step_name=source_id,
+                ),
+                api_name=task.api_name,
+            )
+        elif source_task_data.get('require_completion_by_all'):
+            self.raise_validation_error(
+                message=MSG_PT_0074(
+                    name=task.name,
+                    step_name=source_task_data.get('name', source_id),
+                ),
+                api_name=task.api_name,
+            )
+
     def additional_validate(
         self,
         data: Dict[str, Any],
@@ -181,6 +226,33 @@ class RawPerformerSerializer(
             elif instance.type == PerformerType.GROUP:
                 data['source_id'] = str(instance.group_id)
                 data['label'] = instance.group.name
+            elif instance.type == PerformerType.MANAGER:
+                source_api_name = instance.source_task_api_name
+                data['source_id'] = source_api_name
+                template_tasks = self.context.get(
+                    'template_tasks',
+                )
+                if template_tasks is not None:
+                    task_data = template_tasks.get(
+                        source_api_name, {},
+                    )
+                    source_task_name = task_data.get('name')
+                else:
+                    source_task_name = None
+                    for task_template in (
+                        instance.task.template.tasks.all()
+                    ):
+                        if task_template.api_name == (
+                            source_api_name
+                        ):
+                            source_task_name = (
+                                task_template.name
+                            )
+                            break
+                step_label = (
+                    source_task_name or source_api_name
+                )
+                data['label'] = f'Manager: {step_label}'
         return data
 
     def create(self, validated_data):
@@ -204,6 +276,10 @@ class RawPerformerSerializer(
                 api_name=api_name,
             )
             raw_performer_data['field'] = field
+        elif validated_data['type'] == PerformerType.MANAGER:
+            raw_performer_data['source_task_api_name'] = (
+                validated_data['source_id']
+            )
         return self.create_or_update_instance(
             validated_data=raw_performer_data,
             not_unique_exception_msg=MSG_PT_0056(
@@ -233,6 +309,10 @@ class RawPerformerSerializer(
                 api_name=api_name,
             )
             raw_performer_data['field'] = field
+        elif validated_data['type'] == PerformerType.MANAGER:
+            raw_performer_data['source_task_api_name'] = (
+                validated_data['source_id']
+            )
         return self.create_or_update_instance(
             instance=instance,
             validated_data=raw_performer_data,

--- a/backend/src/processes/serializers/templates/task.py
+++ b/backend/src/processes/serializers/templates/task.py
@@ -145,6 +145,12 @@ class TaskTemplateSerializer(
             context['account_user_ids'] = set(
                 self.context['account'].get_user_ids(include_invited=True),
             )
+        if PerformerType.MANAGER in performers_types:
+            template = self.context['template']
+            context['template_tasks'] = {
+                task.api_name: {'name': task.name}
+                for task in template.tasks.all()
+            }
         return context
 
     def _get_task_available_fields(

--- a/backend/src/processes/serializers/templates/task.py
+++ b/backend/src/processes/serializers/templates/task.py
@@ -148,7 +148,12 @@ class TaskTemplateSerializer(
         if PerformerType.MANAGER in performers_types:
             template = self.context['template']
             context['template_tasks'] = {
-                task.api_name: {'name': task.name}
+                task.api_name: {
+                    'name': task.name,
+                    'require_completion_by_all': (
+                        task.require_completion_by_all
+                    ),
+                }
                 for task in template.tasks.all()
             }
         return context

--- a/backend/src/processes/serializers/templates/task.py
+++ b/backend/src/processes/serializers/templates/task.py
@@ -146,16 +146,31 @@ class TaskTemplateSerializer(
                 self.context['account'].get_user_ids(include_invited=True),
             )
         if PerformerType.MANAGER in performers_types:
-            template = self.context['template']
-            context['template_tasks'] = {
-                task.api_name: {
-                    'name': task.name,
-                    'require_completion_by_all': (
-                        task.require_completion_by_all
-                    ),
+            all_tasks_data = self.context.get('all_tasks_data')
+            if all_tasks_data is not None:
+                context['template_tasks'] = {
+                    task_data['api_name']: {
+                        'name': task_data['name'],
+                        'require_completion_by_all': (
+                            task_data.get(
+                                'require_completion_by_all',
+                                False,
+                            )
+                        ),
+                    }
+                    for task_data in all_tasks_data
                 }
-                for task in template.tasks.all()
-            }
+            else:
+                template = self.context['template']
+                context['template_tasks'] = {
+                    task.api_name: {
+                        'name': task.name,
+                        'require_completion_by_all': (
+                            task.require_completion_by_all
+                        ),
+                    }
+                    for task in template.tasks.all()
+                }
         return context
 
     def _get_task_available_fields(

--- a/backend/src/processes/serializers/templates/template.py
+++ b/backend/src/processes/serializers/templates/template.py
@@ -636,6 +636,7 @@ class TemplateSerializer(
                 'tasks_api_names': tasks_api_names,
                 'parents_by_tasks': parents_by_tasks,
                 'ancestors_by_tasks': ancestors_by_tasks,
+                'all_tasks_data': validated_data['tasks'],
             },
         )
 
@@ -707,6 +708,7 @@ class TemplateSerializer(
                 'tasks_api_names': tasks_api_names,
                 'parents_by_tasks': parents_by_tasks,
                 'ancestors_by_tasks': ancestors_by_tasks,
+                'all_tasks_data': validated_data['tasks'],
             },
         )
 

--- a/backend/src/processes/services/versioning/schemas.py
+++ b/backend/src/processes/services/versioning/schemas.py
@@ -140,6 +140,7 @@ class RawPerformerTemplateSchemaV1(serializers.ModelSerializer):
             'group_id',
             'api_name',
             'field',
+            'source_task_api_name',
         )
 
     field = RawPerformerTemplateFieldSchemaV1(allow_null=True, required=False)

--- a/backend/src/processes/tests/test_models/test_resolve_manager.py
+++ b/backend/src/processes/tests/test_models/test_resolve_manager.py
@@ -2,6 +2,7 @@ import pytest
 from unittest.mock import Mock
 from django.utils import timezone
 
+from src.accounts.enums import UserStatus
 from src.processes.enums import (
     PerformerType,
     TaskStatus,
@@ -635,6 +636,101 @@ def test_resolve_manager__owner_force_completes__none():
     create_test_event(
         workflow=workflow,
         user=owner,
+        type_event=WorkflowEventType.TASK_COMPLETE,
+        task=source_task,
+    )
+
+    target_task = workflow.tasks.get(number=2)
+    raw_perf = Mock(source_task_api_name=source_task.api_name)
+
+    # act
+    result = target_task._resolve_manager(raw_perf)
+
+    # assert
+    assert result is None
+
+
+def test_resolve_manager__inactive_manager__none():
+    """
+    Manager exists but has been deactivated (status=INACTIVE).
+    Should return None — inactive managers must not be assigned.
+    """
+
+    # arrange
+    account = create_test_account()
+    owner = create_test_owner(account=account)
+    subordinate = create_test_user(
+        email='sub@pneumatic.app',
+        account=account,
+        is_account_owner=False,
+    )
+    manager = create_test_user(
+        email='mgr@pneumatic.app',
+        account=account,
+        is_account_owner=False,
+    )
+    subordinate.manager = manager
+    subordinate.save()
+    manager.status = UserStatus.INACTIVE
+    manager.save(update_fields=['status'])
+
+    workflow = create_test_workflow(user=owner)
+    source_task = workflow.tasks.get(number=1)
+    source_task.status = TaskStatus.COMPLETED
+    source_task.date_completed = timezone.now()
+    source_task.save()
+
+    create_test_event(
+        workflow=workflow,
+        user=subordinate,
+        type_event=WorkflowEventType.TASK_COMPLETE,
+        task=source_task,
+    )
+
+    target_task = workflow.tasks.get(number=2)
+    raw_perf = Mock(source_task_api_name=source_task.api_name)
+
+    # act
+    result = target_task._resolve_manager(raw_perf)
+
+    # assert
+    assert result is None
+
+
+def test_resolve_manager__invited_manager__none():
+    """
+    Manager exists but has status=INVITED (not yet active).
+    Should return None — only active managers are valid.
+    """
+
+    # arrange
+    account = create_test_account()
+    owner = create_test_owner(account=account)
+    subordinate = create_test_user(
+        email='sub@pneumatic.app',
+        account=account,
+        is_account_owner=False,
+    )
+    manager = create_test_user(
+        email='mgr@pneumatic.app',
+        account=account,
+        is_account_owner=False,
+    )
+    subordinate.manager = manager
+    subordinate.save()
+
+    manager.status = UserStatus.INVITED
+    manager.save(update_fields=['status'])
+
+    workflow = create_test_workflow(user=owner)
+    source_task = workflow.tasks.get(number=1)
+    source_task.status = TaskStatus.COMPLETED
+    source_task.date_completed = timezone.now()
+    source_task.save()
+
+    create_test_event(
+        workflow=workflow,
+        user=subordinate,
         type_event=WorkflowEventType.TASK_COMPLETE,
         task=source_task,
     )

--- a/backend/src/processes/tests/test_models/test_resolve_manager.py
+++ b/backend/src/processes/tests/test_models/test_resolve_manager.py
@@ -743,3 +743,130 @@ def test_resolve_manager__invited_manager__none():
 
     # assert
     assert result is None
+
+
+def test_resolve_manager__source_reverted_after_complete__none():
+    """
+    Source task was completed (TASK_COMPLETE event exists),
+    then reverted back to ACTIVE. The stale event must be
+    ignored — manager should not be resolved.
+    """
+
+    # arrange
+    account = create_test_account()
+    owner = create_test_owner(account=account)
+    subordinate = create_test_user(
+        email='sub@pneumatic.app',
+        account=account,
+        is_account_owner=False,
+    )
+    manager = create_test_user(
+        email='mgr@pneumatic.app',
+        account=account,
+        is_account_owner=False,
+    )
+    subordinate.manager = manager
+    subordinate.save()
+
+    workflow = create_test_workflow(user=owner)
+    source_task = workflow.tasks.get(number=1)
+
+    # Complete the source task and create the event
+    source_task.status = TaskStatus.COMPLETED
+    source_task.date_completed = timezone.now()
+    source_task.save()
+
+    create_test_event(
+        workflow=workflow,
+        user=subordinate,
+        type_event=WorkflowEventType.TASK_COMPLETE,
+        task=source_task,
+    )
+
+    # Revert: source task goes back to ACTIVE
+    source_task.status = TaskStatus.ACTIVE
+    source_task.date_completed = None
+    source_task.save()
+
+    target_task = workflow.tasks.get(number=2)
+    raw_perf = Mock(source_task_api_name=source_task.api_name)
+
+    # act
+    result = target_task._resolve_manager(raw_perf)
+
+    # assert
+    assert result is None
+
+
+def test_resolve_manager__source_recompleted_by_other__returns_new():
+    """
+    Source task completed by user_a, reverted, then re-completed
+    by user_b. Should return user_b's manager (latest completion).
+    """
+
+    # arrange
+    account = create_test_account()
+    owner = create_test_owner(account=account)
+    user_a = create_test_user(
+        email='a@pneumatic.app',
+        account=account,
+        is_account_owner=False,
+    )
+    user_b = create_test_user(
+        email='b@pneumatic.app',
+        account=account,
+        is_account_owner=False,
+    )
+    manager_a = create_test_user(
+        email='mgr_a@pneumatic.app',
+        account=account,
+        is_account_owner=False,
+    )
+    manager_b = create_test_user(
+        email='mgr_b@pneumatic.app',
+        account=account,
+        is_account_owner=False,
+    )
+    user_a.manager = manager_a
+    user_a.save()
+    user_b.manager = manager_b
+    user_b.save()
+
+    workflow = create_test_workflow(user=owner)
+    source_task = workflow.tasks.get(number=1)
+
+    # First completion by user_a
+    source_task.status = TaskStatus.COMPLETED
+    source_task.date_completed = timezone.now()
+    source_task.save()
+    create_test_event(
+        workflow=workflow,
+        user=user_a,
+        type_event=WorkflowEventType.TASK_COMPLETE,
+        task=source_task,
+    )
+
+    # Revert
+    source_task.status = TaskStatus.ACTIVE
+    source_task.date_completed = None
+    source_task.save()
+
+    # Second completion by user_b
+    source_task.status = TaskStatus.COMPLETED
+    source_task.date_completed = timezone.now()
+    source_task.save()
+    create_test_event(
+        workflow=workflow,
+        user=user_b,
+        type_event=WorkflowEventType.TASK_COMPLETE,
+        task=source_task,
+    )
+
+    target_task = workflow.tasks.get(number=2)
+    raw_perf = Mock(source_task_api_name=source_task.api_name)
+
+    # act
+    result = target_task._resolve_manager(raw_perf)
+
+    # assert
+    assert result == manager_b

--- a/backend/src/processes/tests/test_models/test_resolve_manager.py
+++ b/backend/src/processes/tests/test_models/test_resolve_manager.py
@@ -1,0 +1,173 @@
+import pytest
+from unittest.mock import Mock
+from django.utils import timezone
+
+from src.processes.enums import TaskStatus
+from src.processes.tests.fixtures import (
+    create_test_account,
+    create_test_owner,
+    create_test_user,
+    create_test_workflow,
+)
+
+
+pytestmark = pytest.mark.django_db
+
+
+def test_resolve_manager__ok():
+
+    # arrange
+    account = create_test_account()
+    owner = create_test_owner(account=account)
+    subordinate = create_test_user(
+        email='sub@pneumatic.app',
+        account=account,
+        is_account_owner=False,
+    )
+    manager = create_test_user(
+        email='mgr@pneumatic.app',
+        account=account,
+        is_account_owner=False,
+    )
+    subordinate.manager = manager
+    subordinate.save()
+
+    workflow = create_test_workflow(user=owner)
+    source_task = workflow.tasks.get(number=1)
+    source_task.status = TaskStatus.COMPLETED
+    source_task.date_completed = timezone.now()
+    source_task.save()
+
+    tp = source_task.taskperformer_set.first()
+    tp.user = subordinate
+    tp.date_completed = timezone.now()
+    tp.save()
+
+    target_task = workflow.tasks.get(number=2)
+
+    raw_perf = Mock(source_task_api_name=source_task.api_name)
+
+    # act
+    result = target_task._resolve_manager(raw_perf)
+
+    # assert
+    assert result == manager
+
+
+def test_resolve_manager__source_not_completed__none():
+
+    # arrange
+    account = create_test_account()
+    owner = create_test_owner(account=account)
+    workflow = create_test_workflow(user=owner)
+    source_task = workflow.tasks.get(number=1)
+
+    # keep source active (not completed)
+    source_task.status = TaskStatus.ACTIVE
+    source_task.save()
+
+    target_task = workflow.tasks.get(number=2)
+
+    raw_perf = Mock(source_task_api_name=source_task.api_name)
+
+    # act
+    result = target_task._resolve_manager(raw_perf)
+
+    # assert
+    assert result is None
+
+
+def test_resolve_manager__no_manager__none():
+
+    # arrange
+    account = create_test_account()
+    owner = create_test_owner(account=account)
+    subordinate = create_test_user(
+        email='sub@pneumatic.app',
+        account=account,
+        is_account_owner=False,
+    )
+    # no manager set
+
+    workflow = create_test_workflow(user=owner)
+    source_task = workflow.tasks.get(number=1)
+    source_task.status = TaskStatus.COMPLETED
+    source_task.date_completed = timezone.now()
+    source_task.save()
+
+    tp = source_task.taskperformer_set.first()
+    tp.user = subordinate
+    tp.date_completed = timezone.now()
+    tp.save()
+
+    target_task = workflow.tasks.get(number=2)
+
+    raw_perf = Mock(source_task_api_name=source_task.api_name)
+
+    # act
+    result = target_task._resolve_manager(raw_perf)
+
+    # assert
+    assert result is None
+
+
+def test_resolve_manager__empty_api_name__none():
+
+    # arrange
+    account = create_test_account()
+    owner = create_test_owner(account=account)
+    workflow = create_test_workflow(user=owner)
+    target_task = workflow.tasks.get(number=2)
+
+    raw_perf = Mock(source_task_api_name=None)
+
+    # act
+    result = target_task._resolve_manager(raw_perf)
+
+    # assert
+    assert result is None
+
+
+def test_resolve_manager__nonexistent_api_name__none():
+
+    # arrange
+    account = create_test_account()
+    owner = create_test_owner(account=account)
+    workflow = create_test_workflow(user=owner)
+    target_task = workflow.tasks.get(number=2)
+
+    raw_perf = Mock(source_task_api_name='nonexistent-task')
+
+    # act
+    result = target_task._resolve_manager(raw_perf)
+
+    # assert
+    assert result is None
+
+
+def test_resolve_manager__completer_user_deleted__none():
+
+    # arrange
+    account = create_test_account()
+    owner = create_test_owner(account=account)
+
+    workflow = create_test_workflow(user=owner)
+    source_task = workflow.tasks.get(number=1)
+    source_task.status = TaskStatus.COMPLETED
+    source_task.date_completed = timezone.now()
+    source_task.save()
+
+    tp = source_task.taskperformer_set.first()
+    tp.user = None
+    tp.date_completed = timezone.now()
+    tp.save()
+
+    target_task = workflow.tasks.get(number=2)
+
+    raw_perf = Mock(source_task_api_name=source_task.api_name)
+
+    # act
+    result = target_task._resolve_manager(raw_perf)
+
+    # assert
+    assert result is None

--- a/backend/src/processes/tests/test_models/test_resolve_manager.py
+++ b/backend/src/processes/tests/test_models/test_resolve_manager.py
@@ -2,9 +2,16 @@ import pytest
 from unittest.mock import Mock
 from django.utils import timezone
 
-from src.processes.enums import TaskStatus
+from src.processes.enums import (
+    PerformerType,
+    TaskStatus,
+    WorkflowEventType,
+)
+from src.processes.models.workflows.event import WorkflowEvent
 from src.processes.tests.fixtures import (
     create_test_account,
+    create_test_event,
+    create_test_group,
     create_test_owner,
     create_test_user,
     create_test_workflow,
@@ -14,7 +21,7 @@ from src.processes.tests.fixtures import (
 pytestmark = pytest.mark.django_db
 
 
-def test_resolve_manager__ok():
+def test_resolve_manager__single_user__ok():
 
     # arrange
     account = create_test_account()
@@ -38,13 +45,14 @@ def test_resolve_manager__ok():
     source_task.date_completed = timezone.now()
     source_task.save()
 
-    tp = source_task.taskperformer_set.first()
-    tp.user = subordinate
-    tp.date_completed = timezone.now()
-    tp.save()
+    create_test_event(
+        workflow=workflow,
+        user=subordinate,
+        type_event=WorkflowEventType.TASK_COMPLETE,
+        task=source_task,
+    )
 
     target_task = workflow.tasks.get(number=2)
-
     raw_perf = Mock(source_task_api_name=source_task.api_name)
 
     # act
@@ -52,6 +60,436 @@ def test_resolve_manager__ok():
 
     # assert
     assert result == manager
+
+
+def test_resolve_manager__two_users__returns_completer_manager():
+
+    # arrange
+    account = create_test_account()
+    owner = create_test_owner(account=account)
+    user_a = create_test_user(
+        email='a@pneumatic.app',
+        account=account,
+        is_account_owner=False,
+    )
+    user_b = create_test_user(
+        email='b@pneumatic.app',
+        account=account,
+        is_account_owner=False,
+    )
+    manager_a = create_test_user(
+        email='mgr_a@pneumatic.app',
+        account=account,
+        is_account_owner=False,
+    )
+    user_a.manager = manager_a
+    user_a.save()
+
+    workflow = create_test_workflow(user=owner)
+    source_task = workflow.tasks.get(number=1)
+    source_task.status = TaskStatus.COMPLETED
+    source_task.date_completed = timezone.now()
+    source_task.save()
+
+    # Both performers get date_completed (bulk update)
+    source_task.add_raw_performer(
+        user=user_a,
+        performer_type=PerformerType.USER,
+    )
+    source_task.add_raw_performer(
+        user=user_b,
+        performer_type=PerformerType.USER,
+    )
+    source_task.taskperformer_set.update(
+        is_completed=True,
+        date_completed=timezone.now(),
+    )
+
+    # Event records user_a as actual completer
+    create_test_event(
+        workflow=workflow,
+        user=user_a,
+        type_event=WorkflowEventType.TASK_COMPLETE,
+        task=source_task,
+    )
+
+    target_task = workflow.tasks.get(number=2)
+    raw_perf = Mock(source_task_api_name=source_task.api_name)
+
+    # act
+    result = target_task._resolve_manager(raw_perf)
+
+    # assert
+    assert result == manager_a
+
+
+def test_resolve_manager__single_group__returns_completer_manager():
+
+    # arrange
+    account = create_test_account()
+    owner = create_test_owner(account=account)
+    user_a = create_test_user(
+        email='a@pneumatic.app',
+        account=account,
+        is_account_owner=False,
+    )
+    manager_a = create_test_user(
+        email='mgr_a@pneumatic.app',
+        account=account,
+        is_account_owner=False,
+    )
+    user_a.manager = manager_a
+    user_a.save()
+
+    group = create_test_group(
+        account=account,
+        name='Group1',
+        users=[user_a],
+    )
+
+    workflow = create_test_workflow(user=owner)
+    source_task = workflow.tasks.get(number=1)
+    source_task.status = TaskStatus.COMPLETED
+    source_task.date_completed = timezone.now()
+    source_task.save()
+
+    source_task.add_raw_performer(
+        group_id=group.id,
+        performer_type=PerformerType.GROUP,
+    )
+    source_task.taskperformer_set.update(
+        is_completed=True,
+        date_completed=timezone.now(),
+    )
+
+    # user_a from the group completed the task
+    create_test_event(
+        workflow=workflow,
+        user=user_a,
+        type_event=WorkflowEventType.TASK_COMPLETE,
+        task=source_task,
+    )
+
+    target_task = workflow.tasks.get(number=2)
+    raw_perf = Mock(source_task_api_name=source_task.api_name)
+
+    # act
+    result = target_task._resolve_manager(raw_perf)
+
+    # assert
+    assert result == manager_a
+
+
+def test_resolve_manager__group_and_user__group_member_completes():
+
+    # arrange
+    account = create_test_account()
+    owner = create_test_owner(account=account)
+    user_a = create_test_user(
+        email='a@pneumatic.app',
+        account=account,
+        is_account_owner=False,
+    )
+    user_b = create_test_user(
+        email='b@pneumatic.app',
+        account=account,
+        is_account_owner=False,
+    )
+    manager_a = create_test_user(
+        email='mgr_a@pneumatic.app',
+        account=account,
+        is_account_owner=False,
+    )
+    user_a.manager = manager_a
+    user_a.save()
+
+    group = create_test_group(
+        account=account,
+        name='Group1',
+        users=[user_a],
+    )
+
+    workflow = create_test_workflow(user=owner)
+    source_task = workflow.tasks.get(number=1)
+    source_task.status = TaskStatus.COMPLETED
+    source_task.date_completed = timezone.now()
+    source_task.save()
+
+    source_task.add_raw_performer(
+        group_id=group.id,
+        performer_type=PerformerType.GROUP,
+    )
+    source_task.add_raw_performer(
+        user=user_b,
+        performer_type=PerformerType.USER,
+    )
+    source_task.taskperformer_set.update(
+        is_completed=True,
+        date_completed=timezone.now(),
+    )
+
+    # user_a from group completed
+    create_test_event(
+        workflow=workflow,
+        user=user_a,
+        type_event=WorkflowEventType.TASK_COMPLETE,
+        task=source_task,
+    )
+
+    target_task = workflow.tasks.get(number=2)
+    raw_perf = Mock(source_task_api_name=source_task.api_name)
+
+    # act
+    result = target_task._resolve_manager(raw_perf)
+
+    # assert
+    assert result == manager_a
+
+
+def test_resolve_manager__two_groups__returns_completer_manager():
+
+    # arrange
+    account = create_test_account()
+    owner = create_test_owner(account=account)
+    user_a = create_test_user(
+        email='a@pneumatic.app',
+        account=account,
+        is_account_owner=False,
+    )
+    manager_a = create_test_user(
+        email='mgr_a@pneumatic.app',
+        account=account,
+        is_account_owner=False,
+    )
+    user_a.manager = manager_a
+    user_a.save()
+
+    user_c = create_test_user(
+        email='c@pneumatic.app',
+        account=account,
+        is_account_owner=False,
+    )
+
+    group1 = create_test_group(
+        account=account,
+        name='Group1',
+        users=[user_a],
+    )
+    group2 = create_test_group(
+        account=account,
+        name='Group2',
+        users=[user_c],
+    )
+
+    workflow = create_test_workflow(user=owner)
+    source_task = workflow.tasks.get(number=1)
+    source_task.status = TaskStatus.COMPLETED
+    source_task.date_completed = timezone.now()
+    source_task.save()
+
+    source_task.add_raw_performer(
+        group_id=group1.id,
+        performer_type=PerformerType.GROUP,
+    )
+    source_task.add_raw_performer(
+        group_id=group2.id,
+        performer_type=PerformerType.GROUP,
+    )
+    source_task.taskperformer_set.update(
+        is_completed=True,
+        date_completed=timezone.now(),
+    )
+
+    create_test_event(
+        workflow=workflow,
+        user=user_a,
+        type_event=WorkflowEventType.TASK_COMPLETE,
+        task=source_task,
+    )
+
+    target_task = workflow.tasks.get(number=2)
+    raw_perf = Mock(source_task_api_name=source_task.api_name)
+
+    # act
+    result = target_task._resolve_manager(raw_perf)
+
+    # assert
+    assert result == manager_a
+
+
+def test_resolve_manager__two_groups_two_users__returns_completer_manager():
+
+    # arrange
+    account = create_test_account()
+    owner = create_test_owner(account=account)
+    user_a = create_test_user(
+        email='a@pneumatic.app',
+        account=account,
+        is_account_owner=False,
+    )
+    user_b = create_test_user(
+        email='b@pneumatic.app',
+        account=account,
+        is_account_owner=False,
+    )
+    manager_a = create_test_user(
+        email='mgr_a@pneumatic.app',
+        account=account,
+        is_account_owner=False,
+    )
+    user_a.manager = manager_a
+    user_a.save()
+
+    user_c = create_test_user(
+        email='c@pneumatic.app',
+        account=account,
+        is_account_owner=False,
+    )
+    user_d = create_test_user(
+        email='d@pneumatic.app',
+        account=account,
+        is_account_owner=False,
+    )
+
+    group1 = create_test_group(
+        account=account,
+        name='Group1',
+        users=[user_c],
+    )
+    group2 = create_test_group(
+        account=account,
+        name='Group2',
+        users=[user_d],
+    )
+
+    workflow = create_test_workflow(user=owner)
+    source_task = workflow.tasks.get(number=1)
+    source_task.status = TaskStatus.COMPLETED
+    source_task.date_completed = timezone.now()
+    source_task.save()
+
+    source_task.add_raw_performer(
+        group_id=group1.id,
+        performer_type=PerformerType.GROUP,
+    )
+    source_task.add_raw_performer(
+        group_id=group2.id,
+        performer_type=PerformerType.GROUP,
+    )
+    source_task.add_raw_performer(
+        user=user_a,
+        performer_type=PerformerType.USER,
+    )
+    source_task.add_raw_performer(
+        user=user_b,
+        performer_type=PerformerType.USER,
+    )
+    source_task.taskperformer_set.update(
+        is_completed=True,
+        date_completed=timezone.now(),
+    )
+
+    create_test_event(
+        workflow=workflow,
+        user=user_a,
+        type_event=WorkflowEventType.TASK_COMPLETE,
+        task=source_task,
+    )
+
+    target_task = workflow.tasks.get(number=2)
+    raw_perf = Mock(source_task_api_name=source_task.api_name)
+
+    # act
+    result = target_task._resolve_manager(raw_perf)
+
+    # assert
+    assert result == manager_a
+
+
+def test_resolve_manager__user_in_own_group__returns_manager():
+
+    # arrange
+    account = create_test_account()
+    owner = create_test_owner(account=account)
+    user_a = create_test_user(
+        email='a@pneumatic.app',
+        account=account,
+        is_account_owner=False,
+    )
+    manager_a = create_test_user(
+        email='mgr_a@pneumatic.app',
+        account=account,
+        is_account_owner=False,
+    )
+    user_a.manager = manager_a
+    user_a.save()
+
+    group = create_test_group(
+        account=account,
+        name='Group1',
+        users=[user_a],
+    )
+
+    workflow = create_test_workflow(user=owner)
+    source_task = workflow.tasks.get(number=1)
+    source_task.status = TaskStatus.COMPLETED
+    source_task.date_completed = timezone.now()
+    source_task.save()
+
+    source_task.add_raw_performer(
+        user=user_a,
+        performer_type=PerformerType.USER,
+    )
+    source_task.add_raw_performer(
+        group_id=group.id,
+        performer_type=PerformerType.GROUP,
+    )
+    source_task.taskperformer_set.update(
+        is_completed=True,
+        date_completed=timezone.now(),
+    )
+
+    create_test_event(
+        workflow=workflow,
+        user=user_a,
+        type_event=WorkflowEventType.TASK_COMPLETE,
+        task=source_task,
+    )
+
+    target_task = workflow.tasks.get(number=2)
+    raw_perf = Mock(source_task_api_name=source_task.api_name)
+
+    # act
+    result = target_task._resolve_manager(raw_perf)
+
+    # assert
+    assert result == manager_a
+
+
+def test_resolve_manager__empty_group__no_event__none():
+
+    # arrange
+    account = create_test_account()
+    owner = create_test_owner(account=account)
+
+    create_test_group(
+        account=account,
+        name='EmptyGroup',
+        users=[],
+    )
+
+    workflow = create_test_workflow(user=owner)
+    source_task = workflow.tasks.get(number=1)
+    # Task cannot be completed by anyone вЂ” no TASK_COMPLETE event
+
+    target_task = workflow.tasks.get(number=2)
+    raw_perf = Mock(source_task_api_name=source_task.api_name)
+
+    # act
+    result = target_task._resolve_manager(raw_perf)
+
+    # assert
+    assert result is None
 
 
 def test_resolve_manager__source_not_completed__none():
@@ -62,12 +500,11 @@ def test_resolve_manager__source_not_completed__none():
     workflow = create_test_workflow(user=owner)
     source_task = workflow.tasks.get(number=1)
 
-    # keep source active (not completed)
+    # keep source active (not completed) вЂ” no TASK_COMPLETE event
     source_task.status = TaskStatus.ACTIVE
     source_task.save()
 
     target_task = workflow.tasks.get(number=2)
-
     raw_perf = Mock(source_task_api_name=source_task.api_name)
 
     # act
@@ -95,13 +532,14 @@ def test_resolve_manager__no_manager__none():
     source_task.date_completed = timezone.now()
     source_task.save()
 
-    tp = source_task.taskperformer_set.first()
-    tp.user = subordinate
-    tp.date_completed = timezone.now()
-    tp.save()
+    create_test_event(
+        workflow=workflow,
+        user=subordinate,
+        type_event=WorkflowEventType.TASK_COMPLETE,
+        task=source_task,
+    )
 
     target_task = workflow.tasks.get(number=2)
-
     raw_perf = Mock(source_task_api_name=source_task.api_name)
 
     # act
@@ -157,13 +595,51 @@ def test_resolve_manager__completer_user_deleted__none():
     source_task.date_completed = timezone.now()
     source_task.save()
 
-    tp = source_task.taskperformer_set.first()
-    tp.user = None
-    tp.date_completed = timezone.now()
-    tp.save()
+    create_test_event(
+        workflow=workflow,
+        user=owner,
+        type_event=WorkflowEventType.TASK_COMPLETE,
+        task=source_task,
+    )
+    WorkflowEvent.objects.filter(
+        workflow=workflow,
+        type=WorkflowEventType.TASK_COMPLETE,
+    ).update(user=None)
 
     target_task = workflow.tasks.get(number=2)
+    raw_perf = Mock(source_task_api_name=source_task.api_name)
 
+    # act
+    result = target_task._resolve_manager(raw_perf)
+
+    # assert
+    assert result is None
+
+
+def test_resolve_manager__owner_force_completes__none():
+    """
+    Account owner force-completes the source task (not a performer).
+    Owner has no manager — returns None.
+    """
+
+    # arrange
+    account = create_test_account()
+    owner = create_test_owner(account=account)
+
+    workflow = create_test_workflow(user=owner)
+    source_task = workflow.tasks.get(number=1)
+    source_task.status = TaskStatus.COMPLETED
+    source_task.date_completed = timezone.now()
+    source_task.save()
+
+    create_test_event(
+        workflow=workflow,
+        user=owner,
+        type_event=WorkflowEventType.TASK_COMPLETE,
+        task=source_task,
+    )
+
+    target_task = workflow.tasks.get(number=2)
     raw_perf = Mock(source_task_api_name=source_task.api_name)
 
     # act

--- a/backend/src/processes/tests/test_models/test_task.py
+++ b/backend/src/processes/tests/test_models/test_task.py
@@ -9,14 +9,17 @@ from src.processes.enums import (
     FieldType,
     PerformerType,
     TaskStatus,
+    WorkflowEventType,
 )
 from src.processes.models.workflows.fields import TaskField, FieldSelection
 from src.processes.models.workflows.task import Delay, TaskPerformer
 from src.processes.tests.fixtures import (
     create_test_account,
+    create_test_event,
     create_test_group,
     create_test_owner,
     create_test_not_admin,
+    create_test_user,
     create_test_workflow, create_test_dataset,
 )
 
@@ -2274,3 +2277,77 @@ def test_add_raw_performer__manager_no_source__raise_exception():
 
     # assert
     assert str(ex.value) == 'Manager performer requires source_task_api_name'
+
+
+def test_update_performers__stale_mgr_after_revert__clears():
+    """
+    MANAGER raw performer keeps stale task_performer_id after
+    source task revert — update_performers must clear it so
+    _delete_orphaned_performers removes the old TaskPerformer.
+    """
+
+    # arrange
+    account = create_test_account()
+    owner = create_test_owner(account=account)
+    subordinate = create_test_user(
+        email='sub@pneumatic.app',
+        account=account,
+        is_account_owner=False,
+    )
+    manager = create_test_user(
+        email='mgr@pneumatic.app',
+        account=account,
+        is_account_owner=False,
+    )
+    subordinate.manager = manager
+    subordinate.save()
+
+    workflow = create_test_workflow(
+        user=owner,
+        tasks_count=2,
+    )
+    source_task = workflow.tasks.get(number=1)
+    target_task = workflow.tasks.get(number=2)
+
+    # complete source task so _resolve_manager finds manager
+    source_task.status = TaskStatus.COMPLETED
+    source_task.date_completed = timezone.now()
+    source_task.save()
+
+    create_test_event(
+        workflow=workflow,
+        user=subordinate,
+        type_event=WorkflowEventType.TASK_COMPLETE,
+        task=source_task,
+    )
+
+    # add MANAGER raw performer and run update_performers
+    target_task.raw_performers.all().delete()
+    target_task.taskperformer_set.all().delete()
+    mgr_raw = target_task.add_raw_performer(
+        performer_type=PerformerType.MANAGER,
+        source_task_api_name=source_task.api_name,
+    )
+    target_task.update_performers()
+
+    # verify manager TaskPerformer was created
+    mgr_raw.refresh_from_db()
+    assert mgr_raw.task_performer_id is not None
+    assert target_task.taskperformer_set.filter(
+        user=manager,
+    ).exists()
+
+    # revert source task
+    source_task.status = TaskStatus.ACTIVE
+    source_task.date_completed = None
+    source_task.save()
+
+    # act
+    target_task.update_performers()
+
+    # assert
+    mgr_raw.refresh_from_db()
+    assert mgr_raw.task_performer_id is None
+    assert not target_task.taskperformer_set.filter(
+        user=manager,
+    ).exists()

--- a/backend/src/processes/tests/test_models/test_task.py
+++ b/backend/src/processes/tests/test_models/test_task.py
@@ -1825,6 +1825,52 @@ def test_update_raw_performers_from_tmpl__orphans__deleted(
     ).exists()
 
 
+def test_update_raw_performers_from_tmpl__dict_manager__source_preserved():
+    """
+    MANAGER performer from dict input preserves source_task_api_name
+    through the versioning/update path.
+    """
+
+    # arrange
+    account = create_test_account()
+    user = create_test_owner(account=account)
+    workflow = create_test_workflow(
+        user=user,
+        tasks_count=2,
+    )
+    task_1 = workflow.tasks.get(number=1)
+    task_2 = workflow.tasks.get(number=2)
+
+    # Clear existing raw performers on task_2
+    task_2.raw_performers.all().delete()
+
+    template_dict = {
+        'raw_performers': [
+            {
+                'api_name': 'raw-performer-mgr-1',
+                'type': PerformerType.MANAGER,
+                'user_id': None,
+                'group_id': None,
+                'field': None,
+                'source_task_api_name': task_1.api_name,
+            },
+        ],
+    }
+
+    # act
+    task_2.update_raw_performers_from_task_template(
+        task_template=template_dict,
+    )
+
+    # assert
+    mgr_raw = task_2.raw_performers.filter(
+        type=PerformerType.MANAGER,
+    ).first()
+    assert mgr_raw is not None
+    assert mgr_raw.source_task_api_name == task_1.api_name
+    assert mgr_raw.api_name == 'raw-performer-mgr-1'
+
+
 def test_update_performers__single_user_raw_performer__ok():
     """
     Single raw_performer provided, USER type — creates TaskPerformer
@@ -2202,3 +2248,29 @@ def test_delete_raw_performer__manager_no_source__deletes_nothing():
     assert task_2.raw_performers.filter(
         type=PerformerType.MANAGER,
     ).count() == 1
+
+
+def test_add_raw_performer__manager_no_source__raise_exception():
+    """
+    MANAGER without source_task_api_name raises Exception
+    because the manager can never be resolved without
+    knowing which step's completer to look up.
+    """
+
+    # arrange
+    account = create_test_account()
+    user = create_test_owner(account=account)
+    workflow = create_test_workflow(
+        user=user,
+        tasks_count=2,
+    )
+    task = workflow.tasks.get(number=2)
+
+    # act
+    with pytest.raises(Exception) as ex:
+        task.add_raw_performer(
+            performer_type=PerformerType.MANAGER,
+        )
+
+    # assert
+    assert str(ex.value) == 'Manager performer requires source_task_api_name'

--- a/backend/src/processes/tests/test_models/test_task.py
+++ b/backend/src/processes/tests/test_models/test_task.py
@@ -9,15 +9,18 @@ from src.processes.enums import (
     FieldType,
     PerformerType,
     TaskStatus,
+    WorkflowEventType,
 )
 from src.processes.models.workflows.fields import TaskField, FieldSelection
 from src.processes.models.workflows.task import Delay, TaskPerformer
 from src.processes.tests.fixtures import (
     create_test_account,
+    create_test_event,
     create_test_group,
     create_test_owner,
     create_test_not_admin,
-    create_test_workflow, create_test_dataset,
+    create_test_workflow,
+    create_test_dataset,
 )
 
 pytestmark = pytest.mark.django_db
@@ -2274,3 +2277,63 @@ def test_add_raw_performer__manager_no_source__raise_exception():
 
     # assert
     assert str(ex.value) == 'Manager performer requires source_task_api_name'
+
+
+def test_update_performers__stale_mgr_after_revert__clears():
+    """
+    When source task is reverted, _resolve_manager returns None.
+    update_performers must clear the stale task_performer_id so
+    _delete_orphaned_performers removes the orphaned TaskPerformer.
+    """
+
+    # arrange
+    account = create_test_account()
+    owner = create_test_owner(account=account)
+    subordinate = create_test_not_admin(
+        email='sub@pneumatic.app',
+        account=account,
+    )
+    manager = create_test_not_admin(
+        email='mgr@pneumatic.app',
+        account=account,
+    )
+    subordinate.manager = manager
+    subordinate.save()
+
+    workflow = create_test_workflow(user=owner, tasks_count=2)
+    source_task = workflow.tasks.get(number=1)
+    target_task = workflow.tasks.get(number=2)
+
+    source_task.status = TaskStatus.COMPLETED
+    source_task.date_completed = timezone.now()
+    source_task.save()
+    create_test_event(
+        workflow=workflow,
+        user=subordinate,
+        type_event=WorkflowEventType.TASK_COMPLETE,
+        task=source_task,
+    )
+
+    target_task.raw_performers.all().delete()
+    target_task.taskperformer_set.all().delete()
+    mgr_raw = target_task.add_raw_performer(
+        performer_type=PerformerType.MANAGER,
+        source_task_api_name=source_task.api_name,
+    )
+    target_task.update_performers()
+
+    mgr_raw.refresh_from_db()
+    assert mgr_raw.task_performer_id is not None
+    assert target_task.taskperformer_set.filter(user=manager).exists()
+
+    source_task.status = TaskStatus.ACTIVE
+    source_task.date_completed = None
+    source_task.save()
+
+    # act
+    target_task.update_performers()
+
+    # assert
+    mgr_raw.refresh_from_db()
+    assert mgr_raw.task_performer_id is None
+    assert not target_task.taskperformer_set.filter(user=manager).exists()

--- a/backend/src/processes/tests/test_models/test_task.py
+++ b/backend/src/processes/tests/test_models/test_task.py
@@ -841,6 +841,7 @@ def test_add_raw_performer__with_user__ok(mocker):
         group_id=None,
         user_id=None,
         field=None,
+        source_task_api_name=None,
     )
     raw_performer_mock.save.assert_called_once_with()
     assert result is raw_performer_mock
@@ -881,6 +882,7 @@ def test_add_raw_performer__with_user_id__ok(mocker):
         group_id=None,
         user_id=user.id,
         field=None,
+        source_task_api_name=None,
     )
     raw_performer_mock.save.assert_called_once_with()
     assert result is raw_performer_mock
@@ -923,6 +925,7 @@ def test_add_raw_performer__with_group_id__ok(mocker):
         group_id=group_id,
         user_id=None,
         field=None,
+        source_task_api_name=None,
     )
     raw_performer_mock.save.assert_called_once_with()
     assert result is raw_performer_mock
@@ -965,6 +968,7 @@ def test_add_raw_performer__with_field__ok(mocker):
         group_id=None,
         user_id=None,
         field=field_mock,
+        source_task_api_name=None,
     )
     raw_performer_mock.save.assert_called_once_with()
     assert result is raw_performer_mock
@@ -1005,6 +1009,7 @@ def test_add_raw_performer__workflow_starter_no_user__ok(mocker):
         group_id=None,
         user_id=None,
         field=None,
+        source_task_api_name=None,
     )
     raw_performer_mock.save.assert_called_once_with()
     assert result is raw_performer_mock
@@ -2064,3 +2069,54 @@ def test_update_performers__return_value__ok():
     assert isinstance(created_group_ids, list)
     assert isinstance(del_user_ids, list)
     assert isinstance(del_group_ids, list)
+
+
+def test_add_raw_performer__manager_with_source_api_name__ok():
+    """
+    MANAGER type with source_task_api_name saves correctly
+    """
+
+    # arrange
+    account = create_test_account()
+    user = create_test_owner(account=account)
+    workflow = create_test_workflow(
+        user=user,
+        tasks_count=2,
+    )
+    task = workflow.tasks.get(number=2)
+    source_api = workflow.tasks.get(number=1).api_name
+
+    # act
+    raw_performer = task.add_raw_performer(
+        performer_type=PerformerType.MANAGER,
+        source_task_api_name=source_api,
+    )
+
+    # assert
+    assert raw_performer.source_task_api_name == source_api
+    assert raw_performer.type == PerformerType.MANAGER
+
+
+def test_add_raw_performer__user_without_source_api_name__none():
+    """
+    USER type without source_task_api_name — stays None (backward compat)
+    """
+
+    # arrange
+    account = create_test_account()
+    user = create_test_owner(account=account)
+    workflow = create_test_workflow(
+        user=user,
+        tasks_count=1,
+    )
+    task = workflow.tasks.get(number=1)
+
+    # act
+    raw_performer = task.add_raw_performer(
+        user=user,
+        performer_type=PerformerType.USER,
+    )
+
+    # assert
+    assert raw_performer.source_task_api_name is None
+    assert raw_performer.type == PerformerType.USER

--- a/backend/src/processes/tests/test_models/test_task.py
+++ b/backend/src/processes/tests/test_models/test_task.py
@@ -260,6 +260,7 @@ def test_get_raw_performer__with_user_id__ok(mocker):
         field=None,
         api_name=api_name,
         type=PerformerType.USER,
+        source_task_api_name=None,
     )
 
 
@@ -299,6 +300,7 @@ def test_get_raw_performer__with_group_id__ok(mocker):
         field=None,
         api_name=api_name,
         type=PerformerType.GROUP,
+        source_task_api_name=None,
     )
 
 
@@ -338,6 +340,7 @@ def test_get_raw_performer__with_field__ok(mocker):
         field=field_mock,
         api_name=api_name,
         type=PerformerType.FIELD,
+        source_task_api_name=None,
     )
 
 
@@ -375,6 +378,7 @@ def test_get_raw_performer__workflow_starter_no_user__ok(mocker):
         field=None,
         api_name=api_name,
         type=PerformerType.WORKFLOW_STARTER,
+        source_task_api_name=None,
     )
 
 
@@ -1729,6 +1733,7 @@ def test_update_raw_performers_from_tmpl__new_performers__bulk_created(
         group_id=None,
         field=None,
         api_name=new_api_name,
+        source_task_api_name=None,
     )
     bulk_create_mock.assert_called_once_with([real_rp])
 

--- a/backend/src/processes/tests/test_models/test_task.py
+++ b/backend/src/processes/tests/test_models/test_task.py
@@ -2120,3 +2120,85 @@ def test_add_raw_performer__user_without_source_api_name__none():
     # assert
     assert raw_performer.source_task_api_name is None
     assert raw_performer.type == PerformerType.USER
+
+
+def test_delete_raw_performer__manager__deletes_only_target():
+    """
+    Two MANAGER performers on one task — deleting by
+    source_task_api_name removes only the targeted one
+    """
+
+    # arrange
+    account = create_test_account()
+    user = create_test_owner(account=account)
+    workflow = create_test_workflow(
+        user=user,
+        tasks_count=3,
+    )
+    task_1 = workflow.tasks.get(number=1)
+    task_2 = workflow.tasks.get(number=2)
+    task_3 = workflow.tasks.get(number=3)
+
+    task_3.add_raw_performer(
+        performer_type=PerformerType.MANAGER,
+        source_task_api_name=task_1.api_name,
+    )
+    task_3.add_raw_performer(
+        performer_type=PerformerType.MANAGER,
+        source_task_api_name=task_2.api_name,
+    )
+    assert task_3.raw_performers.filter(
+        type=PerformerType.MANAGER,
+    ).count() == 2
+
+    # act
+    deleted_count = task_3.delete_raw_performer(
+        performer_type=PerformerType.MANAGER,
+        source_task_api_name=task_1.api_name,
+    )
+
+    # assert
+    assert deleted_count == 1
+    remaining = task_3.raw_performers.filter(
+        type=PerformerType.MANAGER,
+    )
+    assert remaining.count() == 1
+    assert remaining.first().source_task_api_name == (
+        task_2.api_name
+    )
+
+
+def test_delete_raw_performer__manager_no_source__deletes_nothing():
+    """
+    MANAGER without source_task_api_name — no rows match,
+    nothing is deleted (safe no-op)
+    """
+
+    # arrange
+    account = create_test_account()
+    user = create_test_owner(account=account)
+    workflow = create_test_workflow(
+        user=user,
+        tasks_count=2,
+    )
+    task_1 = workflow.tasks.get(number=1)
+    task_2 = workflow.tasks.get(number=2)
+
+    task_2.add_raw_performer(
+        performer_type=PerformerType.MANAGER,
+        source_task_api_name=task_1.api_name,
+    )
+    assert task_2.raw_performers.filter(
+        type=PerformerType.MANAGER,
+    ).count() == 1
+
+    # act
+    deleted_count = task_2.delete_raw_performer(
+        performer_type=PerformerType.MANAGER,
+    )
+
+    # assert
+    assert deleted_count == 0
+    assert task_2.raw_performers.filter(
+        type=PerformerType.MANAGER,
+    ).count() == 1

--- a/backend/src/processes/tests/test_services/test_versioning_schema.py
+++ b/backend/src/processes/tests/test_services/test_versioning_schema.py
@@ -1,0 +1,71 @@
+import pytest
+from src.processes.enums import PerformerType
+from src.processes.models.templates.raw_performer import RawPerformerTemplate
+from src.processes.services.versioning.schemas import (
+    RawPerformerTemplateSchemaV1,
+)
+from src.processes.tests.fixtures import (
+    create_test_owner,
+    create_test_template,
+)
+
+
+pytestmark = pytest.mark.django_db
+
+
+def test_raw_performer_schema__manager__includes_source_task_api_name():
+    """
+    RawPerformerTemplateSchemaV1 must serialize source_task_api_name
+    so that MANAGER performers preserve their link to the source step
+    during process versioning/updates.
+    """
+
+    # arrange
+    user = create_test_owner()
+    template = create_test_template(user=user, tasks_count=2)
+    task_template_1 = template.tasks.get(number=1)
+    task_template_2 = template.tasks.get(number=2)
+
+    raw_performer = RawPerformerTemplate.objects.create(
+        template=template,
+        task=task_template_2,
+        account=user.account,
+        type=PerformerType.MANAGER,
+        source_task_api_name=task_template_1.api_name,
+        api_name='raw-performer-mgr-1',
+    )
+
+    # act
+    serialized = RawPerformerTemplateSchemaV1(raw_performer).data
+
+    # assert
+    assert 'source_task_api_name' in serialized
+    assert serialized['source_task_api_name'] == task_template_1.api_name
+    assert serialized['type'] == PerformerType.MANAGER
+
+
+def test_raw_performer_schema__user__source_task_api_name_null():
+    """
+    USER type has null source_task_api_name — schema serializes it as None.
+    """
+
+    # arrange
+    user = create_test_owner()
+    template = create_test_template(user=user, tasks_count=1)
+    task_template = template.tasks.get(number=1)
+
+    raw_performer = RawPerformerTemplate.objects.create(
+        template=template,
+        task=task_template,
+        account=user.account,
+        type=PerformerType.USER,
+        user=user,
+        api_name='raw-performer-usr-1',
+    )
+
+    # act
+    serialized = RawPerformerTemplateSchemaV1(raw_performer).data
+
+    # assert
+    assert serialized['source_task_api_name'] is None
+    assert serialized['type'] == PerformerType.USER

--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -40,7 +40,7 @@ const preview: Preview = {
       if (context.parameters?.store) {
         sagaMiddleware.run(rootSaga);
       }
-      // Получаем текущую локаль из глобальных параметров
+      // Get current locale from global parameters
       const locale = context.globals.locale || reactIntl.defaultLocale;
       
       return (

--- a/frontend/src/public/components/RichEditor/__tests__/RichEditor.spec.test.tsx
+++ b/frontend/src/public/components/RichEditor/__tests__/RichEditor.spec.test.tsx
@@ -35,7 +35,7 @@ const defaultProps: IRichEditorProps = {
   withMentions: false,
 };
 
-describe('Spec §7.1 Базовое редактирование', () => {
+describe('Spec §7.1 Basic editing', () => {
   it('renders editor with placeholder and toolbar props', () => {
     render(
       <RichEditor
@@ -55,7 +55,7 @@ describe('Spec §7.1 Базовое редактирование', () => {
   });
 });
 
-describe('Spec §7.2 Переменные', () => {
+describe('Spec §7.2 Variables', () => {
   it('ref.insertVariable(apiName, title, subtitle) is callable', () => {
     const ref = React.createRef<IRichEditorHandle>();
     render(<RichEditor {...defaultProps} ref={ref} />);
@@ -82,7 +82,7 @@ describe('Spec §7.2 Переменные', () => {
 
 });
 
-describe('Spec §7.3 Чек-листы', () => {
+describe('Spec §7.3 Checklists', () => {
   it('withChecklists renders without crash', () => {
     const handleChangeChecklists = jest.fn();
     render(
@@ -98,7 +98,7 @@ describe('Spec §7.3 Чек-листы', () => {
 
 });
 
-describe('Spec §7.4 Ссылки и упоминания', () => {
+describe('Spec §7.4 Links and mentions', () => {
   it('withMentions and mentions prop render without crash', () => {
     render(
       <RichEditor
@@ -112,7 +112,7 @@ describe('Spec §7.4 Ссылки и упоминания', () => {
 
 });
 
-describe('Spec §7.5 Вложения', () => {
+describe('Spec §7.5 Attachments', () => {
   it('renders with accountId for built-in upload', () => {
     render(
       <RichEditor {...defaultProps} accountId={1} />,
@@ -130,7 +130,7 @@ describe('Spec §7.5 Вложения', () => {
 
 });
 
-describe('Spec §7.6 Интеграция с формами', () => {
+describe('Spec §7.6 Form integration', () => {
   it('TaskDescriptionEditor profile: handleChange + handleChangeChecklists + VariableList children', () => {
     const handleChange = jest.fn().mockResolvedValue('');
     const handleChangeChecklists = jest.fn();
@@ -189,7 +189,7 @@ describe('Spec §7.6 Интеграция с формами', () => {
 
 });
 
-describe('Spec §7.7 Крайние случаи', () => {
+describe('Spec §7.7 Edge cases', () => {
   it('empty defaultValue: editor mounts with empty content', () => {
     render(<RichEditor {...defaultProps} defaultValue="" />);
     expect(screen.getByTestId('rich-editor-root')).toBeInTheDocument();

--- a/frontend/src/public/components/TemplateEdit/TaskForm/TaskForm.tsx
+++ b/frontend/src/public/components/TemplateEdit/TaskForm/TaskForm.tsx
@@ -137,6 +137,7 @@ export function TaskForm({
         <TaskPerformers
           users={users}
           task={task}
+          tasks={tasks}
           variables={listVariables}
           setCurrentTask={setCurrentTask}
           isTeamInvitesModalOpen={isTeamInvitesModalOpen}

--- a/frontend/src/public/components/TemplateEdit/TaskForm/TaskPerformers.tsx
+++ b/frontend/src/public/components/TemplateEdit/TaskForm/TaskPerformers.tsx
@@ -20,13 +20,14 @@ import { createPerformerApiName } from '../../../utils/createId';
 
 export interface ITaskPerformersProps {
   task: ITemplateTask;
+  tasks: ITemplateTask[];
   users: TUserListItem[];
   variables: TTaskVariable[];
   isTeamInvitesModalOpen: boolean;
   setCurrentTask(changedFields: Partial<ITemplateTask>): void;
 }
 
-export function TaskPerformers({ task, users, variables, setCurrentTask }: ITaskPerformersProps) {
+export function TaskPerformers({ task, tasks, users, variables, setCurrentTask }: ITaskPerformersProps) {
   const { formatMessage } = useIntl();
   const groups = useSelector(getRegularGroupsList);
 
@@ -37,11 +38,15 @@ export function TaskPerformers({ task, users, variables, setCurrentTask }: ITask
     groups,
     variables,
     formatMessage,
+    task,
+    tasks,
   );
   const selectedPerformerOption = rawPerformers.map((user) => {
     return {
       ...user,
-      value: String(user.sourceId),
+      value: user.type === ETaskPerformerType.Manager
+        ? `manager-${user.sourceId}`
+        : String(user.sourceId),
     };
   });
 

--- a/frontend/src/public/components/TemplateEdit/TaskForm/__tests__/TaskPerformers.test.tsx
+++ b/frontend/src/public/components/TemplateEdit/TaskForm/__tests__/TaskPerformers.test.tsx
@@ -73,9 +73,11 @@ describe('TaskPerformers', () => {
   });
 
   const renderComponent = (taskOverrides: Partial<ITemplateTask> = {}) => {
+    const task = makeTask(taskOverrides);
     return render(
       React.createElement(TaskPerformers, {
-        task: makeTask(taskOverrides),
+        task,
+        tasks: [task],
         users: [],
         variables: [],
         isTeamInvitesModalOpen: false,

--- a/frontend/src/public/components/TemplateEdit/TaskForm/utils/__tests__/getPerformersForDropdown.test.ts
+++ b/frontend/src/public/components/TemplateEdit/TaskForm/utils/__tests__/getPerformersForDropdown.test.ts
@@ -1,0 +1,116 @@
+/// <reference types="jest" />
+import { intlMock } from '../../../../../__stubs__/intlMock';
+import { ETaskPerformerType, ITemplateTask } from '../../../../../types/template';
+import { getPerformersForDropdown } from '../getPerformersForDropdown';
+import { EOptionTypes } from '../../../../UI/form/UsersDropdown';
+
+jest.mock('../../../../../utils/users', () => ({
+  getUserFullName: jest.fn((u: any) => `${u.firstName} ${u.lastName}`),
+}));
+
+describe('getPerformersForDropdown', () => {
+  const t = (id: string, values?: Record<string, string>) => intlMock.formatMessage({ id }, values);
+  const MANAGER_LABEL = (step: string) => t('tasks.task-manager-of-step', { step });
+
+  const makeTask = (overrides: Partial<ITemplateTask> = {}): ITemplateTask => ({
+    apiName: 'task-1',
+    number: 1,
+    name: 'First Step',
+    description: '',
+    delay: null,
+    rawDueDate: null as any,
+    requireCompletionByAll: false,
+    skipForStarter: false,
+    rawPerformers: [],
+    fields: [],
+    uuid: 'uuid-1',
+    conditions: [],
+    checklists: [],
+    revertTask: null,
+    ancestors: [],
+    ...overrides,
+  });
+
+  describe('Manager options', () => {
+    it('generates a Manager option for each step except the current one', () => {
+      const currentTask = makeTask({ apiName: 'task-2', name: 'Second Step', number: 2 });
+      const tasks = [
+        makeTask({ apiName: 'task-1', name: 'First Step', number: 1 }),
+        currentTask,
+        makeTask({ apiName: 'task-3', name: 'Third Step', number: 3 }),
+      ];
+
+      const result = getPerformersForDropdown(
+        [],
+        [],
+        [],
+        intlMock.formatMessage,
+        currentTask,
+        tasks,
+      );
+
+      const managerOptions = result.filter((o) => o.optionType === EOptionTypes.Manager);
+
+      expect(managerOptions).toHaveLength(2);
+      expect(managerOptions[0]).toMatchObject({
+        type: ETaskPerformerType.Manager,
+        sourceId: 'task-1',
+        label: MANAGER_LABEL('First Step'),
+        optionType: EOptionTypes.Manager,
+      });
+      expect(managerOptions[1]).toMatchObject({
+        type: ETaskPerformerType.Manager,
+        sourceId: 'task-3',
+        label: MANAGER_LABEL('Third Step'),
+      });
+    });
+
+    it('returns empty Manager options array when tasks are not provided', () => {
+      const result = getPerformersForDropdown(
+        [],
+        [],
+        [],
+        intlMock.formatMessage,
+      );
+
+      const managerOptions = result.filter((o) => o.optionType === EOptionTypes.Manager);
+
+      expect(managerOptions).toHaveLength(0);
+    });
+
+    it('returns empty Manager options array for a single step', () => {
+      const task = makeTask();
+
+      const result = getPerformersForDropdown(
+        [],
+        [],
+        [],
+        intlMock.formatMessage,
+        task,
+        [task],
+      );
+
+      const managerOptions = result.filter((o) => o.optionType === EOptionTypes.Manager);
+
+      expect(managerOptions).toHaveLength(0);
+    });
+
+    it('Manager option has a unique value with manager- prefix', () => {
+      const currentTask = makeTask({ apiName: 'task-2', number: 2 });
+      const tasks = [makeTask(), currentTask];
+
+      const result = getPerformersForDropdown(
+        [],
+        [],
+        [],
+        intlMock.formatMessage,
+        currentTask,
+        tasks,
+      );
+
+      const managerOptions = result.filter((o) => o.optionType === EOptionTypes.Manager);
+
+      expect(managerOptions[0].value).toBe('manager-task-1');
+    });
+  });
+});

--- a/frontend/src/public/components/TemplateEdit/TaskForm/utils/getPerformersForDropdown.ts
+++ b/frontend/src/public/components/TemplateEdit/TaskForm/utils/getPerformersForDropdown.ts
@@ -1,5 +1,5 @@
 import { IntlShape } from 'react-intl';
-import { EExtraFieldType, ETaskPerformerType, ITemplateTaskPerformer } from '../../../../types/template';
+import { EExtraFieldType, ETaskPerformerType, ITemplateTask, ITemplateTaskPerformer } from '../../../../types/template';
 import { TUserListItem } from '../../../../types/user';
 import { getUserFullName } from '../../../../utils/users';
 import { TTaskVariable } from '../../types';
@@ -11,6 +11,8 @@ export function getPerformersForDropdown(
   groups: IGroup[],
   variables: TTaskVariable[],
   formatMessage: IntlShape['formatMessage'],
+  currentTask?: ITemplateTask,
+  tasks?: ITemplateTask[],
 ): TUsersDropdownOption[] {
   const userPeformers: (Omit<ITemplateTaskPerformer, 'apiName'> & TUsersDropdownOption)[] = users.map((user) => ({
     id: user.id,
@@ -58,5 +60,24 @@ export function getPerformersForDropdown(
     value: String(null),
   };
 
-  return [workflowStarterPerformers, ...groupsPerformers, ...outputUsersPerformers, ...userPeformers];
+  const managerPerformers: TUsersDropdownOption[] = (tasks || [])
+    .filter((step) => !currentTask || step.apiName !== currentTask.apiName)
+    .map((step) => ({
+      id: 0,
+      optionType: EOptionTypes.Manager,
+      firstName: '',
+      lastName: '',
+      type: ETaskPerformerType.Manager,
+      sourceId: step.apiName,
+      label: formatMessage({ id: 'tasks.task-manager-of-step' }, { step: step.name }),
+      value: `manager-${step.apiName}`,
+    }));
+
+  return [
+    workflowStarterPerformers,
+    ...managerPerformers,
+    ...groupsPerformers,
+    ...outputUsersPerformers,
+    ...userPeformers,
+  ];
 }

--- a/frontend/src/public/components/TemplateEdit/TaskItem/TaskItemUsers/TaskItemUsers.tsx
+++ b/frontend/src/public/components/TemplateEdit/TaskItem/TaskItemUsers/TaskItemUsers.tsx
@@ -64,6 +64,9 @@ export function TaskItemUsers({ task, maxUsers = MAX_SHOW_USERS, onClick }: ITas
       [ETaskPerformerType.WorkflowStarter]: () => {
         return <Avatar size="sm" containerClassName={styles['card-user']} isEmpty />;
       },
+      [ETaskPerformerType.Manager]: () => {
+        return <Avatar size="sm" containerClassName={styles['card-user']} isEmpty />;
+      },
     };
 
     return performer.type && performerRenderMap[performer.type](performer);

--- a/frontend/src/public/components/UI/form/UsersDropdown/UsersDropdown.tsx
+++ b/frontend/src/public/components/UI/form/UsersDropdown/UsersDropdown.tsx
@@ -15,6 +15,7 @@ export enum EOptionTypes {
   User = ETaskPerformerType.User,
   Starter = ETaskPerformerType.WorkflowStarter,
   Field = ETaskPerformerType.OutputUser,
+  Manager = ETaskPerformerType.Manager,
   InviteUsers = 'invite-users',
   AllUsers = 'all-users',
 }

--- a/frontend/src/public/lang/locales/en_US.ts
+++ b/frontend/src/public/lang/locales/en_US.ts
@@ -525,6 +525,7 @@ export const enMessages = {
   'tasks.task-dropdown-finish-header': 'End the workflow now',
   'tasks.task-dropdown-finish-description': 'There is no need to continue',
   'tasks.task-workflow-starter': 'Workflow starter',
+  'tasks.task-manager-of-step': 'Manager: {step}',
   'tasks.task-success-complete': 'Task completed successfully',
   'tasks.task-fail-complete': 'Failed to complete task',
   'tasks.error-field_required': 'Please fill in the required fields',

--- a/frontend/src/public/lang/locales/ru_RU.ts
+++ b/frontend/src/public/lang/locales/ru_RU.ts
@@ -447,6 +447,7 @@ export const ruMessages = {
   'tasks.task-dropdown-finish-header': 'Завершить Процесс сейчас',
   'tasks.task-dropdown-finish-description': 'Продолжать не требуется',
   'tasks.task-workflow-starter': 'Запускатель процесса',
+  'tasks.task-manager-of-step': 'Менеджер: {step}',
   'task.complete-process-success': 'Процесс успешно завершен',
   'task.complete-process-fail': 'Не удалось завершить Процесс',
   'task.resume-process-success': 'Процесс успешно возобновлен',

--- a/frontend/src/public/types/template.ts
+++ b/frontend/src/public/types/template.ts
@@ -122,6 +122,7 @@ export enum ETaskPerformerType {
   OutputUser = 'field',
   WorkflowStarter = 'workflow_starter',
   UserGroup = 'group',
+  Manager = 'manager',
 }
 
 export interface ITemplateResponse extends Omit<ITemplate, 'id' | 'tasks' | 'tasksCount' | 'performersCount'> {

--- a/frontend/src/public/utils/__tests__/template.test.ts
+++ b/frontend/src/public/utils/__tests__/template.test.ts
@@ -535,6 +535,68 @@ describe('template utilities', () => {
       expect(rules[2].field).toBeUndefined();
       expect(rules[3].field).toBeNull();
     });
+
+    it('removes Manager performer when source step is deleted from template', () => {
+      const template = createMockTemplate({
+        tasks: [
+          {
+            ...createMockTemplate().tasks[0],
+            apiName: 'task-1',
+            number: 1,
+            rawPerformers: [
+              { type: ETaskPerformerType.Manager, sourceId: 'task-deleted', label: 'Manager: Deleted', apiName: 'perf-mgr-1' },
+              { type: ETaskPerformerType.User, sourceId: '1', label: 'Regular User', apiName: 'perf-user-1' },
+            ],
+          },
+        ],
+      });
+
+      const cleaned = cleanTemplateReferences(template);
+
+      expect(cleaned.tasks[0].rawPerformers).toHaveLength(1);
+      expect(cleaned.tasks[0].rawPerformers[0].type).toBe(ETaskPerformerType.User);
+    });
+
+    it('preserves Manager performer when source step exists in template', () => {
+      const baseTask = createMockTemplate().tasks[0];
+      const template = createMockTemplate({
+        tasks: [
+          { ...baseTask, apiName: 'task-1', number: 1 },
+          {
+            ...baseTask,
+            apiName: 'task-2',
+            number: 2,
+            rawPerformers: [
+              { type: ETaskPerformerType.Manager, sourceId: 'task-1', label: 'Manager: Task 1', apiName: 'perf-mgr-1' },
+            ],
+          },
+        ],
+      });
+
+      const cleaned = cleanTemplateReferences(template);
+
+      expect(cleaned.tasks[1].rawPerformers).toHaveLength(1);
+      expect(cleaned.tasks[1].rawPerformers[0].type).toBe(ETaskPerformerType.Manager);
+      expect(cleaned.tasks[1].rawPerformers[0].sourceId).toBe('task-1');
+    });
+
+    it('removes Manager performer with empty sourceId', () => {
+      const template = createMockTemplate({
+        tasks: [
+          {
+            ...createMockTemplate().tasks[0],
+            rawPerformers: [
+              { type: ETaskPerformerType.Manager, sourceId: '', label: 'Manager: ?', apiName: 'perf-mgr-empty' },
+              { type: ETaskPerformerType.Manager, sourceId: null, label: 'Manager: null', apiName: 'perf-mgr-null' },
+            ],
+          },
+        ],
+      });
+
+      const cleaned = cleanTemplateReferences(template);
+
+      expect(cleaned.tasks[0].rawPerformers).toHaveLength(0);
+    });
   });
 });
 });

--- a/frontend/src/public/utils/template.ts
+++ b/frontend/src/public/utils/template.ts
@@ -160,6 +160,11 @@ export const cleanTemplateReferences = (template: ITemplate): ITemplate => {
 
   const tasks = [...(template.tasks || [])].sort((a, b) => a.number - b.number);
 
+  const validTaskApiNames = new Set<string>();
+  tasks.forEach((t) => {
+    if (t.apiName) validTaskApiNames.add(t.apiName);
+  });
+
   const cleanedTasks = tasks.map((task) => {
     const name = removeInvalidReferences(task.name, validApiNames, TASK_SYSTEM_VARS);
     const description = removeInvalidReferences(task.description, validApiNames, TASK_SYSTEM_VARS);
@@ -176,6 +181,9 @@ export const cleanTemplateReferences = (template: ITemplate): ITemplate => {
     const rawPerformers = (task.rawPerformers || []).filter((p) => {
       if (p.type === 'field') {
         return !!p.sourceId && validApiNames.has(p.sourceId);
+      }
+      if (p.type === 'manager') {
+        return !!p.sourceId && validTaskApiNames.has(p.sourceId);
       }
       return true;
     });


### PR DESCRIPTION
## 1. Description (Problem)

The system lacked a "Manager of Step N" performer type — the ability to assign a workflow step to the manager of the user who completed a specified previous step. Previously, achieving a similar effect required manually assigning specific users or using workarounds.

**Where it manifested:** in the Template Editor, in the Performers dropdown on the step form — no "Manager: <step name>" option was available.

## 2. Context

This feature was needed to support hierarchical business processes where a task must be routed to a specific performer's supervisor. Example: an employee completes "Prepare Report" → the next step "Approval" is automatically assigned to their manager.

Ticket: **#46269**. This extends the `PerformerType` model following the same pattern as existing types `workflow_starter` and `field`.

## 3. Solution

Added a new `PerformerType.MANAGER` performer type across the full stack:

- **Backend:** new enum value, `source_task_api_name` field on `RawPerformer` / `RawPerformerTemplate`, `_resolve_manager()` method on `Task`, validation in the serializer.
- **Frontend:** new `ETaskPerformerType.Manager` enum, generation of "Manager: <step>" dropdown options, reference cleanup on step deletion.

**Key principle — JIT resolution:** the manager is determined **only when the step starts** (`start_task` → `update_performers`), not in advance. If the employee's manager changes during the workflow — the system uses the current one. Resolution queries `WorkflowEvent(type=TASK_COMPLETE)` to find the actual user who completed the source step, then follows `select_related('user__manager')` in a single optimized query. Using `WorkflowEvent` (rather than `TaskPerformer.date_completed`) ensures reliable resolution regardless of performer configuration — groups, multiple users, or mixed setups all work correctly because the event always records the actual completer.

**Key design decisions:**
- Manager is **not mutually exclusive** — can coexist with user/group performers on the same step
- **Multiple Manager performers** on one step — allowed, each resolves independently
- Template steps are **non-linear** (may activate via conditions), so the dropdown shows all steps, not just "previous"
- `require_completion_by_all` on the source step is **prohibited** by validation (no single completer can be determined)
- Reject logic is implemented via standard conditions + radio + revert_task, no new code needed

## 4. Implementation Details

### Backend (8 files + 1 migration)

| File | Change |
|------|--------|
| `processes/enums.py` | Added `PerformerType.MANAGER = 'manager'` to choices |
| `processes/models/mixins.py` | Added `source_task_api_name` field to `RawPerformerMixin`; updated validation — `MANAGER` does not require user/group/field |
| `processes/models/workflows/task.py` | Added `source_task_api_name` to `_get_raw_performer()`, `add_raw_performer()`, and `_get_raw_performers_template()`; new `_resolve_manager()` method using `WorkflowEvent(type=TASK_COMPLETE)` with `select_related('user__manager')`; `MANAGER` handling in `update_performers()` |
| `processes/serializers/templates/raw_performer.py` | Validation `additional_validate_raw_performers_type_manager()` (source_id presence, self-reference, missing step, `require_completion_by_all`); `to_representation()` — `label: "Manager: <step>"`; `create()/update()` — mapping `source_id → source_task_api_name` |
| `processes/serializers/templates/task.py` | Passes `template_tasks` context (including `require_completion_by_all`) when manager performers are present |
| `processes/messages/template.py` | 4 new validation messages: `MSG_PT_0071`–`MSG_PT_0074` |
| `migrations/0252_add_manager_performer_type.py` | `AddField source_task_api_name` on `RawPerformerTemplate` and `RawPerformer` |

### Frontend (11 files)

| File | Change |
|------|--------|
| `types/template.ts` | Added `Manager = 'manager'` to `ETaskPerformerType` |
| `getPerformersForDropdown.ts` | Generates manager options from the list of steps (excluding current) |
| `TaskPerformers.tsx` | Passes `tasks` prop; forms `value` with `manager-` prefix |
| `TaskForm.tsx` | Passes `tasks` to `<TaskPerformers>` |
| `TaskItemUsers.tsx` | Renders `<Avatar isEmpty />` for manager type |
| `UsersDropdown.tsx` | Added `EOptionTypes.Manager` |
| `template.ts` | Cleanup logic: removes manager performers when source step is missing |
| `en_US.ts` / `ru_RU.ts` | Localization: `'Manager: {step}'` / `'Менеджер: {step}'` |
| `.storybook/preview.tsx` | Translated comment RU→EN |
| `RichEditor.spec.test.tsx` | Translated describe blocks RU→EN |

### Tests

- **Backend:** `test_resolve_manager.py` — 13 tests: 8 performer configuration cases (`single_user`, `two_users`, `single_group`, `group_and_user`, `two_groups`, `two_groups_two_users`, `user_in_own_group`, `empty_group`) + 5 edge cases (`source_not_completed`, `no_manager`, `empty_api_name`, `nonexistent_api_name`, `completer_user_deleted`); `test_task.py` — 2 tests for `add_raw_performer` (`manager_with_source_api_name`, `user_without_source_api_name`); updated mocks in `test_task.py` (5 fixes: +`source_task_api_name=None`)
- **Frontend:** `getPerformersForDropdown.test.ts` — 4 tests (multiple steps, no tasks, single step, unique value); `template.test.ts` — 3 tests (deleted source step, step exists, empty sourceId); updated `TaskPerformers.test.tsx`

## 5. What to Test

### 5.1 Preconditions

- Account with at least 2 users on the same team, one assigned as the other's manager (Settings → Team → select Manager for a user)
- Template with at least 2 steps
- Dev environment

### 5.2 Positive Scenarios

1. **Creating a template with a Manager performer:**
   - [ ] Open Template Editor → create a template with 2+ steps
   - [ ] On Step 2, open the Performers dropdown
   - [ ] Verify dropdown contains "Manager: <Step 1 name>" options (and other steps, excluding current)
   - [ ] Select "Manager: Step 1" → save template
   - [ ] **Expected:** template saves without errors, performer is displayed in the list

2. **Running a workflow and manager resolution:**
   - [ ] Start a workflow from the created template
   - [ ] The subordinate user completes Step 1
   - [ ] **Expected:** Step 2 is assigned to that subordinate's manager

3. **Display in TaskItem (step card):**
   - [ ] In the template step list, verify that the manager performer displays as an empty avatar (same as Workflow Starter)

4. **Chain of managers ("manager of manager"):**
   - [ ] Create a template with 3 steps: Step 1 → regular user, Step 2 → Manager of Step 1, Step 3 → Manager of Step 2
   - [ ] Run workflow: Employee → their Manager → Manager's Manager (Director)
   - [ ] **Expected:** each level receives the task correctly

5. **Manager + regular performers on the same step:**
   - [ ] Add both Manager: Step 1 and a regular user as performers on the same step
   - [ ] Run workflow
   - [ ] **Expected:** both performers are assigned, step works with all of them

### 5.3 Negative Scenarios and Edge Cases

1. **Self-reference:**
   - [ ] Attempt to add a Manager performer referencing the step's own step
   - [ ] **Expected:** validation error "Manager performer cannot reference its own step"

2. **Non-existent step (deleted):**
   - [ ] Create a template, add Manager: Step 1, then delete Step 1
   - [ ] **Expected:** performer is automatically removed from the list (cleanTemplateReferences)

3. **Step with require_completion_by_all:**
   - [ ] Enable "Required completion by all" on the source step, try to add a Manager performer on another step referencing it
   - [ ] **Expected:** validation error "Disable 'Required completion by all' on step..."

4. **No manager assigned + no other performers:**
   - [ ] Run a workflow where the subordinate (who completed the step) has no manager assigned, and the target step has no other performers
   - [ ] **Expected:** the step is skipped (SKIPPED)

5. **No manager assigned + other performers exist:**
   - [ ] Same as above, but the target step also has a regular user performer
   - [ ] **Expected:** the step is NOT skipped, works with remaining performers

6. **Deactivated manager:**
   - [ ] The user's manager is deactivated (inactive)
   - [ ] **Expected:** treated as "no manager" — fallback to remaining performers or skip

7. **Source step not yet completed:**
   - [ ] In a non-standard scenario where the source step is still active (conditions led to this)
   - [ ] **Expected:** manager not found, fallback behavior

8. **Group performer completes source step:**
   - [ ] Source step has a GROUP performer (not individual user). A member of the group completes the step.
   - [ ] **Expected:** Manager of the group member who actually clicked "Complete" is resolved correctly

9. **Mixed performers on source step (group + user):**
   - [ ] Source step has both a GROUP and individual USER performers. Any of them completes.
   - [ ] **Expected:** Manager is resolved for the actual completer, regardless of performer type

### 5.4 Verification Points

- **UI:** Performers dropdown contains Manager options; selected performer displays correctly after page reload
- **API:** in template response (`GET /templates/{id}`), rawPerformer with `type: "manager"` has `source_id` and `label: "Manager: <step>"` fields
- **DB:** in `processes_rawperformertemplate` / `processes_rawperformer` tables, `source_task_api_name` field is populated

### 5.5 API Checks

- **Saving template (PUT/PATCH `/templates/{id}`):**
  - In DevTools → Network → find the save request
  - In request body (`payload`) → `tasks[N].rawPerformers` → for manager performer: `type: "manager"`, `source_id: "<step api_name>"`

- **Getting template (GET `/templates/{id}`):**
  - In response `tasks[N].rawPerformers` → for manager performer: `type: "manager"`, `source_id: "<api_name>"`, `label: "Manager: <step name>"`

### 5.6 What Was NOT Tested

- Locales partially verified (en/ru labels added, full locale switching was not tested)
- Not tested on mobile devices
- Not tested in production (verified in dev only)
- Not tested under load (many steps, many manager performers)
- Delegation (Substitutes): if the manager is on vacation and delegated — standard substitutes logic is expected to work, but not explicitly verified
- Custom task view for manager (context showing "whose task", approve/reject buttons) — planned for Phase 2
- System variable "who completed the step" — not implemented, planned for Phase 2

## 6. Testing Affected Areas (Dependencies)

| Component | What to verify |
|-----------|---------------|
| `TaskPerformers` | Basic dropdown functionality is intact — User, Group, Workflow Starter, Field selection still works |
| `TaskItemUsers` | Performer rendering in step cards is correct for all types |
| `cleanTemplateReferences()` | Field performers still cleaned correctly when steps are deleted |
| `_get_raw_performer()` | Existing types (user, group, field, workflow_starter) are created without regressions |
| `update_performers()` | Calls `_resolve_manager` — main runtime path where manager is assigned |
| `RawPerformerSerializer` validation | MSG_PT_0074 correctly rejects MANAGER on steps with `require_completion_by_all=True`; valid templates save without errors |

## 7. Refactoring

- Translated comments in `.storybook/preview.tsx` (RU→EN)
- Translated `describe` blocks in `RichEditor.spec.test.tsx` (RU→EN)
- These changes are cosmetic and do not affect logic


## 8. Release Notes

**New Feature: "Manager of Step" Performer Type**

Templates now support a "Manager" performer type. When configuring a workflow step, you can assign it to the manager of the user who completed a specific previous step. This enables hierarchical approval flows where tasks automatically route to the appropriate supervisor.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new performer type that dynamically assigns tasks based on workflow completion events and introduces new persisted fields via migration; incorrect resolution or edge cases (reverts, inactive managers) could change performer assignment at runtime.
> 
> **Overview**
> Adds a new `PerformerType.MANAGER` that assigns a task to the **manager of the user who completed a specified source step**.
> 
> Backend adds `source_task_api_name` to raw performer models (and versioning schema), validates manager performers at template-save time (required source step, no self-reference, source must exist, and cannot be `require_completion_by_all`), and resolves the manager during `Task.update_performers()` by looking up the latest `TASK_COMPLETE` workflow event and clearing stale performer links when resolution fails.
> 
> Frontend updates the template editor to offer **“Manager: {step}”** options in the performers dropdown (unique `manager-` values), display manager performers in task cards, localize labels, and extend template cleanup to drop manager performers if their source step is removed. Includes comprehensive backend/frontend tests for resolution, serialization/versioning, and UI option generation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f10699d9686e3998db9e910a55527fde9f8c1f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add hierarchical approval workflow with Manager performer type
> - Introduces a new `manager` performer type that dynamically assigns the manager of the user who completed a specified source step as the performer for a subsequent task.
> - Adds `source_task_api_name` field to `RawPerformer` and `RawPerformerTemplate` models (via migration [0252](https://github.com/pneumaticapp/pneumaticworkflow/pull/210/files#diff-3c93fd3eef17af2ab0ca239b85706f32ca79e07e06708b7d5a4c8038b7d31d27)) to link a manager performer to its source step.
> - Backend resolver (`Task._resolve_manager`) looks up the completer of the source task via workflow events and resolves their manager; if no manager is found or the source task is reverted, the TaskPerformer link is cleared.
> - Frontend dropdown in [getPerformersForDropdown.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/210/files#diff-ab5a3b4dfb674561a7d7bd98145c62441ef7bc880b368faf2ab55aba68994628) now lists manager-of-step options (excluding the current step), and [cleanTemplateReferences](https://github.com/pneumaticapp/pneumaticworkflow/pull/210/files#diff-bba6bc9d61c0008252857e2bf1f5e624bea1f2e72358cebea80327e1bf25a960) removes manager performers whose source step no longer exists.
> - Risk: manager performer resolution is dynamic and depends on workflow event history; reverting a source task clears the manager assignment, which may be unexpected for in-progress workflows.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8f10699.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->