### PR TITLE
47201 frontend [ Run ] Identical radio fields for two different radio

### DIFF
--- a/frontend/src/public/__stubs__/fields.factory.ts
+++ b/frontend/src/public/__stubs__/fields.factory.ts
@@ -1,0 +1,18 @@
+import { EExtraFieldType, IExtraField } from '../types/template';
+
+export const makeExtraField = (overrides: Partial<IExtraField> = {}): IExtraField => ({
+  apiName: 'field-1',
+  name: 'Field',
+  type: EExtraFieldType.String,
+  order: 0,
+  userId: null,
+  groupId: null,
+  description: '',
+  isRequired: false,
+  isHidden: false,
+  value: '',
+  selections: [],
+  attachments: [],
+  dataset: null,
+  ...overrides,
+});

--- a/frontend/src/public/components/TemplateEdit/ExtraFields/Radio/ExtraFieldRadio.tsx
+++ b/frontend/src/public/components/TemplateEdit/ExtraFields/Radio/ExtraFieldRadio.tsx
@@ -213,7 +213,7 @@ export function ExtraFieldRadio({
 
     return (
       <li key={selectionValue} className={fieldStyles['kickoff-set-field-option']}>
-        <RadioButton id={selectionValue} title={selectionValue} onChange={handleToggleOption(selectionValue)} checked={isChecked} />
+        <RadioButton id={`${field.apiName}-${selectionValue}`} title={selectionValue} onChange={handleToggleOption(selectionValue)} checked={isChecked} />
       </li>
     );
   };

--- a/frontend/src/public/components/TemplateEdit/ExtraFields/Radio/__tests__/ExtraFieldRadio.test.tsx
+++ b/frontend/src/public/components/TemplateEdit/ExtraFields/Radio/__tests__/ExtraFieldRadio.test.tsx
@@ -6,7 +6,9 @@ import { ExtraFieldRadio } from '../ExtraFieldRadio';
 import { OutputFieldContent } from '../../utils/OutputFieldContent';
 import { RadioButton } from '../../../../UI/Fields/RadioButton';
 import { intlMock } from '../../../../../__stubs__/intlMock';
-import { EExtraFieldMode } from '../../../../../types/template';
+import { EExtraFieldMode, EExtraFieldType } from '../../../../../types/template';
+import { IWorkflowExtraFieldProps } from '../../types';
+import { makeExtraField } from '../../../../../__stubs__/fields.factory';
 
 jest.mock('../../utils/OutputFieldContent', () => ({
   OutputFieldContent: jest.fn(({ children }: any) =>
@@ -125,5 +127,53 @@ describe('ExtraFieldRadio', () => {
     expect(mock).toHaveBeenCalledWith(expect.objectContaining({ title: 'Red' }), {});
     expect(mock).toHaveBeenCalledWith(expect.objectContaining({ title: 'Blue' }), {});
     expect(mock).toHaveBeenCalledWith(expect.objectContaining({ title: 'Green' }), {});
+  });
+
+  describe('unique radio grouping across multiple fields', () => {
+    it('ProcessRun: two fields with identical selections receive unique RadioButton ids', () => {
+      const sharedSelections = ['Red', 'Blue'];
+
+      const field1 = makeExtraField({
+        apiName: 'radio-1',
+        name: 'Color',
+        type: EExtraFieldType.Radio,
+        selections: sharedSelections,
+        value: 'Red',
+      });
+
+      const field2 = makeExtraField({
+        apiName: 'radio-2',
+        name: 'Color',
+        type: EExtraFieldType.Radio,
+        selections: sharedSelections,
+        value: null,
+      });
+
+      const commonProps: Omit<IWorkflowExtraFieldProps, 'field'> = {
+        intl: intlMock,
+        editField: mockEditField,
+        mode: EExtraFieldMode.ProcessRun,
+        isDisabled: false,
+        accountId: 1,
+      };
+
+      // @ts-expect-error master version returns ReactNode; after fieldsets merge this becomes JSX.Element and labelPosition must be added
+      render(<ExtraFieldRadio {...commonProps} field={field1} />);
+      // @ts-expect-error master version returns ReactNode; after fieldsets merge this becomes JSX.Element and labelPosition must be added
+      render(<ExtraFieldRadio {...commonProps} field={field2} />);
+
+      const mock = RadioButton as jest.Mock;
+      expect(mock).toHaveBeenCalledTimes(4);
+      const allIds = mock.mock.calls.map((call: [Record<string, unknown>]) => call[0].id as string);
+
+      const uniqueIds = new Set(allIds);
+      expect(uniqueIds.size).toBe(allIds.length);
+
+      const field1Ids = allIds.filter((id: string) => id.includes('radio-1'));
+      expect(field1Ids).toHaveLength(sharedSelections.length);
+
+      const field2Ids = allIds.filter((id: string) => id.includes('radio-2'));
+      expect(field2Ids).toHaveLength(sharedSelections.length);
+    });
   });
 });

--- a/frontend/src/public/constants/menu.tsx
+++ b/frontend/src/public/constants/menu.tsx
@@ -84,7 +84,7 @@ export const getUserMenuItems = (
     },
     {
       id: 'help-center',
-      to: 'https://support.pneumatic.app/en/',
+      to: 'https://support.pneumatic.app/',
       label: 'menu.help-center',
       subsSlug: 'help-center',
       newWindow: true,


### PR DESCRIPTION
### 1. Release notes

- Fixed a bug where multiple radio fields with identical selection options (e.g., two "Color" fields with options "Red", "Blue") conflicted with each other: selecting a value in one field would deselect the value in the other.
- Fixed a broken Help Center link in the sidebar menu (it led to a non-existent page).

### 2. Description (problem)

When a Process Run form contained two or more radio fields with **identical selection options**, selecting a value in one field would reset the selection in the other.

**Root cause:** in task #45407 the API contract was changed — `selections` in ProcessRun switched from `IExtraFieldSelection[]` (objects with a unique `apiName`) to `string[]` (plain values: `["Red", "Blue"]`). Before this change, `RadioButton` received `id={apiName}`, where `apiName` was a unique option identifier. After the switch to `string[]`, `id` became `id={selectionValue}` — the option's display value itself. When two fields share the same options (e.g., both have `"Red"`, `"Blue"`), their `id` values collide, causing `RadioButton` to generate identical HTML `name` attributes — which the browser uses to group `<input type="radio">` into a single radio group.

**Where it manifested:** Process Run screen, when the template has two radio fields with identical options.

### 3. Context

- Task: #47201
- Component: `ExtraFieldRadio` (path: `TemplateEdit/ExtraFields/Radio/`)
- Affects ProcessRun mode (form filling during process launch)
- Kickoff mode (template editing) is not affected — it already uses option `apiName` as `id`

### 4. Solution

Added `field.apiName` as a prefix to the `RadioButton` `id` in ProcessRun mode: `` id={`${field.apiName}-${selectionValue}`} ``. This ensures a unique `name` for each radio field, even when selection options are identical.

### 5. Implementation details

**Before:**
```tsx
<RadioButton id={selectionValue} ... />
// With selectionValue="Red" → name contains "Red"
// Two fields with option "Red" → same name → conflict
```

**After:**
```tsx
<RadioButton id={`${field.apiName}-${selectionValue}`} ... />
// With field.apiName="radio-1", selectionValue="Red" → name contains "radio-1-Red"
// Two fields with option "Red" → different name → isolation
```

### 6. What to test

#### 6.1 Preconditions

- Create a template with two radio fields that have **identical** selection options (e.g., both fields with options "Red", "Blue", "Green")
- Testing in Desktop Chromium (dev branch). Safari, Firefox, Mobile — deferred to QA.

#### 6.2 Positive scenarios

| Scenario | Description (steps and expected result) | Verified by Developer (desktop) | Verified by Developer (mobile) | Verified by AI Agent (Chromium) |
| :--- | :--- | :--- | :--- | :--- |
| **Two radio fields with same options** | Create a template with two radio fields both having options "Red", "Blue". Run the process. Select "Red" in the first field, then "Blue" in the second → Both selections persist, the first is not reset. | [ ] | [ ] | [ ] |
| **Single radio field** | Run a process with one radio field → Selection works as expected, no regressions. | [ ] | [ ] | [ ] |
| **Radio fields with unique options** | Two radio fields with **different** options → They work independently. | [ ] | [ ] | [ ] |

#### 6.3 Negative scenarios

| Scenario | Description (steps and expected result) | Verified by Developer (desktop) | Verified by Developer (mobile) | Verified by AI Agent (Chromium) |
| :--- | :--- | :--- | :--- | :--- |
| **Deselecting a value** | Select a value in a radio field → Click the same value again → Selection is cleared (if this behavior is supported). | [ ] | [ ] | [ ] |
| **Required field without selection** | Leave a required radio field empty → Attempt to submit the form → Validation fires. | [ ] | [ ] | [ ] |

#### 6.4 Verification points

- In UI: selecting a value in one radio field does not reset the value in another
- In DOM (DevTools): radio buttons from different fields have different `name` attribute values (inspect via DevTools → Elements)

#### 6.5 Not tested

- Locales were not tested (change does not affect text)
- Not tested under load
- Kickoff mode (template editing) is not affected by the changes
- Safari, Firefox, Mobile — deferred to QA

### 7. Unit tests

Added test: `ProcessRun: two fields with identical selections receive unique RadioButton ids`
- Renders two fields with identical options (`['Red', 'Blue']`) and different `apiName` values
- Verifies all 4 `RadioButton` calls receive unique `id` values
- Verifies each field's `id` values contain the corresponding `apiName`

Also added the `makeExtraField` factory in `__stubs__/fields.factory.ts` for type-safe `IExtraField` test object creation.

---

### Additional fix: Help Center

#### Problem

Clicking "Help Center" in the sidebar menu opened `support.pneumatic.app/en/`, which returned a 404 (Page not found). The link had been set with `/en/` since the project's initial commit, but the support site no longer serves that path.

#### Solution

Removed the `/en/` segment from the URL in the menu configuration (`menu.tsx`). Changed from `https://support.pneumatic.app/en/` to `https://support.pneumatic.app/`.

#### Testing

| Scenario | Description (steps and expected result) | Verified by Developer (desktop) | Verified by Developer (mobile) | Verified by AI Agent (Chromium) |
| :--- | :--- | :--- | :--- | :--- |
| **Help Center opens** | Click "Help Center" in the sidebar → A new tab opens with `support.pneumatic.app` → Page loads without errors (no 404). | [ ] | [ ] | [ ] |
| **Link opens in a new tab** | Click "Help Center" → The link opens in a **new** tab, the current page remains unchanged. |[ ] | [ ] | [ ] |

### 8. Commits

- `062a3d3b` — 47201 fix(radio): prevent radio fields from conflicting when multiple share identical options
- `8a729f58` — 47201 fix: update Help Center link to match current support site URL



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI and navigation URL changes with no auth, API, or data-layer impact; risk is limited to form radio behavior and the help link.
> 
> **Overview**
> Fixes **Process Run** radio fields that shared the same option labels being treated as one browser radio group: `RadioButton` `id` values are now **`${field.apiName}-${selectionValue}`** instead of the raw option string, so selections stay independent across fields.
> 
> Adds a **`makeExtraField`** test stub and a unit test that two fields with identical options get distinct `RadioButton` ids. Updates the sidebar **Help Center** link from `https://support.pneumatic.app/en/` to **`https://support.pneumatic.app/`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a729f580114057c62bf1bf08cebc19748956599. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->





<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> <!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
> <!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix duplicate radio button IDs when two fields share identical selections
> When multiple radio fields have the same selection values, their `RadioButton` elements were assigned identical `id` attributes, breaking HTML label association. The fix prefixes each `id` with the field's `apiName` (e.g. `${field.apiName}-${selectionValue}`) in [`ExtraFieldRadio.tsx`](https://github.com/pneumaticapp/pneumaticworkflow/pull/223/files#diff-1c85523b54fbb5b0e107b579c411d9aff8948142949ae9c5a0c6b61546e2a2d9). A new test suite using the [`makeExtraField`](https://github.com/pneumaticapp/pneumaticworkflow/pull/223/files#diff-0cb5a694e7dfb9855c2f66e540be779ca76079c3cd342a01499dcb8ac7d6865f) factory verifies that two fields with identical selections produce unique IDs.
> >
> <!-- Macroscope's changelog starts here -->
> #### Changes since #223 opened
>
> - Changed the Help Center menu item URL in `getUserMenuItems` function [8a729f5]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
> >
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 062a3d3.</sup>
> <!-- Macroscope's review summary ends here -->
> >
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->