### PR TITLE
46825 frontend [ template ] Dashes escaped with backslash in workflow name

### DIFF
--- a/frontend/src/public/utils/__tests__/escapeMarkdown.test.ts
+++ b/frontend/src/public/utils/__tests__/escapeMarkdown.test.ts
@@ -1,0 +1,226 @@
+// <reference types="jest" />
+import { escapeMarkdown } from '../escapeMarkdown';
+
+describe('escapeMarkdown', () => {
+  describe('plain text without special characters', () => {
+    it('returns empty string for no arguments', () => {
+      expect(escapeMarkdown()).toBe('');
+    });
+
+    it('returns empty string for empty string', () => {
+      expect(escapeMarkdown('')).toBe('');
+    });
+
+    it('preserves plain text without special characters', () => {
+      expect(escapeMarkdown('Hello world')).toBe('Hello world');
+    });
+
+    it('preserves numbers', () => {
+      expect(escapeMarkdown('Order 12345')).toBe('Order 12345');
+    });
+
+    it('preserves whitespace and newlines', () => {
+      expect(escapeMarkdown('  spaced  out  ')).toBe('  spaced  out  ');
+      expect(escapeMarkdown('line1\nline2')).toBe('line1\nline2');
+    });
+  });
+
+  describe('dashes are NOT escaped (bug fix)', () => {
+    it('does not escape dashes in plain text', () => {
+      expect(escapeMarkdown('a-b')).toBe('a-b');
+      expect(escapeMarkdown('one-two-three')).toBe('one-two-three');
+      expect(escapeMarkdown('-')).toBe('-');
+      expect(escapeMarkdown('---')).toBe('---');
+    });
+
+    it('does not escape dash between variables', () => {
+      expect(escapeMarkdown('{{date}}-{{template-name}}')).toBe('{{date}}-{{template-name}}');
+    });
+
+    it('does not escape dash with spaces around', () => {
+      expect(escapeMarkdown('value - another')).toBe('value - another');
+    });
+
+    it('does not escape em-dash', () => {
+      expect(escapeMarkdown('word — word')).toBe('word — word');
+    });
+  });
+
+  describe('variable preservation', () => {
+    it('preserves a single variable', () => {
+      expect(escapeMarkdown('{{date}}')).toBe('{{date}}');
+    });
+
+    it('preserves variable with dashes in api-name', () => {
+      expect(escapeMarkdown('{{template-name}}')).toBe('{{template-name}}');
+    });
+
+    it('preserves variable with alphanumeric api-name', () => {
+      expect(escapeMarkdown('{{field-8d287d}}')).toBe('{{field-8d287d}}');
+    });
+
+    it('preserves variable with spaces inside braces', () => {
+      expect(escapeMarkdown('{{ date }}')).toBe('{{ date }}');
+    });
+
+    it('preserves multiple variables', () => {
+      expect(escapeMarkdown('{{date}} {{template-name}}')).toBe('{{date}} {{template-name}}');
+    });
+
+    it('preserves many variables in a row', () => {
+      const input = '{{a}}{{b}}{{c}}{{d}}';
+      expect(escapeMarkdown(input)).toBe(input);
+    });
+
+    it('preserves variables with text between them', () => {
+      expect(escapeMarkdown('Start {{date}} middle {{name}} end')).toBe('Start {{date}} middle {{name}} end');
+    });
+
+    it('preserves workflow-id variable', () => {
+      expect(escapeMarkdown('{{workflow-id}}')).toBe('{{workflow-id}}');
+    });
+
+    it('preserves workflow-starter variable', () => {
+      expect(escapeMarkdown('{{workflow-starter}}')).toBe('{{workflow-starter}}');
+    });
+  });
+
+  describe('markdown special characters escaping', () => {
+    const cases: [string, string, string][] = [
+      ['backslash', 'a\\b', 'a\\\\b'],
+      ['backtick', 'a`b', 'a\\`b'],
+      ['asterisk', 'a*b', 'a\\*b'],
+      ['underscore', 'a_b', 'a\\_b'],
+      ['square brackets', 'a[b]c', 'a\\[b\\]c'],
+      ['curly braces outside variables', 'a{b}c', 'a\\{b\\}c'],
+      ['parentheses', 'a(b)c', 'a\\(b\\)c'],
+      ['hash', 'a#b', 'a\\#b'],
+      ['plus', 'a+b', 'a\\+b'],
+      ['dot', 'a.b', 'a\\.b'],
+      ['exclamation mark', 'a!b', 'a\\!b'],
+      ['pipe', 'a|b', 'a\\|b'],
+      ['tilde', 'a~b', 'a\\~b'],
+      ['colon', 'a:b', 'a\\:b'],
+      ['double quote', 'a"b', 'a\\"b'],
+      ['single quote', "a'b", "a\\'b"],
+      ['ampersand', 'a&b', 'a\\&b'],
+      ['percent', 'a%b', 'a\\%b'],
+      ['equals', 'a=b', 'a\\=b'],
+    ];
+
+    test.each(cases)('escapes %s: %s -> %s', (_label, input, expected) => {
+      expect(escapeMarkdown(input)).toBe(expected);
+    });
+
+    it('escapes multiple special characters in a row', () => {
+      expect(escapeMarkdown('**bold**')).toBe('\\*\\*bold\\*\\*');
+    });
+
+    it('escapes mixed special characters', () => {
+      expect(escapeMarkdown('_italic_ and **bold**')).toBe('\\_italic\\_ and \\*\\*bold\\*\\*');
+    });
+  });
+
+  describe('combined: variables + dashes + special characters', () => {
+    it('real-world wf_name_template with dashes between variables', () => {
+      const input = '{{date}} — {{template-name}}-{{field-8d287d}} -{{workflow-id}}';
+      expect(escapeMarkdown(input)).toBe('{{date}} — {{template-name}}-{{field-8d287d}} -{{workflow-id}}');
+    });
+
+    it('variable followed by dash and text', () => {
+      expect(escapeMarkdown('{{date}}-report')).toBe('{{date}}-report');
+    });
+
+    it('text with dash followed by variable', () => {
+      expect(escapeMarkdown('report-{{date}}')).toBe('report-{{date}}');
+    });
+
+    it('variable with special characters around it', () => {
+      expect(escapeMarkdown('**{{date}}**')).toBe('\\*\\*{{date}}\\*\\*');
+    });
+
+    it('complex template with dashes and special chars', () => {
+      const input = '{{date}} — {{template-name}} (v1.0) #{{workflow-id}}';
+      const expected = '{{date}} — {{template-name}} \\(v1\\.0\\) \\#{{workflow-id}}';
+      expect(escapeMarkdown(input)).toBe(expected);
+    });
+
+    it('multiple dashes and variables mixed', () => {
+      const input = '{{a}}-{{b}}-{{c}}';
+      expect(escapeMarkdown(input)).toBe('{{a}}-{{b}}-{{c}}');
+    });
+
+    it('preserves dash in text between two variables with spaces', () => {
+      const input = '{{date}} - {{name}}';
+      expect(escapeMarkdown(input)).toBe('{{date}} - {{name}}');
+    });
+
+    it('template name with underscores gets escaped but variables preserved', () => {
+      const input = '{{date}}_{{template-name}}';
+      expect(escapeMarkdown(input)).toBe('{{date}}\\_{{template-name}}');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles single curly brace (not a variable)', () => {
+      expect(escapeMarkdown('{not a var}')).toBe('\\{not a var\\}');
+    });
+
+    it('handles triple curly braces', () => {
+      expect(escapeMarkdown('{{{var}}}')).toBe('\\{{{var}}\\}');
+    });
+
+    it('handles empty variable name', () => {
+      expect(escapeMarkdown('{{}}')).toBe('\\{\\{\\}\\}');
+    });
+
+    it('handles text that looks like placeholder pattern __VAR_0__', () => {
+      const input = '__VAR_0__ some text';
+      expect(escapeMarkdown(input)).toBe('\\_\\_VAR\\_0\\_\\_ some text');
+    });
+
+    it('handles very long text without escaping dashes', () => {
+      const longText = 'a-b '.repeat(1000);
+      expect(escapeMarkdown(longText)).toBe(longText);
+    });
+
+    it('handles unicode characters', () => {
+      expect(escapeMarkdown('Привет-мир')).toBe('Привет-мир');
+    });
+
+    it('handles emoji', () => {
+      expect(escapeMarkdown('🚀-launch')).toBe('🚀-launch');
+    });
+
+    it('preserves tab characters', () => {
+      expect(escapeMarkdown('col1\tcol2')).toBe('col1\tcol2');
+    });
+  });
+
+  describe('idempotency concerns', () => {
+    it('double-escaping: already escaped backslash gets double-escaped', () => {
+      expect(escapeMarkdown('a\\-b')).toBe('a\\\\-b');
+    });
+
+    it('double call produces double escaping for special chars', () => {
+      const once = escapeMarkdown('a*b');
+      const twice = escapeMarkdown(once);
+      expect(once).toBe('a\\*b');
+      expect(twice).toBe('a\\\\\\*b');
+    });
+
+    it('double call does NOT double-escape dashes', () => {
+      const once = escapeMarkdown('a-b');
+      const twice = escapeMarkdown(once);
+      expect(once).toBe('a-b');
+      expect(twice).toBe('a-b');
+    });
+
+    it('double call preserves variables both times', () => {
+      const once = escapeMarkdown('{{date}}-{{name}}');
+      const twice = escapeMarkdown(once);
+      expect(once).toBe('{{date}}-{{name}}');
+      expect(twice).toBe('{{date}}-{{name}}');
+    });
+  });
+});

--- a/frontend/src/public/utils/escapeMarkdown.ts
+++ b/frontend/src/public/utils/escapeMarkdown.ts
@@ -5,7 +5,7 @@ export function escapeMarkdown(text: string = ''): string {
     return `__VAR_${variables.length - 1}__`;
   });
 
-  text = text.replace(/([\\`*_[\]{}()#+\-.!|&%=:"'~])/g, '\\$1');
+  text = text.replace(/([\\`*_[\]{}()#+.!|&%=:"'~])/g, '\\$1');
   variables.forEach((variable, index) => {
     text = text.replace(`\\_\\_VAR\\_${index}\\_\\_`, variable);
   });


### PR DESCRIPTION
## 1. Description (Problem)
When launching a workflow from a template, backslashes appear before every dash (`\-`) in the "Workflow name" field of the launch modal.
Example: template `{{date}} — {{template-name}}-{{field-xxx}} -{{workflow-id}}` renders as `Date — Template name \- Checkbox Field \- Workflow id`.
Visible in the workflow launch modal ("Run" button on the template page) and in the template editor ("Workflow name" field in the Kick-off Form).
## 2. Context
The `escapeMarkdown` function was introduced to prepare text before loading it into the Lexical editor — so that markdown special characters (`*`, `_`, `` ` ``, etc.) are not interpreted as formatting. The dash (`-`) was incorrectly included in the list of escaped characters, even though it is not a markdown special character in inline context (only at line start as a list marker, but the field is single-line with `multiline={false}`).
## 3. Solution
Remove the dash character from the escaping regex pattern in `escapeMarkdown`. This is a minimal one-line change that eliminates the issue without side effects.
## 4. Implementation Details
### Files affected:
- **`frontend/src/public/utils/escapeMarkdown.ts`** — removed `\-` from regex character class on line 8
- **`frontend/src/public/utils/__tests__/escapeMarkdown.test.ts`** — new file, 59 tests
### Regex change:
- Before: `/([\\`*_[\]{}()#+\-.!|&%=:"'~])/g`
- After: `/([\\`*_[\]{}()#+.!|&%=:"'~])/g`
No API, type, or contract changes. Frontend-only change.
## 5. What to Test
### 5.1 Preconditions
- Environment: dev
- Account with template editor access
- A template with "Workflow name" field containing dashes between variables
### 5.2 Positive Scenarios
1. **Launch workflow with dashes in name:**
   - [ ] Open template → Kick-off Form → set "Workflow name" to: `{{date}} — {{template-name}}-{{field-xxx}}`
   - [ ] Save template → click "Run"
   - [ ] In the launch modal, verify dashes display without backslashes
   - [ ] Launch the workflow → check that the workflow name in the list is correct (no `\-`)
2. **Edit name in the launch modal:**
   - [ ] Open the launch modal for a template with dashes in Workflow name
   - [ ] Edit the name: add/remove a dash
   - [ ] Click Run → verify the name is saved correctly
3. **Template without dashes (regression):**
   - [ ] Verify that a template like `{{date}} {{template-name}}` still works correctly
### 5.3 Negative Scenarios and Edge Cases
1. **Multiple consecutive dashes:** Workflow name `---{{date}}---` → should display as-is, no `\`
2. **Dash only:** Workflow name `-` → should remain just `-`
3. **Markdown formatting in name:** Enter `**bold** _italic_` → asterisks and underscores should still be escaped (displayed as text, not formatting)
4. **Empty workflow name:** Leave field empty → Run button should be disabled
### 5.4 Verification Points
- [ ] Launch modal UI: dashes without backslashes
- [ ] Template editor UI (Kick-off Form → Workflow name): dashes without backslashes
- [ ] Created workflow name in the list: correct, no `\-`
- [ ] DevTools → Network → launch request payload: `name` field without `\-`
### 5.5 API Checks
This PR **does not change API requests or responses**. The change is only in the client-side text preparation before displaying in the Lexical editor. However, verify:
- In the `POST /workflows` request, the `name` field should not contain `\-`
- The `wf_name_template` field in `GET /templates/{id}` response remains unchanged (dashes without escaping)
### 5.6 What Was NOT Tested
- Not tested on mobile devices
- Not tested in production
- Locales were not checked (change does not affect i18n)
- Public form was not tested separately
## 6. Affected Areas (Dependencies)
`escapeMarkdown` is used in the `InputWithVariables` component, which is used in 3 places:
| Location | Component | What to verify |
|----------|-----------|----------------|
| Workflow launch modal | `WorkflowEditPopup` | "Workflow name" field — dashes without `\` |
| Template editor, Kick-off Form | `KickoffRedux` | "Workflow name" field — dashes without `\` |
| Template editor, task description | `TaskForm` | Task name field — dashes without `\` |
## 7. Refactoring
No refactoring was performed. The change is a 1-character bugfix in a regex.
## 8. Commits
- `7d0b0ab7` — `fix(frontend): stop escaping dashes in workflow name template`
## 9. Release Notes
Fixed: dashes in workflow name template no longer display with backslashes when launching a workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-character regex change to stop escaping `-`, plus comprehensive unit tests; main risk is a small behavior change where `-` will no longer be backslash-escaped in any `escapeMarkdown` usage.
> 
> **Overview**
> Fixes workflow/template text rendering by updating `escapeMarkdown` to **no longer escape hyphens (`-`)** while continuing to escape other markdown-relevant characters.
> 
> Adds a comprehensive Jest test suite for `escapeMarkdown`, covering variable placeholder preservation (`{{...}}`), special-character escaping, dash handling, and edge/idempotency cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d0b0ab7dbf36313c5e3dc73630b6f5b5bbd173b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix dash escaping in workflow name template `escapeMarkdown` function
> Removes `-` from the set of characters backslash-escaped in [`escapeMarkdown.ts`](https://github.com/pneumaticapp/pneumaticworkflow/pull/214/files#diff-93e7918697facecc8812bb026f1a1c1bf926c39ad78068eabd661046e76fc0c0), so strings like `a-b` stay as `a-b` instead of becoming `a\-b`. Adds a Jest test suite in [`escapeMarkdown.test.ts`](https://github.com/pneumaticapp/pneumaticworkflow/pull/214/files#diff-f76b2072b19ccc70d86132e35183b591a2bed20abb997c115d84b8cfd3433a25) covering dash handling, variable preservation, and idempotency.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7d0b0ab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->