### PR TITLE
47135 backend [ configuration ] Fix dockerignore

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -44,9 +44,6 @@ Thumbs.db
 staticfiles/
 tmp/
 
-# Google credentials (should be mounted, not baked in)
-google_api_credentials.json
-
 # Pre-commit
 .pre-commit-config.yaml
 


### PR DESCRIPTION
## 1. Description

File uploads (POST `/workflows/attachments`) fail in production with **"Cloud service: get_new_file_urls exception"** (Sentry error, 10 events / 3 users in 1 hour). No user can upload attachments to workflows.

Root cause: `google_api_credentials.json` is excluded from the Docker image by `backend/.dockerignore`, so `storage.Client()` (Google Cloud SDK) cannot find credentials to generate signed URLs.

## 2. Context

PR #216 (`46858_add_copy_instruction_backend_dockerfile`) expanded `backend/.dockerignore` and added `google_api_credentials.json` with the comment "should be mounted, not baked in". However, in the production deploy (Ansible), the file is **not mounted** — it is copied by the `app_copy_credentials_files` role into the build directory, then `ADD . /pneumatic_backend/` in `Dockerfile.j2` includes it in the image. The `.dockerignore` exclusion broke this chain.

## 3. Solution

Remove `google_api_credentials.json` from `backend/.dockerignore` so the file is included in the Docker image during production builds.

## 4. Implementation Details

- **Changed file:** `backend/.dockerignore`
- **Change:** removed 3 lines (comment + exclusion rule + blank line)
- **No API/contract changes**

## 5. What to Test

### 5.1 Preconditions

- Access to production backend server
- Account with active subscription
- Backend Docker image rebuild required after deploy

### 5.2 Positive Scenarios

1. Deploy the branch to staging/production
2. Enter the backend container: `docker exec -it backend-prod sh`
3. Verify file exists: `ls -la /pneumatic_backend/google_api_credentials.json`
   - **Expected:** file exists, contains valid JSON
4. In UI: open any workflow → attach a file (image, document)
   - **Expected:** file uploads without errors, preview is displayed
5. Check Sentry — no new "Cloud service: get_new_file_urls exception" events

### 5.3 Negative Scenarios

1. Upload an oversized file — should show validation error, not GCS error
2. Upload a file with non-standard content-type — should be handled correctly

### 5.4 Verification Points

- **In container:** `/pneumatic_backend/google_api_credentials.json` exists
- **In Docker image:** `docker run --rm <image> ls /pneumatic_backend/google_api_credentials.json`
- **Sentry:** no new `get_new_file_urls exception` events
- **UI:** attachment uploads work

### 5.5 What Was NOT Tested

- Push notifications (Firebase) — `firebase-push.json` was not affected
- Locales not tested (out of scope)
- Mobile devices not tested
- Testing only on staging/production after deploy

## 6. Affected Areas

`.dockerignore` change affects **only** production Docker image builds. Does not affect local development, tests, or CI/CD pipeline.

## 7. Refactoring

None.

## 8. Commits

- `d4f741ea` — hotfix(docker): allow GCS credentials into Docker image

## 9. Release Notes

**Fixed:** File uploads were failing with "Cloud service exception" because GCS credentials were excluded from the Docker image by `.dockerignore`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bakes Google Cloud service account credentials into the production image again, which increases credential exposure if images leak but is required for the current Ansible copy-into-image deploy model.
> 
> **Overview**
> Restores inclusion of `google_api_credentials.json` in production Docker images by removing its entry from `backend/.dockerignore`.
> 
> That file is expected at `/pneumatic_backend/google_api_credentials.json` (via `GOOGLE_APPLICATION_CREDENTIALS`) for GCS signed URLs during workflow attachment uploads. Excluding it broke `storage.Client()` in production and surfaced as **Cloud service: get_new_file_urls exception**; the deploy path copies credentials into the build context rather than mounting them at runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4f741ea3fd52dfb1bcd0e7ec6befa97e392f7e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Include `google_api_credentials.json` in backend Docker build context
> Removes the `google_api_credentials.json` exclusion rule from [backend/.dockerignore](https://github.com/pneumaticapp/pneumaticworkflow/pull/222/files#diff-b148396bbfff0ab728abd0f4ecccb2d94ee1929bebbfdcb301a1818a7fa8a351) so the file is included in the Docker build context.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d4f741e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->