### PR TITLE
🔧 47207 frontend [ forms ] Fix environment-dependent

### DIFF
--- a/frontend/src/server/__tests__/server.test.ts
+++ b/frontend/src/server/__tests__/server.test.ts
@@ -57,6 +57,7 @@ const initMockConfig = () => {
   const realConfig = utils.getConfig();
   return {
     ...realConfig,
+    formSubdomain: '',
     api: {
       ...realConfig.api,
       urls: realConfig.api?.urls || {},


### PR DESCRIPTION
## 1. Description (Problem)

`server.test.ts` consistently fails on CI (lines 117, 147):
- `expect(app.use).toHaveBeenCalledTimes(4)` — receives 5
- `expect(app.use).toHaveBeenCalledTimes(6)` — receives 7

The test passes locally but fails in the CI pipeline.

## 2. Context

Commit `125e67aa` (PR #217, task 46864 — public forms via URL path) added conditional middleware registration in `server.ts:102-105`:

```ts
if (formSubdomain) {
  app.use(forwardForSubdomain([formSubdomain], formsRouter));
}
```

`formSubdomain` comes from `getConfig()`, which reads `process.env.FORM_DOMAIN`.
On CI this env var is set → `formSubdomain` is truthy → extra `app.use()` call → call count assertion fails.

The root cause is an anti-pattern in the test: `initMockConfig()` calls the **real** `getConfig()` via `jest.requireActual` to seed mock data, inheriting the `process.env` state.

## 3. Solution

Explicitly override `formSubdomain: ''` in `initMockConfig()` so the mock config does not depend on CI environment variables. Minimal, targeted fix that makes the test deterministic.

## 4. Implementation Details

- **File:** `frontend/src/server/__tests__/server.test.ts`
- **Change:** +1 line in `initMockConfig()` — added `formSubdomain: ''` to the config spread
- No API, type, or contract changes

## 5. What to Test

### 5.1 Preconditions
- Node.js and dependencies installed (`npm install`)

### 5.2 Positive Scenarios

1. Run test **with** `FORM_DOMAIN` set:
   ```bash
   FORM_DOMAIN=form.test npx jest src/server/__tests__/server.test.ts
   ```
   **Expected:** 6/6 tests pass ✅

2. Run test **without** `FORM_DOMAIN`:
   ```bash
   npx jest src/server/__tests__/server.test.ts
   ```
   **Expected:** 6/6 tests pass ✅

### 5.3 Negative Scenarios

1. Set `FORM_DOMAIN=anything.example.com` → test should pass
2. Set `FORM_DOMAIN=''` → test should pass

### 5.4 Verification Points
- CI pipeline passes green
- All 6 test cases in `server.test.ts` — pass

### 5.5 API Checks
N/A — test-only changes.

### 5.6 What Was NOT Tested
- Runtime behavior of `forwardForSubdomain` middleware (unchanged)
- Full refactor of `initMockConfig` (using `requireActual` to seed mock data is tech debt — separate task)

## 6. Affected Areas (Dependencies)

Test file only. No production code changed — zero regression risk.

## 7. Refactoring

None. Minimal targeted fix.

## 8. Commits

- `4b2c371b` — `47207 fix(tests): mock formSubdomain in server test to fix CI failure`

## 9. Release Notes

N/A — test-only changes, no user impact.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no production code or runtime behavior modified.
> 
> **Overview**
> Makes **`server.test.ts`** deterministic on CI by forcing **`formSubdomain: ''`** in **`initMockConfig()`**, so tests no longer inherit **`FORM_DOMAIN`** from the real **`getConfig()`** seed.
> 
> Without this override, a truthy **`formSubdomain`** registers an extra **`forwardForSubdomain`** **`app.use()`** in **`server.ts`**, which broke production/development **`app.use`** call-count expectations (5 vs 4, 7 vs 6).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b2c371be5c37a349b6966753705712cc9ba3920. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix environment-dependent test config by adding `formSubdomain` to `initMockConfig`
> Adds `formSubdomain: ''` to the mock config returned by `initMockConfig` in [server.test.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/224/files#diff-598df658d2534c36a04138a95a212618d054607a059114711dee7c93d74f1a0a). This prevents test failures caused by `formSubdomain` being undefined in environments where it is not set in the real config.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4b2c371.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->