### PR TITLE
47327 frontend [ sentry ] 15K, 15Q, 15M, 19J, 18N (No error message)

### DIFF
--- a/frontend/src/public/api/__tests__/getResponseErrorMessage.test.ts
+++ b/frontend/src/public/api/__tests__/getResponseErrorMessage.test.ts
@@ -1,0 +1,124 @@
+import { AxiosError, AxiosResponse } from 'axios';
+
+jest.mock('../../utils/logger', () => ({ logger: { error: jest.fn() } }));
+jest.mock('../../../server/utils/getAuthHeader', () => ({ getAuthHeader: jest.fn() }));
+jest.mock('../../utils/getConfig', () => ({
+  getBrowserConfigEnv: jest.fn().mockReturnValue({
+    api: { publicUrl: 'http://test', urls: {} },
+  }),
+}));
+jest.mock('../../utils/mappers', () => ({ mapToCamelCase: jest.fn((d: unknown) => d) }));
+jest.mock('../../utils/urls', () => ({ mergePaths: jest.fn((_b: string, u: string) => u) }));
+jest.mock('../../utils/identifyAppPart/identifyAppPartOnClient', () => ({
+  identifyAppPartOnClient: jest.fn().mockReturnValue('public'),
+}));
+jest.mock('../../utils/auth', () => ({ getCurrentToken: jest.fn() }));
+jest.mock('../../constants/enviroment', () => ({ envBackendURL: '' }));
+jest.mock('../../utils/isRequestCanceled', () => ({ isRequestCanceled: jest.fn().mockReturnValue(false) }));
+
+import { getResponseErrorMessage } from '../commonRequest';
+
+jest.mock('axios', () => {
+  const mockRequest = jest.fn().mockRejectedValue(new Error('not configured'));
+  const mockInstance = Object.assign(mockRequest, {
+    interceptors: {
+      request: { use: jest.fn() },
+      response: { use: jest.fn() },
+    },
+  });
+
+  return {
+    __esModule: true,
+    default: {
+      create: jest.fn().mockReturnValue(mockInstance),
+    },
+  };
+});
+
+import axios from 'axios';
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+const mockInstance = mockedAxios.create.mock.results[0].value;
+const responseErrorHandler = mockInstance.interceptors.response.use.mock.calls[0][1] as
+  (error: AxiosError) => Promise<never>;
+
+function makeAxiosError(data: unknown, status: number): AxiosError {
+  return {
+    response: {
+      data,
+      status,
+    } as AxiosResponse,
+    isAxiosError: true,
+    name: 'AxiosError',
+    message: `Request failed with status code ${status}`,
+    toJSON: () => ({}),
+  } as AxiosError;
+}
+
+describe('response interceptor: Error.message for Sentry', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('rejected Error contains detail from DRF response in .message', async () => {
+    const error = makeAxiosError({ detail: 'Not found.' }, 404);
+
+    await expect(responseErrorHandler(error)).rejects.toMatchObject({
+      message: 'Not found.',
+      status: 404,
+    });
+  });
+
+  it('rejected Error contains message field when detail is absent', async () => {
+    const error = makeAxiosError({ message: 'Validation failed' }, 400);
+
+    await expect(responseErrorHandler(error)).rejects.toMatchObject({
+      message: 'Validation failed',
+      status: 400,
+    });
+  });
+
+  it('rejected Error contains plain text from response.data in .message', async () => {
+    const error = makeAxiosError('Internal Server Error', 500);
+
+    await expect(responseErrorHandler(error)).rejects.toMatchObject({
+      message: 'Internal Server Error',
+      status: 500,
+    });
+  });
+
+  it('rejected Error contains non-empty fallback when data has no detail/message', async () => {
+    const error = makeAxiosError({ code: 'ERR_001' }, 422);
+
+    await expect(responseErrorHandler(error)).rejects.toHaveProperty('message');
+    await expect(responseErrorHandler(error)).rejects.not.toHaveProperty('message', '');
+  });
+});
+
+const FALLBACK = 'No error details provided by server';
+
+describe('getResponseErrorMessage', () => {
+  it('returns string as-is when data is a string', () => {
+    expect(getResponseErrorMessage('Server error')).toBe('Server error');
+  });
+
+  it('returns detail from object (DRF standard)', () => {
+    expect(getResponseErrorMessage({ detail: 'Not found.' })).toBe('Not found.');
+  });
+
+  it('returns message when detail is absent', () => {
+    expect(getResponseErrorMessage({ message: 'Validation error' })).toBe('Validation error');
+  });
+
+  it('prioritizes detail over message', () => {
+    expect(getResponseErrorMessage({ detail: 'Detail text', message: 'Message text' })).toBe('Detail text');
+  });
+
+  it.each([
+    ['empty object', {}],
+    ['undefined', undefined],
+    ['null', null],
+  ])('returns fallback when data is %s', (_label, data) => {
+    expect(getResponseErrorMessage(data)).toBe(FALLBACK);
+  });
+});

--- a/frontend/src/public/api/__tests__/getResponseErrorMessage.test.ts
+++ b/frontend/src/public/api/__tests__/getResponseErrorMessage.test.ts
@@ -54,6 +54,15 @@ function makeAxiosError(data: unknown, status: number): AxiosError {
   } as AxiosError;
 }
 
+function makeNetworkError(message: string): AxiosError {
+  return {
+    message,
+    isAxiosError: true,
+    name: 'AxiosError',
+    toJSON: () => ({}),
+  } as AxiosError;
+}
+
 describe('response interceptor: Error.message for Sentry', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -110,5 +119,26 @@ describe('response interceptor: Error.message for Sentry', () => {
       details: { name: 'url', reason: 'invalid' },
       status: 400,
     });
+  });
+
+  it('uses Axios error.message when response is absent (network error)', async () => {
+    const error = makeNetworkError('Network Error');
+
+    await expect(responseErrorHandler(error)).rejects.toHaveProperty('message', 'Network Error');
+  });
+
+  it('uses Axios error.message on timeout (no response)', async () => {
+    const error = makeNetworkError('timeout of 10000ms exceeded');
+
+    await expect(responseErrorHandler(error)).rejects.toHaveProperty('message', 'timeout of 10000ms exceeded');
+  });
+
+  it('never produces empty message for network errors without response', async () => {
+    const error = makeNetworkError('');
+
+    const rejected = responseErrorHandler(error);
+    await expect(rejected).rejects.toHaveProperty('message');
+    await expect(responseErrorHandler(error)).rejects.not.toHaveProperty('message', '');
+    await expect(responseErrorHandler(error)).rejects.not.toHaveProperty('message', '{}');
   });
 });

--- a/frontend/src/public/api/__tests__/getResponseErrorMessage.test.ts
+++ b/frontend/src/public/api/__tests__/getResponseErrorMessage.test.ts
@@ -16,8 +16,6 @@ jest.mock('../../utils/auth', () => ({ getCurrentToken: jest.fn() }));
 jest.mock('../../constants/enviroment', () => ({ envBackendURL: '' }));
 jest.mock('../../utils/isRequestCanceled', () => ({ isRequestCanceled: jest.fn().mockReturnValue(false) }));
 
-import { getResponseErrorMessage } from '../commonRequest';
-
 jest.mock('axios', () => {
   const mockRequest = jest.fn().mockRejectedValue(new Error('not configured'));
   const mockInstance = Object.assign(mockRequest, {
@@ -35,6 +33,7 @@ jest.mock('axios', () => {
   };
 });
 
+import '../commonRequest';
 import axios from 'axios';
 
 const mockedAxios = axios as jest.Mocked<typeof axios>;
@@ -60,65 +59,56 @@ describe('response interceptor: Error.message for Sentry', () => {
     jest.clearAllMocks();
   });
 
-  it('rejected Error contains detail from DRF response in .message', async () => {
-    const error = makeAxiosError({ detail: 'Not found.' }, 404);
-
-    await expect(responseErrorHandler(error)).rejects.toMatchObject({
-      message: 'Not found.',
-      status: 404,
-    });
-  });
-
-  it('rejected Error contains message field when detail is absent', async () => {
-    const error = makeAxiosError({ message: 'Validation failed' }, 400);
+  it('uses message from payload when present', async () => {
+    const error = makeAxiosError({ message: 'Validation failed', code: 'ERR_001' }, 400);
 
     await expect(responseErrorHandler(error)).rejects.toMatchObject({
       message: 'Validation failed',
+      code: 'ERR_001',
       status: 400,
     });
   });
 
-  it('rejected Error contains plain text from response.data in .message', async () => {
+  it('falls back to JSON.stringify with status when payload has no message field', async () => {
+    const error = makeAxiosError({ detail: 'Not found.' }, 404);
+
+    await expect(responseErrorHandler(error)).rejects.toMatchObject({
+      message: JSON.stringify({ detail: 'Not found.', status: 404 }),
+      detail: 'Not found.',
+      status: 404,
+    });
+  });
+
+  it('uses plain text from response.data as Error.error property', async () => {
     const error = makeAxiosError('Internal Server Error', 500);
 
     await expect(responseErrorHandler(error)).rejects.toMatchObject({
-      message: 'Internal Server Error',
+      error: 'Internal Server Error',
       status: 500,
     });
   });
 
-  it('rejected Error contains non-empty fallback when data has no detail/message', async () => {
+  it('falls back to JSON.stringify with status when payload has no message or detail', async () => {
     const error = makeAxiosError({ code: 'ERR_001' }, 422);
+
+    const rejected = responseErrorHandler(error);
+    await expect(rejected).rejects.toHaveProperty('message', JSON.stringify({ code: 'ERR_001', status: 422 }));
+  });
+
+  it('never produces empty Error.message', async () => {
+    const error = makeAxiosError({}, 500);
 
     await expect(responseErrorHandler(error)).rejects.toHaveProperty('message');
     await expect(responseErrorHandler(error)).rejects.not.toHaveProperty('message', '');
   });
-});
 
-const FALLBACK = 'No error details provided by server';
+  it('preserves all payload properties on the rejected Error', async () => {
+    const error = makeAxiosError({ code: 'ERR_002', details: { name: 'url', reason: 'invalid' } }, 400);
 
-describe('getResponseErrorMessage', () => {
-  it('returns string as-is when data is a string', () => {
-    expect(getResponseErrorMessage('Server error')).toBe('Server error');
-  });
-
-  it('returns detail from object (DRF standard)', () => {
-    expect(getResponseErrorMessage({ detail: 'Not found.' })).toBe('Not found.');
-  });
-
-  it('returns message when detail is absent', () => {
-    expect(getResponseErrorMessage({ message: 'Validation error' })).toBe('Validation error');
-  });
-
-  it('prioritizes detail over message', () => {
-    expect(getResponseErrorMessage({ detail: 'Detail text', message: 'Message text' })).toBe('Detail text');
-  });
-
-  it.each([
-    ['empty object', {}],
-    ['undefined', undefined],
-    ['null', null],
-  ])('returns fallback when data is %s', (_label, data) => {
-    expect(getResponseErrorMessage(data)).toBe(FALLBACK);
+    await expect(responseErrorHandler(error)).rejects.toMatchObject({
+      code: 'ERR_002',
+      details: { name: 'url', reason: 'invalid' },
+      status: 400,
+    });
   });
 });

--- a/frontend/src/public/api/commonRequest.ts
+++ b/frontend/src/public/api/commonRequest.ts
@@ -9,7 +9,6 @@ import { identifyAppPartOnClient } from '../utils/identifyAppPart/identifyAppPar
 import { getCurrentToken } from '../utils/auth';
 import { envBackendURL } from '../constants/enviroment';
 import { isRequestCanceled } from '../utils/isRequestCanceled';
-import { TResponseErrorData } from './types';
 
 export type TRequestType = 'public' | 'local';
 export type TResponseType = 'json' | 'text' | 'empty';
@@ -37,20 +36,6 @@ const axiosInstance: AxiosInstance = axios.create({
     'Content-Type': 'application/json',
   },
 });
-
-
-export function getResponseErrorMessage(data: TResponseErrorData): string {
-  if (typeof data === 'string') {
-    return data;
-  }
-
-  if (data && typeof data === 'object') {
-    if (typeof data.detail === 'string') return data.detail;
-    if (typeof data.message === 'string') return data.message;
-  }
-
-  return 'No error details provided by server';
-}
 
 axiosInstance.interceptors.request.use(
   (config) => {
@@ -104,9 +89,13 @@ axiosInstance.interceptors.response.use(
 
     const data = error.response?.data;
     const payload = typeof data === 'string' ? { error: data } : data ?? {};
-    const errorMessage = getResponseErrorMessage(data);
+    const rejectedError = Object.assign(new Error(), payload, { status: error.response?.status });
 
-    return Promise.reject(Object.assign(new Error(errorMessage), payload, { status: error.response?.status }));
+    if (!rejectedError.message) {
+      rejectedError.message = JSON.stringify({ ...payload, status: error.response?.status });
+    }
+
+    return Promise.reject(rejectedError);
   },
 );
 

--- a/frontend/src/public/api/commonRequest.ts
+++ b/frontend/src/public/api/commonRequest.ts
@@ -9,6 +9,7 @@ import { identifyAppPartOnClient } from '../utils/identifyAppPart/identifyAppPar
 import { getCurrentToken } from '../utils/auth';
 import { envBackendURL } from '../constants/enviroment';
 import { isRequestCanceled } from '../utils/isRequestCanceled';
+import { TResponseErrorData } from './types';
 
 export type TRequestType = 'public' | 'local';
 export type TResponseType = 'json' | 'text' | 'empty';
@@ -36,6 +37,20 @@ const axiosInstance: AxiosInstance = axios.create({
     'Content-Type': 'application/json',
   },
 });
+
+
+export function getResponseErrorMessage(data: TResponseErrorData): string {
+  if (typeof data === 'string') {
+    return data;
+  }
+
+  if (data && typeof data === 'object') {
+    if (typeof data.detail === 'string') return data.detail;
+    if (typeof data.message === 'string') return data.message;
+  }
+
+  return 'No error details provided by server';
+}
 
 axiosInstance.interceptors.request.use(
   (config) => {
@@ -89,7 +104,9 @@ axiosInstance.interceptors.response.use(
 
     const data = error.response?.data;
     const payload = typeof data === 'string' ? { error: data } : data ?? {};
-    return Promise.reject(Object.assign(new Error(), payload, { status: error.response?.status }));
+    const errorMessage = getResponseErrorMessage(data);
+
+    return Promise.reject(Object.assign(new Error(errorMessage), payload, { status: error.response?.status }));
   },
 );
 

--- a/frontend/src/public/api/commonRequest.ts
+++ b/frontend/src/public/api/commonRequest.ts
@@ -92,7 +92,10 @@ axiosInstance.interceptors.response.use(
     const rejectedError = Object.assign(new Error(), payload, { status: error.response?.status });
 
     if (!rejectedError.message) {
-      rejectedError.message = JSON.stringify({ ...payload, status: error.response?.status });
+      const hasPayloadData = Object.keys(payload).length > 0;
+      rejectedError.message = hasPayloadData
+        ? JSON.stringify({ ...payload, status: error.response?.status })
+        : error.message || 'Request failed';
     }
 
     return Promise.reject(rejectedError);

--- a/frontend/src/public/api/types.ts
+++ b/frontend/src/public/api/types.ts
@@ -1,0 +1,1 @@
+export type TResponseErrorData = string | { detail?: string; message?: string } | null | undefined;

--- a/frontend/src/public/api/types.ts
+++ b/frontend/src/public/api/types.ts
@@ -1,1 +1,0 @@
-export type TResponseErrorData = string | { detail?: string; message?: string } | null | undefined;


### PR DESCRIPTION
### 1. Release notes

Fixed API error logging in Sentry: errors previously reported as "No error message" now include full context — payload and HTTP status. Network errors now display meaningful notifications (e.g. "Network Error") instead of empty messages.

### 2. Problem

The response interceptor in `commonRequest` constructed `Error` objects via `new Error()` (empty constructor) and then copied response properties using `Object.assign`. Since API responses typically contain `detail`, `error`, or `code` fields — but not `message` — the `Error.message` remained empty, causing Sentry to display "No error message".

Scale: **~2,501 events**, **~133 users**, 5 Sentry issues.

### 3. Context

- **Sentry issues:**
  - [15K](https://pneumatic.sentry.io/issues/PNEUMATIC-FRONTEND-PROD-15K) — 2,252 events, 104 users
  - [15Q](https://pneumatic.sentry.io/issues/PNEUMATIC-FRONTEND-PROD-15Q) — 145 events, 22 users
  - [15M](https://pneumatic.sentry.io/issues/PNEUMATIC-FRONTEND-PROD-15M) — 102 events, 5 users
  - [19J](https://pneumatic.sentry.io/issues/PNEUMATIC-FRONTEND-PROD-19J) — 1 event, 1 user
  - [18N](https://pneumatic.sentry.io/issues/PNEUMATIC-FRONTEND-PROD-18N) — 1 event, 1 user
- **Period:** First Seen 2026-03-13, Last Seen 2026-06-06
- **Environment:** production
- **Location:** `frontend/src/public/api/commonRequest.ts` — response interceptor (shared across all API requests)

### 4. Solution

Added a two-level fallback in the response interceptor when `Error.message` is empty after `Object.assign`:
1. If payload is non-empty — populated with `JSON.stringify({ ...payload, status })`
2. If payload is empty (network error) — uses Axios `error.message` (e.g. `"Network Error"`, `"timeout of 10000ms exceeded"`)

This ensures every error reported to Sentry carries meaningful context, and users see informative notifications instead of empty `{}`.

### 5. Implementation Details

**Before:**
```typescript
const data = error.response?.data;
const payload = typeof data === 'string' ? { error: data } : data ?? {};
return Promise.reject(Object.assign(new Error(), payload, { status: error.response?.status }));
```
`new Error()` creates an Error with empty `.message`. `Object.assign` copies `detail`, `code`, `status`, but not `message` → Sentry receives `Error.message === ''`.

**After:**
```typescript
const rejectedError = Object.assign(new Error(), payload, { status: error.response?.status });

if (!rejectedError.message) {
  const hasPayloadData = Object.keys(payload).length > 0;
  rejectedError.message = hasPayloadData
    ? JSON.stringify({ ...payload, status: error.response?.status })
    : error.message || 'Request failed';
}

return Promise.reject(rejectedError);
```

- If payload contains a `message` field (e.g. `{ message: 'Validation failed' }`), it flows into `Error.message` via `Object.assign`.
- If payload is non-empty but has no `message` — `JSON.stringify` provides full context.
- If payload is empty (network error, timeout) — Axios `error.message` is used.

**Side effect (UX improvement):** Previously, network errors produced empty `Error.message`, so `NotificationManager` did not show any notification. Now users see meaningful messages (e.g. "Network Error", "Failed to fetch notifications: Network Error").

### 6. Testing

#### 6.1 Preconditions

- Branch `fix/sentry-15K-no-error-message` deployed to dev
- Access to Sentry (project pneumatic-frontend-prod)
- Browser: Desktop Chromium

#### 6.2 Positive Scenarios

| Scenario | Description | Developer | AI Agent (Chromium) |
| :--- | :--- | :--- | :--- |
| **API 404** | Navigate to `/tasks/999999/` → Sentry event should contain message with `detail` and `status: 404` | [ ] | [ ] |
| **API 403** | Log out, attempt an action → Sentry event with `status: 403` and payload in message | [ ] | [ ] |
| **API with `message`** | Submit invalid form data → Sentry event with `message: "Validation failed"`, payload preserved | [ ] | [ ] |

#### 6.3 Negative / Edge Cases

| Scenario | Description | Developer | AI Agent (Chromium) |
| :--- | :--- | :--- | :--- |
| **Empty response.data** | API returns empty body → Error.message is not empty, contains `{"status":...}` | [ ] | [ ] |
| **String response.data** | API returns plain text → Error contains `{ error: "Internal Server Error" }` | [ ] | [ ] |
| **Network error** | DevTools → Network → Block `localhost:8001` → refresh → notifications show "Network Error" (not `{}`) | [ ] | [ ] |
| **Timeout** | Slow server / timeout → message contains "timeout of 10000ms exceeded" (not `{}`) | [ ] | [ ] |

#### 6.4 Verification Points

- **Sentry:** new events do NOT contain "No error message" — instead they contain JSON with payload/status or a specific message from the API
- **UI:** error handling behavior is unchanged (notifications, redirects, component error handling)
- **Console:** `logger.error('Response Error:', ...)` still outputs to console

#### 6.6 Not Tested

- Not tested on mobile devices (infrastructure change, no UI impact)
- Not tested under load
- Not tested in Safari/Firefox (deferred to QA)

### 9. Unit Tests

Added `frontend/src/public/api/__tests__/getResponseErrorMessage.test.ts` (9 tests):

- **uses message from payload when present** — payload with `message` → Error.message preserved
- **falls back to JSON.stringify when no message** — payload with `detail` only → JSON.stringify fallback
- **uses plain text from response.data** — string response → wrapped in `{ error: ... }`
- **falls back to JSON.stringify when no message or detail** — payload with `code` → fallback
- **never produces empty Error.message** — empty payload `{}` with response → message is not empty
- **preserves all payload properties** — all payload properties retained on Error object
- **uses Axios error.message when response is absent (network error)** — network error without response → message = `"Network Error"`
- **uses Axios error.message on timeout (no response)** — timeout → message = `"timeout of 10000ms exceeded"`
- **never produces empty message for network errors without response** — empty error.message without response → message is not `""` or `"{}"`

### 10. Commits

- `50bba8a0` — `fix(api): populate Error.message in response interceptor for Sentry` — initial fix: fallback message, getResponseErrorMessage utility, TResponseErrorData type, tests
- `1c0acb18` — `fix(api): fallback to full JSON payload in Error.message when API response has no message field` — simplified interceptor to inline fallback, rewrote tests
- `73b3246c` — `fix(api): use Axios error.message as fallback for network errors instead of empty '{}'` — fix empty `{}` for network errors, added 3 tests for network error/timeout

---

Closes https://pneumatic.sentry.io/issues/PNEUMATIC-FRONTEND-PROD-15K
Closes https://pneumatic.sentry.io/issues/PNEUMATIC-FRONTEND-PROD-15Q
Closes https://pneumatic.sentry.io/issues/PNEUMATIC-FRONTEND-PROD-15M
Closes https://pneumatic.sentry.io/issues/PNEUMATIC-FRONTEND-PROD-19J
Closes https://pneumatic.sentry.io/issues/PNEUMATIC-FRONTEND-PROD-18N




<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> <!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
> <!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ensure axios response interceptor always sets a non-empty error message
> Previously, rejected errors from the axios response interceptor could have an empty `message` field. The interceptor in [commonRequest.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/226/files#diff-7d429e9cf8c4d29682c46cd3b707ccee5ef9388cdcddfbdbe8be6b034c1378aa) now uses `payload.message` when present, otherwise falls back to `JSON.stringify({ ...payload, status })`. A new test suite in [getResponseErrorMessage.test.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/226/files#diff-8e22181e83f804938ecdc851d5360b36bb525b2a40b22636aeebaee9a06f842c) covers all fallback cases.
> >
> <!-- Macroscope's changelog starts here -->
> #### Changes since #226 opened
>
> - Modified `axiosInstance` response interceptor error handler to populate `rejectedError.message` with the original Axios `error.message` or 'Request failed' fallback when the payload derived from `error.response.data` is empty [73b3246]
> - Added test cases and helper function for `getResponseErrorMessage` to verify error message handling when no response is present [73b3246]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
> >
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1c0acb1.</sup>
> <!-- Macroscope's review summary ends here -->
> >
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->