### PR TITLE
47299 frontend [ sentry ] 18Q, 18V, 18T, 196, 19E (fix public form "Not Found" noise & filter expired token errors) 

### DIFF
--- a/frontend/.storybook/initData.ts
+++ b/frontend/.storybook/initData.ts
@@ -30,6 +30,7 @@ window['__pneumaticConfig'] = {
         getUsers: '/accounts/users',
         createUser: '/accounts/users',
         getUsersPublic: '/accounts/public/users',
+        getPublicAccount: '/accounts/public/account',
         getActiveUsersCount: '/accounts/users/active-count',
         getWorkflowsDuration: '/workflows/duration',
         getWorkflowsSuccessRate: '/workflows/success-rate',

--- a/frontend/config/common.json
+++ b/frontend/config/common.json
@@ -26,6 +26,7 @@
       "getUsers": "/accounts/users",
       "createUser": "/accounts/users",
       "getUsersPublic": "/accounts/public/users",
+      "getPublicAccount": "/accounts/public/account",
       "getActiveUsersCount": "/accounts/users/active-count",
       "getWorkflowsDuration": "/workflows/duration",
       "getWorkflowsSuccessRate": "/workflows/success-rate",

--- a/frontend/src/server/handlers/__tests__/oauthHandler.test.ts
+++ b/frontend/src/server/handlers/__tests__/oauthHandler.test.ts
@@ -1,0 +1,117 @@
+import { Request, Response } from 'express';
+
+import { oAuthHandler } from '../oauthHandler';
+import { logServerError } from '../../utils/expectedErrors';
+import { serverApi } from '../../utils';
+import { setAuthCookie } from '../../utils/cookie';
+
+jest.mock('../../utils/expectedErrors', () => ({
+  logServerError: jest.fn(),
+}));
+jest.mock('../../utils', () => ({ serverApi: { get: jest.fn() } }));
+jest.mock('../../utils/cookie', () => ({ setAuthCookie: jest.fn() }));
+jest.mock('../../../public/constants/routes', () => ({
+  ERoutes: {
+    Main: '/',
+    Register: '/auth/signup/',
+  },
+}));
+
+type MockRequest = Partial<Request> & {
+  query: Record<string, string>;
+};
+
+type MockResponse = Partial<Response> & {
+  redirect: jest.Mock;
+  send: jest.Mock;
+};
+
+const createRes = (): MockResponse => ({
+  redirect: jest.fn(),
+  send: jest.fn(),
+});
+
+describe('oAuthHandler', () => {
+  const handler = oAuthHandler('/auth/uri', '/auth/token');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when code is present (token exchange)', () => {
+    const req: MockRequest = {
+      query: { code: 'test-code', client_info: 'info', state: 'state', session_state: 'session' },
+    };
+
+    it('exchanges code for token and redirects to main', async () => {
+      const tokenResponse = JSON.stringify({ token: 'jwt-token' });
+      (serverApi.get as jest.Mock).mockResolvedValue(tokenResponse);
+      const res = createRes();
+
+      await handler(req as Request, res as Response);
+
+      expect(serverApi.get).toHaveBeenCalledTimes(1);
+      expect(setAuthCookie).toHaveBeenCalledTimes(1);
+      expect(res.redirect).toHaveBeenCalledTimes(1);
+      expect(res.redirect).toHaveBeenCalledWith('/');
+    });
+
+    it('uses logServerError when token exchange fails', async () => {
+      const apiError = new Error('Token is expired');
+      (serverApi.get as jest.Mock).mockRejectedValue(apiError);
+      const res = createRes();
+
+      await handler(req as Request, res as Response);
+
+      expect(logServerError).toHaveBeenCalledTimes(1);
+      expect(logServerError).toHaveBeenCalledWith(apiError);
+    });
+
+    it('redirects to register when token exchange fails', async () => {
+      (serverApi.get as jest.Mock).mockRejectedValue(new Error('Token is expired'));
+      const res = createRes();
+
+      await handler(req as Request, res as Response);
+
+      expect(res.redirect).toHaveBeenCalledTimes(1);
+      expect(res.redirect).toHaveBeenCalledWith('/auth/signup/');
+    });
+  });
+
+  describe('when no code (auth URI request)', () => {
+    const req: MockRequest = { query: {} };
+
+    it('fetches auth URI and sends redirect URI', async () => {
+      const authResponse = JSON.stringify({ auth_uri: 'https://login.microsoft.com/...' });
+      (serverApi.get as jest.Mock).mockResolvedValue(authResponse);
+      const res = createRes();
+
+      await handler(req as Request, res as Response);
+
+      expect(serverApi.get).toHaveBeenCalledTimes(1);
+      expect(serverApi.get).toHaveBeenCalledWith('/auth/uri');
+      expect(res.send).toHaveBeenCalledTimes(1);
+    });
+
+    it('uses logServerError when auth URI fetch fails', async () => {
+      const apiError = new Error('Request was throttled');
+      (serverApi.get as jest.Mock).mockRejectedValue(apiError);
+      const res = createRes();
+
+      await handler(req as Request, res as Response);
+
+      expect(logServerError).toHaveBeenCalledTimes(1);
+      expect(logServerError).toHaveBeenCalledWith(apiError);
+    });
+
+    it('redirects to register when auth URI fetch fails', async () => {
+      (serverApi.get as jest.Mock).mockRejectedValue(new Error('Server Error'));
+      const res = createRes();
+
+      await handler(req as Request, res as Response);
+
+      expect(res.redirect).toHaveBeenCalledTimes(1);
+      expect(res.redirect).toHaveBeenCalledWith('/auth/signup/');
+    });
+  });
+});

--- a/frontend/src/server/handlers/oauthHandler.ts
+++ b/frontend/src/server/handlers/oauthHandler.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express';
 import { serverApi } from '../utils';
-import { logger } from '../../public/utils/logger';
+import { logServerError } from '../utils/expectedErrors';
 import { ERoutes } from '../../public/constants/routes';
 import { setAuthCookie } from '../utils/cookie';
 
@@ -35,8 +35,8 @@ export function oAuthHandler(getAuthUri: string, getAuthTokenUri: string) {
         setAuthCookie(req, res, tokenResponse);
   
         return res.redirect(ERoutes.Main);
-      } catch (err) {
-        logger.error(err);
+      } catch (error) {
+        logServerError(error);
       }
   
       return res.redirect(ERoutes.Register);
@@ -47,8 +47,8 @@ export function oAuthHandler(getAuthUri: string, getAuthTokenUri: string) {
 
       const { auth_uri: redirectUri }: IAuthURIResponse = JSON.parse(responseData);
       return res.send(JSON.stringify({ redirectUri }));
-    } catch(err) {
-      logger.error(err);
+    } catch(error) {
+      logServerError(error);
     }
   
     return res.redirect(ERoutes.Register);

--- a/frontend/src/server/middleware/__tests__/getPages.test.ts
+++ b/frontend/src/server/middleware/__tests__/getPages.test.ts
@@ -1,9 +1,9 @@
 import { getPages } from '../utils/getPages';
-import { logger } from '../../../public/utils/logger';
+import { logServerError } from '../../utils/expectedErrors';
 import { serverApi } from '../../utils';
 
-jest.mock('../../../public/utils/logger', () => ({
-  logger: { error: jest.fn(), info: jest.fn() },
+jest.mock('../../utils/expectedErrors', () => ({
+  logServerError: jest.fn(),
 }));
 jest.mock('../../utils', () => ({ serverApi: { get: jest.fn() } }));
 jest.mock('../../../public/utils/getConfig', () => ({
@@ -26,15 +26,14 @@ describe('getPages', () => {
     expect(serverApi.get).toHaveBeenCalledWith('/pages');
   });
 
-  it('logs with info level (not error) when API call fails', async () => {
+  it('uses logServerError (not logger.error) when API call fails', async () => {
     const apiError = new Error('Not Found');
     (serverApi.get as jest.Mock).mockRejectedValue(apiError);
 
     await getPages();
 
-    expect(logger.info).toHaveBeenCalledTimes(1);
-    expect(logger.info).toHaveBeenCalledWith('failed to get pages: ', apiError);
-    expect(logger.error).not.toHaveBeenCalled();
+    expect(logServerError).toHaveBeenCalledTimes(1);
+    expect(logServerError).toHaveBeenCalledWith('failed to get pages: ', apiError);
   });
 
   it('returns null when API call fails', async () => {

--- a/frontend/src/server/middleware/__tests__/getPages.test.ts
+++ b/frontend/src/server/middleware/__tests__/getPages.test.ts
@@ -1,0 +1,47 @@
+import { getPages } from '../utils/getPages';
+import { logger } from '../../../public/utils/logger';
+import { serverApi } from '../../utils';
+
+jest.mock('../../../public/utils/logger', () => ({
+  logger: { error: jest.fn(), info: jest.fn() },
+}));
+jest.mock('../../utils', () => ({ serverApi: { get: jest.fn() } }));
+jest.mock('../../../public/utils/getConfig', () => ({
+  getConfig: () => ({ api: { urls: { getPages: '/pages' } } }),
+}));
+
+describe('getPages', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns pages data on successful API call', async () => {
+    const mockPages = { logo: 'logo.png', title: 'My App' };
+    (serverApi.get as jest.Mock).mockResolvedValue(mockPages);
+
+    const result = await getPages();
+
+    expect(result).toBe(mockPages);
+    expect(serverApi.get).toHaveBeenCalledTimes(1);
+    expect(serverApi.get).toHaveBeenCalledWith('/pages');
+  });
+
+  it('logs with info level (not error) when API call fails', async () => {
+    const apiError = new Error('Not Found');
+    (serverApi.get as jest.Mock).mockRejectedValue(apiError);
+
+    await getPages();
+
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith('failed to get pages: ', apiError);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('returns null when API call fails', async () => {
+    (serverApi.get as jest.Mock).mockRejectedValue(new Error('Not Found'));
+
+    const result = await getPages();
+
+    expect(result).toBeNull();
+  });
+});

--- a/frontend/src/server/middleware/__tests__/getUser.test.ts
+++ b/frontend/src/server/middleware/__tests__/getUser.test.ts
@@ -1,11 +1,9 @@
-
-
 import { getUser } from '../utils/getUser';
-import { logger } from '../../../public/utils/logger';
+import { logServerError } from '../../utils/expectedErrors';
 import { serverApi } from '../../utils';
 
-jest.mock('../../../public/utils/logger', () => ({
-  logger: { error: jest.fn(), info: jest.fn() },
+jest.mock('../../utils/expectedErrors', () => ({
+  logServerError: jest.fn(),
 }));
 jest.mock('../../utils', () => ({ serverApi: { get: jest.fn() } }));
 jest.mock('../../utils/getAuthHeader', () => ({
@@ -45,15 +43,14 @@ describe('getUser', () => {
     );
   });
 
-  it('logs with info level (not error) when API call fails', async () => {
+  it('uses logServerError (not logger.error) when API call fails', async () => {
     const apiError = new Error('token_not_valid');
     (serverApi.get as jest.Mock).mockRejectedValue(apiError);
 
     await expect(getUser(req as GetUserRequest, 'invalid-token')).rejects.toThrow('token_not_valid');
 
-    expect(logger.info).toHaveBeenCalledTimes(1);
-    expect(logger.info).toHaveBeenCalledWith('failed to get user context: ', apiError);
-    expect(logger.error).not.toHaveBeenCalled();
+    expect(logServerError).toHaveBeenCalledTimes(1);
+    expect(logServerError).toHaveBeenCalledWith('failed to get user context: ', apiError);
   });
 
   it('re-throws the original error after logging', async () => {

--- a/frontend/src/server/middleware/__tests__/getUser.test.ts
+++ b/frontend/src/server/middleware/__tests__/getUser.test.ts
@@ -1,0 +1,65 @@
+
+
+import { getUser } from '../utils/getUser';
+import { logger } from '../../../public/utils/logger';
+import { serverApi } from '../../utils';
+
+jest.mock('../../../public/utils/logger', () => ({
+  logger: { error: jest.fn(), info: jest.fn() },
+}));
+jest.mock('../../utils', () => ({ serverApi: { get: jest.fn() } }));
+jest.mock('../../utils/getAuthHeader', () => ({
+  getAuthHeader: jest.fn(() => ({ Authorization: 'Bearer test-token' })),
+}));
+jest.mock('../../../public/utils/identifyAppPart/identifyAppPartOnServer', () => ({
+  identifyAppPartOnServer: jest.fn(() => 'main'),
+}));
+
+type MockRequest = {
+  headers: { 'user-agent': string };
+};
+
+type GetUserRequest = Parameters<typeof getUser>[0];
+
+const req: MockRequest = {
+  headers: { 'user-agent': 'test-agent' },
+};
+
+describe('getUser', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns user data on successful API call', async () => {
+    const mockUser = { id: 1, email: 'test@test.com', account: {} };
+    (serverApi.get as jest.Mock).mockResolvedValue(mockUser);
+
+    const result = await getUser(req as GetUserRequest, 'valid-token', 'test-agent');
+
+    expect(result).toBe(mockUser);
+    expect(serverApi.get).toHaveBeenCalledTimes(1);
+    expect(serverApi.get).toHaveBeenCalledWith(
+      'getUser',
+      { headers: { Authorization: 'Bearer test-token' }, json: true },
+      true,
+    );
+  });
+
+  it('logs with info level (not error) when API call fails', async () => {
+    const apiError = new Error('token_not_valid');
+    (serverApi.get as jest.Mock).mockRejectedValue(apiError);
+
+    await expect(getUser(req as GetUserRequest, 'invalid-token')).rejects.toThrow('token_not_valid');
+
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith('failed to get user context: ', apiError);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('re-throws the original error after logging', async () => {
+    const apiError = new Error('Unauthorized');
+    (serverApi.get as jest.Mock).mockRejectedValue(apiError);
+
+    await expect(getUser(req as GetUserRequest, 'bad-token')).rejects.toBe(apiError);
+  });
+});

--- a/frontend/src/server/middleware/__tests__/getUserPublic.test.ts
+++ b/frontend/src/server/middleware/__tests__/getUserPublic.test.ts
@@ -1,20 +1,24 @@
-import { Request } from 'express';
-
 import { getUserPublic } from '../utils/getUserPublic';
-import { logger } from '../../../public/utils/logger';
+import { logServerError } from '../../utils/expectedErrors';
 import { serverApi } from '../../utils';
 
-jest.mock('../../../public/utils/logger', () => ({
-  logger: { error: jest.fn(), info: jest.fn() },
+type GetUserPublicRequest = Parameters<typeof getUserPublic>[0];
+
+jest.mock('../../utils/expectedErrors', () => ({
+  logServerError: jest.fn(),
 }));
 jest.mock('../../utils', () => ({ serverApi: { get: jest.fn() } }));
 jest.mock('../../utils/getAuthHeader', () => ({
   getAuthHeader: jest.fn(() => ({ Authorization: 'Bearer test-token' })),
 }));
 
-const req = {
+type MockRequest = {
+  headers: { 'user-agent': string };
+};
+
+const req: MockRequest = {
   headers: { 'user-agent': 'test-agent' },
-} as Request;
+};
 
 describe('getUserPublic', () => {
   beforeEach(() => {
@@ -25,7 +29,7 @@ describe('getUserPublic', () => {
     const mockUser = { id: 1, email: 'test@test.com' };
     (serverApi.get as jest.Mock).mockResolvedValue(mockUser);
 
-    const result = await getUserPublic(req, 'valid-token', 'test-agent');
+    const result = await getUserPublic(req as GetUserPublicRequest, 'valid-token', 'test-agent');
 
     expect(result).toBe(mockUser);
     expect(serverApi.get).toHaveBeenCalledTimes(1);
@@ -36,21 +40,20 @@ describe('getUserPublic', () => {
     );
   });
 
-  it('logs with info level (not error) when API call fails', async () => {
+  it('uses logServerError (not logger.error) when API call fails', async () => {
     const apiError = new Error('Not Found');
     (serverApi.get as jest.Mock).mockRejectedValue(apiError);
 
-    await expect(getUserPublic(req, 'invalid-token')).rejects.toThrow('Not Found');
+    await expect(getUserPublic(req as GetUserPublicRequest, 'invalid-token')).rejects.toThrow('Not Found');
 
-    expect(logger.info).toHaveBeenCalledTimes(1);
-    expect(logger.info).toHaveBeenCalledWith('failed to get account context: ', apiError);
-    expect(logger.error).not.toHaveBeenCalled();
+    expect(logServerError).toHaveBeenCalledTimes(1);
+    expect(logServerError).toHaveBeenCalledWith('failed to get account context: ', apiError);
   });
 
   it('re-throws the original error after logging', async () => {
     const apiError = new Error('Server Error');
     (serverApi.get as jest.Mock).mockRejectedValue(apiError);
 
-    await expect(getUserPublic(req, 'bad-token')).rejects.toBe(apiError);
+    await expect(getUserPublic(req as GetUserPublicRequest, 'bad-token')).rejects.toBe(apiError);
   });
 });

--- a/frontend/src/server/middleware/__tests__/getUserPublic.test.ts
+++ b/frontend/src/server/middleware/__tests__/getUserPublic.test.ts
@@ -1,0 +1,56 @@
+import { Request } from 'express';
+
+import { getUserPublic } from '../utils/getUserPublic';
+import { logger } from '../../../public/utils/logger';
+import { serverApi } from '../../utils';
+
+jest.mock('../../../public/utils/logger', () => ({
+  logger: { error: jest.fn(), info: jest.fn() },
+}));
+jest.mock('../../utils', () => ({ serverApi: { get: jest.fn() } }));
+jest.mock('../../utils/getAuthHeader', () => ({
+  getAuthHeader: jest.fn(() => ({ Authorization: 'Bearer test-token' })),
+}));
+
+const req = {
+  headers: { 'user-agent': 'test-agent' },
+} as Request;
+
+describe('getUserPublic', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns user data on successful API call', async () => {
+    const mockUser = { id: 1, email: 'test@test.com' };
+    (serverApi.get as jest.Mock).mockResolvedValue(mockUser);
+
+    const result = await getUserPublic(req, 'valid-token', 'test-agent');
+
+    expect(result).toBe(mockUser);
+    expect(serverApi.get).toHaveBeenCalledTimes(1);
+    expect(serverApi.get).toHaveBeenCalledWith(
+      'getPublicAccount',
+      { headers: { Authorization: 'Bearer test-token' }, json: true },
+      true,
+    );
+  });
+
+  it('logs with info level (not error) when API call fails', async () => {
+    const apiError = new Error('Not Found');
+    (serverApi.get as jest.Mock).mockRejectedValue(apiError);
+
+    await expect(getUserPublic(req, 'invalid-token')).rejects.toThrow('Not Found');
+
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith('failed to get account context: ', apiError);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('re-throws the original error after logging', async () => {
+    const apiError = new Error('Server Error');
+    (serverApi.get as jest.Mock).mockRejectedValue(apiError);
+
+    await expect(getUserPublic(req, 'bad-token')).rejects.toBe(apiError);
+  });
+});

--- a/frontend/src/server/middleware/__tests__/verificateAccountMiddleware.test.ts
+++ b/frontend/src/server/middleware/__tests__/verificateAccountMiddleware.test.ts
@@ -1,11 +1,11 @@
 import { Request, Response } from 'express';
 
 import { verificateAccountMiddleware } from '../verificateAccountMiddleware';
-import { logger } from '../../../public/utils/logger';
+import { logServerError } from '../../utils/expectedErrors';
 import { serverApi } from '../../utils';
 
-jest.mock('../../../public/utils/logger', () => ({
-  logger: { error: jest.fn(), info: jest.fn() },
+jest.mock('../../utils/expectedErrors', () => ({
+  logServerError: jest.fn(),
 }));
 jest.mock('../../utils', () => ({ serverApi: { get: jest.fn() } }));
 jest.mock('../../../public/constants/routes', () => ({
@@ -41,7 +41,7 @@ describe('verificateAccountMiddleware', () => {
     expect(res.redirect).toHaveBeenCalledWith('/auth/signin/');
   });
 
-  it('logs with info level (not error) when API call fails', async () => {
+  it('uses logServerError (not logger.error) when API call fails', async () => {
     const apiError = new Error('Token is invalid');
     (serverApi.get as jest.Mock).mockRejectedValue(apiError);
     const req: MockRequest = { query: { token: 'invalid-token' } };
@@ -49,9 +49,8 @@ describe('verificateAccountMiddleware', () => {
 
     await verificateAccountMiddleware(req as Request, res as Response);
 
-    expect(logger.info).toHaveBeenCalledTimes(1);
-    expect(logger.info).toHaveBeenCalledWith(apiError);
-    expect(logger.error).not.toHaveBeenCalled();
+    expect(logServerError).toHaveBeenCalledTimes(1);
+    expect(logServerError).toHaveBeenCalledWith(apiError);
   });
 
   it('redirects to login even when API call fails', async () => {

--- a/frontend/src/server/middleware/__tests__/verificateAccountMiddleware.test.ts
+++ b/frontend/src/server/middleware/__tests__/verificateAccountMiddleware.test.ts
@@ -1,0 +1,67 @@
+import { Request, Response } from 'express';
+
+import { verificateAccountMiddleware } from '../verificateAccountMiddleware';
+import { logger } from '../../../public/utils/logger';
+import { serverApi } from '../../utils';
+
+jest.mock('../../../public/utils/logger', () => ({
+  logger: { error: jest.fn(), info: jest.fn() },
+}));
+jest.mock('../../utils', () => ({ serverApi: { get: jest.fn() } }));
+jest.mock('../../../public/constants/routes', () => ({
+  ERoutes: {
+    AccountVerification: '/auth/verification/:token',
+    Login: '/auth/signin/',
+  },
+}));
+
+type MockRequest = Partial<Request> & {
+  query: { token: string };
+};
+
+type MockResponse = Partial<Response> & {
+  redirect: jest.Mock;
+};
+
+describe('verificateAccountMiddleware', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls API with token from query and redirects to login on success', async () => {
+    (serverApi.get as jest.Mock).mockResolvedValue({});
+    const req: MockRequest = { query: { token: 'valid-token' } };
+    const res: MockResponse = { redirect: jest.fn() };
+
+    await verificateAccountMiddleware(req as Request, res as Response);
+
+    expect(serverApi.get).toHaveBeenCalledTimes(1);
+    expect(serverApi.get).toHaveBeenCalledWith('/auth/verification/valid-token', {}, true);
+    expect(res.redirect).toHaveBeenCalledTimes(1);
+    expect(res.redirect).toHaveBeenCalledWith('/auth/signin/');
+  });
+
+  it('logs with info level (not error) when API call fails', async () => {
+    const apiError = new Error('Token is invalid');
+    (serverApi.get as jest.Mock).mockRejectedValue(apiError);
+    const req: MockRequest = { query: { token: 'invalid-token' } };
+    const res: MockResponse = { redirect: jest.fn() };
+
+    await verificateAccountMiddleware(req as Request, res as Response);
+
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith(apiError);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('redirects to login even when API call fails', async () => {
+    (serverApi.get as jest.Mock).mockRejectedValue(new Error('Token is invalid'));
+    const req: MockRequest = { query: { token: 'bad-token' } };
+    const res: MockResponse = { redirect: jest.fn() };
+
+    await verificateAccountMiddleware(req as Request, res as Response);
+
+    expect(res.redirect).toHaveBeenCalledTimes(1);
+    expect(res.redirect).toHaveBeenCalledWith('/auth/signin/');
+  });
+});

--- a/frontend/src/server/middleware/utils/getPages.ts
+++ b/frontend/src/server/middleware/utils/getPages.ts
@@ -11,7 +11,7 @@ export async function getPages() {
   try {
     return await serverApi.get<IPages>(urls.getPages);
   } catch (error) {
-    logger.error('failed to get pages: ', error);
+    logger.info('failed to get pages: ', error);
   }
 
   return null;

--- a/frontend/src/server/middleware/utils/getPages.ts
+++ b/frontend/src/server/middleware/utils/getPages.ts
@@ -1,4 +1,4 @@
-import { logger } from '../../../public/utils/logger';
+import { logServerError } from '../../utils/expectedErrors';
 import { serverApi } from '../../utils';
 import { getConfig } from '../../../public/utils/getConfig';
 import { IPages } from '../../../public/redux/pages/types';
@@ -11,7 +11,7 @@ export async function getPages() {
   try {
     return await serverApi.get<IPages>(urls.getPages);
   } catch (error) {
-    logger.info('failed to get pages: ', error);
+    logServerError('failed to get pages: ', error);
   }
 
   return null;

--- a/frontend/src/server/middleware/utils/getUser.ts
+++ b/frontend/src/server/middleware/utils/getUser.ts
@@ -21,7 +21,7 @@ export async function getUser(req: Request, token: string, userAgent?: string) {
 
     return user;
   } catch (error) {
-    logger.error('failed to get user context: ', error);
+    logger.info('failed to get user context: ', error);
 
     throw error;
   }

--- a/frontend/src/server/middleware/utils/getUser.ts
+++ b/frontend/src/server/middleware/utils/getUser.ts
@@ -1,7 +1,7 @@
 import { Request } from 'express';
 
 import { identifyAppPartOnServer } from '../../../public/utils/identifyAppPart/identifyAppPartOnServer';
-import { logger } from '../../../public/utils/logger';
+import { logServerError } from '../../utils/expectedErrors';
 import { serverApi } from '../../utils';
 import { getAuthHeader } from '../../utils/getAuthHeader';
 import { IAuthenticatedUser } from '../../utils/types';
@@ -21,7 +21,7 @@ export async function getUser(req: Request, token: string, userAgent?: string) {
 
     return user;
   } catch (error) {
-    logger.info('failed to get user context: ', error);
+    logServerError('failed to get user context: ', error);
 
     throw error;
   }

--- a/frontend/src/server/middleware/utils/getUserPublic.ts
+++ b/frontend/src/server/middleware/utils/getUserPublic.ts
@@ -20,7 +20,7 @@ export async function getUserPublic(req: Request, token: string, userAgent?: str
 
     return user;
   } catch (error) {
-    logger.error('failed to get account context: ', error);
+    logger.info('failed to get account context: ', error);
 
     throw error;
   }

--- a/frontend/src/server/middleware/utils/getUserPublic.ts
+++ b/frontend/src/server/middleware/utils/getUserPublic.ts
@@ -1,6 +1,6 @@
 import { Request } from 'express';
 
-import { logger } from '../../../public/utils/logger';
+import { logServerError } from '../../utils/expectedErrors';
 import { serverApi } from '../../utils';
 import { getAuthHeader } from '../../utils/getAuthHeader';
 import { IAuthenticatedUser } from '../../utils/types';
@@ -20,7 +20,7 @@ export async function getUserPublic(req: Request, token: string, userAgent?: str
 
     return user;
   } catch (error) {
-    logger.info('failed to get account context: ', error);
+    logServerError('failed to get account context: ', error);
 
     throw error;
   }

--- a/frontend/src/server/middleware/verificateAccountMiddleware.ts
+++ b/frontend/src/server/middleware/verificateAccountMiddleware.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from 'express';
 
 import { ERoutes } from '../../public/constants/routes';
-import { logger } from '../../public/utils/logger';
+import { logServerError } from '../utils/expectedErrors';
 import { serverApi } from '../utils';
 
 export async function verificateAccountMiddleware(req: Request, res: Response) {
@@ -9,8 +9,8 @@ export async function verificateAccountMiddleware(req: Request, res: Response) {
     const { token } = req.query;
     const url = ERoutes.AccountVerification.replace(':token', token as string);
     await serverApi.get(url, {}, true);
-  } catch (e) {
-    logger.info(e);
+  } catch (error) {
+    logServerError(error);
   }
 
   return res.redirect(ERoutes.Login);

--- a/frontend/src/server/middleware/verificateAccountMiddleware.ts
+++ b/frontend/src/server/middleware/verificateAccountMiddleware.ts
@@ -10,7 +10,7 @@ export async function verificateAccountMiddleware(req: Request, res: Response) {
     const url = ERoutes.AccountVerification.replace(':token', token as string);
     await serverApi.get(url, {}, true);
   } catch (e) {
-    logger.error(e);
+    logger.info(e);
   }
 
   return res.redirect(ERoutes.Login);

--- a/frontend/src/server/utils/__tests__/expectedErrors.test.ts
+++ b/frontend/src/server/utils/__tests__/expectedErrors.test.ts
@@ -25,11 +25,27 @@ describe('isExpectedError', () => {
     expect(isExpectedError(errorMessage)).toBe(false);
   });
 
-  it('handles non-string error values', () => {
+  it('returns false for non-string primitives', () => {
     expect(isExpectedError(null)).toBe(false);
     expect(isExpectedError(undefined)).toBe(false);
     expect(isExpectedError(42)).toBe(false);
+  });
+
+  it('matches pattern in Error.message', () => {
     expect(isExpectedError(new Error('token_not_valid'))).toBe(true);
+  });
+
+  it('matches expected patterns in plain objects (json: true body)', () => {
+    expect(isExpectedError({ code: 'token_not_valid', detail: 'Given token not valid' })).toBe(true);
+    expect(isExpectedError({ message: 'Token is invalid.' })).toBe(true);
+    expect(isExpectedError({ message: 'Token is expired.' })).toBe(true);
+    expect(isExpectedError({ detail: 'Request was throttled. Expected available in 5 seconds.' })).toBe(true);
+  });
+
+  it('returns false for plain objects without expected patterns', () => {
+    expect(isExpectedError({ detail: 'Not found.' })).toBe(false);
+    expect(isExpectedError({ error: 'Server Error' })).toBe(false);
+    expect(isExpectedError({})).toBe(false);
   });
 });
 
@@ -62,6 +78,16 @@ describe('logServerError', () => {
     logServerError('prefix: ', '{"message":"Token is expired."}');
 
     expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('uses logger.info when error is a plain object with expected pattern (json: true)', () => {
+    const error = { code: 'token_not_valid', detail: 'Given token not valid' };
+
+    logServerError('failed to get user context: ', error);
+
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith('failed to get user context: ', error);
     expect(logger.error).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/server/utils/__tests__/expectedErrors.test.ts
+++ b/frontend/src/server/utils/__tests__/expectedErrors.test.ts
@@ -1,0 +1,74 @@
+import { isExpectedError, logServerError } from '../expectedErrors';
+import { logger } from '../../../public/utils/logger';
+
+jest.mock('../../../public/utils/logger', () => ({
+  logger: { error: jest.fn(), info: jest.fn() },
+}));
+
+describe('isExpectedError', () => {
+  it.each([
+    ['token_not_valid', '{"code":"token_not_valid","detail":"Given token not valid"}'],
+    ['Token is invalid', '{"code":"validation_error","message":"Token is invalid."}'],
+    ['Token is expired', '{"code":"validation_error","message":"Token is expired."}'],
+    ['Request was throttled', '{"detail":"Request was throttled. Expected available in 5 seconds."}'],
+  ])('returns true for known pattern "%s"', (_name, errorMessage) => {
+    expect(isExpectedError(errorMessage)).toBe(true);
+  });
+
+  it.each([
+    ['Server Error (500)', '<h1>Server Error (500)</h1>'],
+    ['502 Bad Gateway', '<html><head><title>502 Bad Gateway</title></head></html>'],
+    ['Not Found', '<h1>Not Found</h1>'],
+    ['undefined', 'undefined'],
+    ['random error', 'Something completely unexpected happened'],
+  ])('returns false for unknown pattern "%s"', (_name, errorMessage) => {
+    expect(isExpectedError(errorMessage)).toBe(false);
+  });
+
+  it('handles non-string error values', () => {
+    expect(isExpectedError(null)).toBe(false);
+    expect(isExpectedError(undefined)).toBe(false);
+    expect(isExpectedError(42)).toBe(false);
+    expect(isExpectedError(new Error('token_not_valid'))).toBe(true);
+  });
+});
+
+describe('logServerError', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uses logger.info for expected errors', () => {
+    const error = '{"code":"token_not_valid"}';
+
+    logServerError('context: ', error);
+
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith('context: ', error);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('uses logger.error for unexpected errors', () => {
+    const error = '<h1>Server Error (500)</h1>';
+
+    logServerError('context: ', error);
+
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledWith('context: ', error);
+    expect(logger.info).not.toHaveBeenCalled();
+  });
+
+  it('checks the last argument when multiple args are passed', () => {
+    logServerError('prefix: ', '{"message":"Token is expired."}');
+
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('checks the single argument when only one arg is passed', () => {
+    logServerError('{"message":"Token is invalid."}');
+
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/server/utils/expectedErrors.ts
+++ b/frontend/src/server/utils/expectedErrors.ts
@@ -1,0 +1,31 @@
+import { logger } from '../../public/utils/logger';
+import { TLoggerArgs } from './types';
+
+/**
+ * Known non-critical error patterns from backend API responses.
+ * Errors matching these patterns are logged at info level (not sent to Sentry).
+ * All other errors remain at error level to preserve visibility.
+ */
+const EXPECTED_ERROR_PATTERNS = [
+  'token_not_valid',
+  'Token is invalid',
+  'Token is expired',
+  'Request was throttled',
+];
+
+const EXPECTED_ERROR_REGEX = new RegExp(EXPECTED_ERROR_PATTERNS.join('|'));
+
+export function isExpectedError(error: TLoggerArgs[number]): boolean {
+  return EXPECTED_ERROR_REGEX.test(String(error));
+}
+
+/**
+ * Logs expected errors at info level (no Sentry event) and unexpected errors at error level.
+ */
+export function logServerError(...args: TLoggerArgs) {
+  if (args.some(isExpectedError)) {
+    logger.info(...args);
+  } else {
+    logger.error(...args);
+  }
+}

--- a/frontend/src/server/utils/expectedErrors.ts
+++ b/frontend/src/server/utils/expectedErrors.ts
@@ -16,7 +16,17 @@ const EXPECTED_ERROR_PATTERNS = [
 const EXPECTED_ERROR_REGEX = new RegExp(EXPECTED_ERROR_PATTERNS.join('|'));
 
 export function isExpectedError(error: TLoggerArgs[number]): boolean {
-  return EXPECTED_ERROR_REGEX.test(String(error));
+  let errorString: string;
+
+  if (error instanceof Error) {
+    errorString = error.message;
+  } else if (typeof error === 'object' && error !== null) {
+    errorString = JSON.stringify(error);
+  } else {
+    errorString = String(error);
+  }
+
+  return EXPECTED_ERROR_REGEX.test(errorString);
 }
 
 /**

--- a/frontend/src/server/utils/types.ts
+++ b/frontend/src/server/utils/types.ts
@@ -1,3 +1,5 @@
+import { logger } from '../../public/utils/logger';
+
 export interface IAuthenticatedUser {
   id: string;
   email: string;
@@ -24,3 +26,5 @@ export interface IAuthenticatedAccount {
   owner_email: string;
   billing_plan: string | null;
 }
+
+export type TLoggerArgs = Parameters<typeof logger.error>;


### PR DESCRIPTION
## 1. Release notes

**a)** Expected API errors (expired/invalid token, throttling) in server middleware are now logged at `info` level and no longer appear in Sentry.

**b)** Fixed a configuration bug: the `getPublicAccount` mapping was missing → every public form visit generated a junk Sentry event (~18 000 over 3 months).

---

## 2. Problem

### a) Expected errors polluting Sentry (~85 events)

Server middleware (`getUser`, `getPages`, `verificateAccountMiddleware`, `oauthHandler`) called `logger.error()` on API failures. Every request with an expired/invalid token or throttling generated an error-level Sentry event, even though these errors are routine and require no action.

**Sentry issues:**
- [#196](https://pneumatic.sentry.io/issues/PNEUMATIC-FRONTEND-PROD-196) — getUser, `token_not_valid` (5 events)
- [#19E](https://pneumatic.sentry.io/issues/PNEUMATIC-FRONTEND-PROD-19E) — verificateAccountMiddleware, `Token is invalid` (1 event)
- [#18T](https://pneumatic.sentry.io/issues/PNEUMATIC-FRONTEND-PROD-18T) — oauthHandler, `Token is expired` (40 events)
- [#18V](https://pneumatic.sentry.io/issues/PNEUMATIC-FRONTEND-PROD-18V) — getPages, HTML 404 during backend restarts (39 events)

### b) Configuration bug polluting Sentry (~18 169 events)

The `getPublicAccount` key was missing from `config/common.json`. `serverApi` used the string `'getPublicAccount'` as a literal URL path → request went to `BACKEND_URL/getPublicAccount` (non-existent route) → nginx returned HTML 404 → `logger.error` → Sentry.

The backend endpoint `/accounts/public/account` actually exists and works — the frontend simply didn't know the correct path.

**Impact:**
- **18 169 junk events** over 3 months (every public form visit = error)

**Sentry issue:**
- [#18Q](https://pneumatic.sentry.io/issues/PNEUMATIC-FRONTEND-PROD-18Q) — getUserPublic (18 169 events)

---

## 3. Context

- SSR layer (Express middleware and handlers)
- Logging via `logger` from `public/utils/logger.ts`, which sends `error`-level events to Sentry
- Branch is based on `master`

---

## 4. Solution

### a) Expected errors — allowlist + logServerError

Created `logServerError()` utility in `server/utils/expectedErrors.ts`:
- Checks arguments against a list of expected patterns (`token_not_valid`, `Token is invalid`, `Token is expired`, `Request was throttled`)
- Expected errors → `logger.info()` (not sent to Sentry)
- All others → `logger.error()` (remain visible in Sentry)

All 5 SSR middleware and handlers switched from `logger.error()` to `logServerError()`.

### b) Configuration bug — added mapping

Added `getPublicAccount: "/accounts/public/account"` to `config/common.json` and `.storybook/initData.ts`. Now `getUserPublic` calls the correct endpoint, the request succeeds, and 404 errors no longer occur.

**Local verification:**
- Before fix: Django → `The current path, getPublicAccount, didn't match any of these`
- After fix: `getUserPublic OK: {id: 1, name: 'Company name', logo_lg: null, ...}`

---

## 5. Implementation details

### a) `expectedErrors.ts` utility

**Before:** no mechanism existed to distinguish expected vs unexpected errors at the SSR level. All errors went through `logger.error()` → Sentry.

**After:**
- `isExpectedError(error)` — checks a single argument against patterns. Handles three input types:
  - `Error` — uses `.message`
  - Object (non-null) — serializes via `JSON.stringify()` (important for `json: true` requests where error is a plain object)
  - Primitive — converts to string via `String()`
- `logServerError(...args)` — checks all arguments via `args.some(isExpectedError)` and routes to `logger.info` or `logger.error`
- Type `TLoggerArgs = Parameters<typeof logger.error>` — ensures signature compatible with `logger.error()`

**Changes in middleware and handlers:**

| Module | Before | After |
|--------|--------|-------|
| `getUserPublic.ts` | `logger.error(...)` | `logServerError('failed to get account context: ', error)` |
| `getUser.ts` | `logger.error(...)` | `logServerError('failed to get user context: ', error)` |
| `getPages.ts` | `logger.error(...)` | `logServerError('failed to get pages: ', error)` |
| `verificateAccountMiddleware.ts` | `logger.error(error)` | `logServerError(error)` |
| `oauthHandler.ts` | `logger.error(error)` (×2 catch blocks) | `logServerError(error)` (×2) |

### b) `getPublicAccount` config

**Before:** `getPublicAccount` mapping was missing from `config/common.json` and `.storybook/initData.ts`. `serverApi.get('getPublicAccount', ...)` sent requests to `BACKEND_URL/getPublicAccount` — a non-existent route.

**After:** added `"getPublicAccount": "/accounts/public/account"`. Request goes to the correct endpoint, account data loads successfully.

---

## 6. Testing

### 6.1 Preconditions

- Dev environment with running frontend and backend
- For (a) scenarios: a user with an expired/invalid token (or simulated via DevTools)
- For (b) scenarios: a public form (via link, without authentication)
- By default tested **only in Desktop Chromium**; Safari, Firefox, Mobile — deferred to QA

### 6.2 Positive scenarios

| Scenario | Description (steps and expected result) | Verified by Developer (desktop) | Verified by Developer (mobile) | Verified by AI Agent (Chromium) |
| :--- | :--- | :--- | :--- | :--- |
| **(a) Normal auth** | Log in with a valid token → Page loads without errors, no error-level middleware entries in server logs | [ ] | N/A | N/A |
| **(a) Expired token** | Wait for token expiry (or replace cookie with invalid one) → App correctly redirects to login. Server logs show `info` level (not `error`) | [ ] | N/A | N/A |
| **(b) Public form** | Open a public form via link → Form loads. Server logs for `getUserPublic` — no errors (request goes to correct endpoint) | [ ] | N/A | N/A |
| **(b) Public form — account data** | Open a public form → In DevTools → Network check request to `/accounts/public/account` → Response `200 OK` with account data | [ ] | N/A | N/A |

### 6.3 Negative scenarios and edge cases

| Scenario | Description (steps and expected result) | Verified by Developer (desktop) | Verified by Developer (mobile) | Verified by AI Agent (Chromium) |
| :--- | :--- | :--- | :--- | :--- |
| **(a) Real server error (500)** | Simulate 500 from backend → Server logs should show `error` level (sent to Sentry) | [ ] | N/A | N/A |
| **(a) Throttling** | Trigger throttling → Response `429` with `"Request was throttled"` → Logged as `info`, not `error` | [ ] | N/A | N/A |
| **(a) Unknown API error** | Return a non-standard error (e.g., HTML "502 Bad Gateway") → Logged as `error` (sent to Sentry) | [ ] | N/A | N/A |
| **(b) Public form with invalid URL** | Open a non-existent public form → Fallback page is displayed, logs show `info` (not `error`) | [ ] | N/A | N/A |

### 6.4 Verification points

- **(a) Server logs**: middleware log level (`info` for expected errors, `error` for unexpected)
- **(a+b) Sentry**: after deploy — monitor: issues 18Q, 18V, 196, 19E, 18T should stop receiving new events
- **(b) Network**: `getUserPublic` request goes to `/accounts/public/account` (not `/getPublicAccount`)
- **UI**: application behavior is unchanged (logging is internal, user sees no difference)

### 6.6 Not tested

- OAuth authentication (Microsoft) — no test environment available
- Locales not tested (changes do not affect UI)
- Not tested under load
- Mobile devices and browsers other than Chromium

---

## 9. Unit tests

### a) expectedErrors (utility)

**`expectedErrors.test.ts`** — 12 tests:
- `isExpectedError`: correctly identifies each of 4 patterns in strings, rejects unknown (500, 502, Not Found, random text), handles primitives (`null`, `undefined`, `42`), recognizes pattern in `Error.message`, recognizes patterns in plain objects (`json: true` body), rejects objects without patterns
- `logServerError`: calls `logger.info` for expected errors, `logger.error` for unexpected, checks multiple arguments, single argument, plain object with pattern

### b) Middleware and handlers (logger.error → logServerError replacement)

- **`getUserPublic.test.ts`** — verifies that `logServerError` is called on API error, not `logger.error`
- **`getUser.test.ts`** — same verification for getUser
- **`getPages.test.ts`** — same verification for getPages
- **`verificateAccountMiddleware.test.ts`** — verification for verificateAccountMiddleware
- **`oauthHandler.test.ts`** — verification for both catch blocks in oauthHandler

---

## 10. Commits

| Hash | Message | Part |
|------|---------|------|
| `d092fa15` | fix(ssr): downgrade getUserPublic error logging to info [Sentry #18Q] | a |
| `555fbfd7` | fix(ssr): downgrade getPages error logging to info [Sentry #18V] | a |
| `2bfdb2b1` | fix(sentry): downgrade logger.error to logger.info in getUser and verificateAccountMiddleware | a |
| `694dd74e` | fix(ssr): replace logger.error with logServerError for expected API errors [Sentry #18Q, #18V, #196, #19E, #18T] | a |
| `106878d9` | fix(config): add missing getPublicAccount URL mapping (Fixes PNEUMATIC-FRONTEND-PROD-18Q) | b |
| `8113c77c` | fix(expectedErrors): handle object errors from json:true responses | a |
