### PR TITLE
42684 frontend [ workflows ] Markdown breaks if file or link name

### DIFF
--- a/frontend/src/public/components/RichEditor/converters/attachmentMarkdown.ts
+++ b/frontend/src/public/components/RichEditor/converters/attachmentMarkdown.ts
@@ -15,6 +15,8 @@ import { buildAttachmentMarkdownString } from '../nodes/attachments/attachmentMa
 import {
   ATTACHMENT_MARKDOWN_INLINE_RE,
   ATTACHMENT_MARKDOWN_LINE_RE,
+  getMarkdownLinkMatchEndIndex,
+  parseAttachmentMarkdownFromStart,
   unescapeMarkdownLinkText,
 } from '../utils/converters/markdownLinkText';
 import { ECustomEditorEntities } from '../utils/types';
@@ -95,8 +97,16 @@ export const ATTACHMENT_INLINE: TextMatchTransformer = {
   dependencies: [ImageAttachmentNode, VideoAttachmentNode, FileAttachmentNode],
   importRegExp: ATTACHMENT_IMPORT_RE,
   regExp: ATTACHMENT_IMPORT_RE,
+  getEndIndex: (textNode, match) =>
+    getMarkdownLinkMatchEndIndex(
+      textNode.getTextContent(),
+      match.index ?? 0,
+      parseAttachmentMarkdownFromStart,
+    ),
   replace: (replaceNode, match) => {
-    const node = createAttachmentNodeFromMatch(match);
+    const parsedMatch =
+      parseAttachmentMarkdownFromStart(replaceNode.getTextContent()) ?? match;
+    const node = createAttachmentNodeFromMatch(parsedMatch);
     replaceNode.replace(node);
     const next = node.getNextSibling();
     if (next && $isTextNode(next)) {

--- a/frontend/src/public/components/RichEditor/converters/attachmentMarkdown.ts
+++ b/frontend/src/public/components/RichEditor/converters/attachmentMarkdown.ts
@@ -12,17 +12,20 @@ import {
   $isFileAttachmentNode,
 } from '../nodes/attachments';
 import { buildAttachmentMarkdownString } from '../nodes/attachments/attachmentMarkdownFormat';
+import {
+  ATTACHMENT_MARKDOWN_INLINE_RE,
+  ATTACHMENT_MARKDOWN_LINE_RE,
+  unescapeMarkdownLinkText,
+} from '../utils/converters/markdownLinkText';
 import { ECustomEditorEntities } from '../utils/types';
 
 type TAttachmentEntityType = ECustomEditorEntities.Image | ECustomEditorEntities.Video | ECustomEditorEntities.File;
 
-/** Full-line match for block-level import (line is only the image). Name allows escaped ] and \. */
-const ATTACHMENT_RE =
-  /^!?\[((?:[^\]\\]|\\.)*)\]\((.*?)\s*"(?:attachment_id:(\d*)\s*)?entityType:(image|video|file)[^"]*"\)?$/;
+/** Full-line match for block-level import (line is only the attachment). */
+const ATTACHMENT_RE = ATTACHMENT_MARKDOWN_LINE_RE;
 
-/** Inline match when line was merged by normalizeMarkdown (image inside a line). */
-export const ATTACHMENT_IMPORT_RE =
-  /!?\[((?:[^\]\\]|\\.)*)\]\((.*?)\s*"(?:attachment_id:(\d*)\s*)?entityType:(image|video|file)[^"]*"\)?/;
+/** Inline match when line was merged by normalizeMarkdown (attachment inside a line). */
+export const ATTACHMENT_IMPORT_RE = ATTACHMENT_MARKDOWN_INLINE_RE;
 
 const nodeCreators = {
   [ECustomEditorEntities.Image]: $createImageAttachmentNode,
@@ -33,8 +36,7 @@ const nodeCreators = {
 function createAttachmentNodeFromMatch(
   match: RegExpMatchArray | string[],
 ): ReturnType<typeof $createImageAttachmentNode> {
-  const nameRaw = match[1] ?? '';
-  const name = nameRaw.replace(/\\(.)/g, (_, c) => c);
+  const name = unescapeMarkdownLinkText(match[1] ?? '');
   const urlRaw = (match[2] ?? '').trim();
   // Use URL as-is to avoid corrupting presigned/signed URLs (e.g. S3) where
   // decoding %26, %3D, %2B in query params would alter the signature.

--- a/frontend/src/public/components/RichEditor/converters/linkMarkdown.ts
+++ b/frontend/src/public/components/RichEditor/converters/linkMarkdown.ts
@@ -4,10 +4,13 @@ import { $createTextNode, $isTextNode } from 'lexical';
 import {
   escapeMarkdownLinkText,
   GENERAL_MARKDOWN_LINK_IMPORT_RE,
+  GENERAL_MARKDOWN_LINK_LINE_RE,
+  getMarkdownLinkMatchEndIndex,
+  parseGeneralMarkdownLinkFromStart,
   unescapeMarkdownLinkText,
 } from '../utils/converters/markdownLinkText';
 
-const LINK_LINE_RE = new RegExp(`^${GENERAL_MARKDOWN_LINK_IMPORT_RE.source}$`);
+const LINK_LINE_RE = GENERAL_MARKDOWN_LINK_LINE_RE;
 
 const ATTACHMENT_ENTITY_TYPES = new Set(['image', 'video', 'file']);
 
@@ -33,14 +36,22 @@ export const MARKDOWN_LINK: TextMatchTransformer = {
   },
   importRegExp: GENERAL_MARKDOWN_LINK_IMPORT_RE,
   regExp: LINK_LINE_RE,
+  getEndIndex: (textNode, match) =>
+    getMarkdownLinkMatchEndIndex(
+      textNode.getTextContent(),
+      match.index ?? 0,
+      parseGeneralMarkdownLinkFromStart,
+    ),
   replace: (textNode, match) => {
-    const attachmentEntityType = match[4];
+    const parsedMatch =
+      parseGeneralMarkdownLinkFromStart(textNode.getTextContent()) ?? match;
+    const attachmentEntityType = parsedMatch[4];
     if (attachmentEntityType != null && ATTACHMENT_ENTITY_TYPES.has(attachmentEntityType)) {
       return;
     }
 
-    const linkText = unescapeMarkdownLinkText(match[1] ?? '');
-    const linkUrl = (match[2] ?? '').trim();
+    const linkText = unescapeMarkdownLinkText(parsedMatch[1] ?? '');
+    const linkUrl = (parsedMatch[2] ?? '').trim();
     const linkNode = $createLinkNode(linkUrl);
     const linkTextNode = $createTextNode(linkText);
     linkTextNode.setFormat(textNode.getFormat());

--- a/frontend/src/public/components/RichEditor/converters/linkMarkdown.ts
+++ b/frontend/src/public/components/RichEditor/converters/linkMarkdown.ts
@@ -1,0 +1,52 @@
+import type { TextMatchTransformer } from '@lexical/markdown';
+import { $createLinkNode, LinkNode, $isLinkNode } from '@lexical/link';
+import { $createTextNode, $isTextNode } from 'lexical';
+import {
+  escapeMarkdownLinkText,
+  GENERAL_MARKDOWN_LINK_IMPORT_RE,
+  unescapeMarkdownLinkText,
+} from '../utils/converters/markdownLinkText';
+
+const LINK_LINE_RE = new RegExp(`^${GENERAL_MARKDOWN_LINK_IMPORT_RE.source}$`);
+
+const ATTACHMENT_ENTITY_TYPES = new Set(['image', 'video', 'file']);
+
+export const MARKDOWN_LINK: TextMatchTransformer = {
+  dependencies: [LinkNode],
+  export: (node, _exportChildren, exportFormat) => {
+    if (!$isLinkNode(node)) {
+      return null;
+    }
+
+    const title = node.getTitle();
+    const escapedText = escapeMarkdownLinkText(node.getTextContent());
+    const linkContent = title
+      ? `[${escapedText}](${node.getURL()} "${title}")`
+      : `[${escapedText}](${node.getURL()})`;
+    const firstChild = node.getFirstChild();
+
+    if (node.getChildrenSize() === 1 && $isTextNode(firstChild)) {
+      return exportFormat(firstChild, linkContent);
+    }
+
+    return linkContent;
+  },
+  importRegExp: GENERAL_MARKDOWN_LINK_IMPORT_RE,
+  regExp: LINK_LINE_RE,
+  replace: (textNode, match) => {
+    const attachmentEntityType = match[4];
+    if (attachmentEntityType != null && ATTACHMENT_ENTITY_TYPES.has(attachmentEntityType)) {
+      return;
+    }
+
+    const linkText = unescapeMarkdownLinkText(match[1] ?? '');
+    const linkUrl = (match[2] ?? '').trim();
+    const linkNode = $createLinkNode(linkUrl);
+    const linkTextNode = $createTextNode(linkText);
+    linkTextNode.setFormat(textNode.getFormat());
+    linkNode.append(linkTextNode);
+    textNode.replace(linkNode);
+  },
+  trigger: ')',
+  type: 'text-match',
+};

--- a/frontend/src/public/components/RichEditor/converters/transformers.ts
+++ b/frontend/src/public/components/RichEditor/converters/transformers.ts
@@ -5,9 +5,9 @@ import {
   ORDERED_LIST,
   BOLD_STAR,
   ITALIC_STAR,
-  LINK,
 } from '@lexical/markdown';
 import { MENTION } from './mentionMarkdown';
+import { MARKDOWN_LINK } from './linkMarkdown';
 import { createVariableTransformer } from './variableMarkdown';
 import { createChecklistTransformer } from './checklistMarkdown';
 import { ATTACHMENT, ATTACHMENT_INLINE } from './attachmentMarkdown';
@@ -29,7 +29,7 @@ export function createMarkdownTransformers(templateVariables?: TTaskVariable[]) 
     ORDERED_LIST,
     BOLD_STAR,
     ITALIC_STAR,
-    LINK,
+    MARKDOWN_LINK,
     MENTION,
     createChecklistTransformer(templateVariables),
     createVariableTransformer(templateVariables),

--- a/frontend/src/public/components/RichEditor/utils/converters/__tests__/markdownLinkText.test.ts
+++ b/frontend/src/public/components/RichEditor/utils/converters/__tests__/markdownLinkText.test.ts
@@ -1,0 +1,62 @@
+import {
+  ATTACHMENT_MARKDOWN_INLINE_RE,
+  ATTACHMENT_MARKDOWN_LINE_RE,
+  GENERAL_MARKDOWN_LINK_RE,
+  escapeMarkdownLinkText,
+  unescapeMarkdownLinkText,
+} from '../markdownLinkText';
+
+describe('attachment markdown regex', () => {
+  it('matches attachment with unescaped brackets in filename', () => {
+    const markdown = '![report[Q1].pdf](https://example.com/f "entityType:file")';
+    const match = ATTACHMENT_MARKDOWN_LINE_RE.exec(markdown);
+
+    expect(match).not.toBeNull();
+    expect(match?.[1]).toBe('report[Q1].pdf');
+    expect(match?.[2]).toBe('https://example.com/f');
+    expect(match?.[4]).toBe('file');
+  });
+
+  it('matches attachment with escaped brackets in filename', () => {
+    const markdown = '![report\\[Q1\\].pdf](https://example.com/f "entityType:file")';
+    const match = ATTACHMENT_MARKDOWN_INLINE_RE.exec(markdown);
+
+    expect(match).not.toBeNull();
+    expect(unescapeMarkdownLinkText(match?.[1] ?? '')).toBe('report[Q1].pdf');
+  });
+});
+
+describe('general markdown link regex', () => {
+  it('matches link text with nested brackets', () => {
+    const markdown = '[ewfer[ergerg]ergerg](http://localhost:8000/templates/edit/19755/)';
+    const match = GENERAL_MARKDOWN_LINK_RE.exec(markdown);
+
+    expect(match).not.toBeNull();
+    expect(match?.[1]).toBe('ewfer[ergerg]ergerg');
+    expect(match?.[2]).toBe('http://localhost:8000/templates/edit/19755/');
+  });
+});
+
+describe('escapeMarkdownLinkText', () => {
+  it('escapes ] in link text', () => {
+    expect(escapeMarkdownLinkText('click [here]')).toBe('click [here\\]');
+  });
+});
+
+describe('unescapeMarkdownLinkText', () => {
+  it('returns plain text unchanged', () => {
+    expect(unescapeMarkdownLinkText('report.pdf')).toBe('report.pdf');
+  });
+
+  it('unescapes ] in link alt text', () => {
+    expect(unescapeMarkdownLinkText('report\\[Q1\\].pdf')).toBe('report[Q1].pdf');
+  });
+
+  it('unescapes backslashes', () => {
+    expect(unescapeMarkdownLinkText('path\\\\to\\\\file')).toBe('path\\to\\file');
+  });
+
+  it('unescapes mixed brackets and backslashes', () => {
+    expect(unescapeMarkdownLinkText('file\\[1\\].pdf')).toBe('file[1].pdf');
+  });
+});

--- a/frontend/src/public/components/RichEditor/utils/converters/__tests__/markdownLinkText.test.ts
+++ b/frontend/src/public/components/RichEditor/utils/converters/__tests__/markdownLinkText.test.ts
@@ -1,8 +1,11 @@
 import {
   ATTACHMENT_MARKDOWN_INLINE_RE,
   ATTACHMENT_MARKDOWN_LINE_RE,
+  GENERAL_MARKDOWN_LINK_IMPORT_RE,
   GENERAL_MARKDOWN_LINK_RE,
   escapeMarkdownLinkText,
+  parseAttachmentMarkdownFromStart,
+  parseGeneralMarkdownLinkFromStart,
   unescapeMarkdownLinkText,
 } from '../markdownLinkText';
 
@@ -24,6 +27,27 @@ describe('attachment markdown regex', () => {
     expect(match).not.toBeNull();
     expect(unescapeMarkdownLinkText(match?.[1] ?? '')).toBe('report[Q1].pdf');
   });
+
+  it('does not match attachment markdown without closing parenthesis', () => {
+    const markdown = '![alt](url "entityType:file"';
+    const match = parseAttachmentMarkdownFromStart(markdown);
+
+    expect(match).toBeNull();
+  });
+
+  it('matches only the first attachment when two are on the same line', () => {
+    const markdown =
+      '![a](url1 "entityType:file") ![b](url2 "entityType:file")';
+    const firstMatch = parseAttachmentMarkdownFromStart(markdown);
+    const secondMatch = parseAttachmentMarkdownFromStart(
+      markdown.slice(firstMatch?.[0].length ?? 0).trimStart(),
+    );
+
+    expect(firstMatch?.[1]).toBe('a');
+    expect(firstMatch?.[2]).toBe('url1');
+    expect(secondMatch?.[1]).toBe('b');
+    expect(secondMatch?.[2]).toBe('url2');
+  });
 });
 
 describe('general markdown link regex', () => {
@@ -34,6 +58,38 @@ describe('general markdown link regex', () => {
     expect(match).not.toBeNull();
     expect(match?.[1]).toBe('ewfer[ergerg]ergerg');
     expect(match?.[2]).toBe('http://localhost:8000/templates/edit/19755/');
+  });
+
+  it('matches only the first link when two are on the same line', () => {
+    const markdown = '[a](url1) [b](url2)';
+    const firstMatch = parseGeneralMarkdownLinkFromStart(markdown);
+    const secondMatch = parseGeneralMarkdownLinkFromStart(
+      markdown.slice(firstMatch?.[0].length ?? 0).trimStart(),
+    );
+
+    expect(firstMatch?.[1]).toBe('a');
+    expect(firstMatch?.[2]).toBe('url1');
+    expect(secondMatch?.[1]).toBe('b');
+    expect(secondMatch?.[2]).toBe('url2');
+  });
+
+  it('finds the first inline link inside surrounding text', () => {
+    const markdown = 'see [a](url1) and [b](url2)';
+    const match = GENERAL_MARKDOWN_LINK_IMPORT_RE.exec(markdown);
+
+    expect(match?.index).toBe(4);
+    expect(match?.[1]).toBe('a');
+    expect(match?.[2]).toBe('url1');
+  });
+
+  it('supports String.match used by Lexical markdown import', () => {
+    const markdown = 'hello [click here](https://example.com) world';
+    const match = markdown.match(GENERAL_MARKDOWN_LINK_IMPORT_RE);
+
+    expect(match?.index).toBe(6);
+    expect(match?.[0]).toBe('[click here](https://example.com)');
+    expect(match?.[1]).toBe('click here');
+    expect(match?.[2]).toBe('https://example.com');
   });
 });
 

--- a/frontend/src/public/components/RichEditor/utils/converters/customMarkdownPlugins.ts
+++ b/frontend/src/public/components/RichEditor/utils/converters/customMarkdownPlugins.ts
@@ -9,8 +9,8 @@ import { ECustomEditorEntities } from '../types';
 import { getAttachmentEntityType } from '../getAttachmentEntityType';
 import { ContentToken } from 'remarkable/lib';
 import {
-  ATTACHMENT_MARKDOWN_INLINE_RE,
-  GENERAL_MARKDOWN_LINK_RE,
+  parseAttachmentMarkdownFromStart,
+  parseGeneralMarkdownLinkFromStart,
   unescapeMarkdownLinkText,
 } from './markdownLinkText';
 
@@ -144,8 +144,8 @@ export const linksRemarkablePlugin = (remarkable: Remarkable) => {
       }
 
       const slice = state.src.slice(state.pos);
-      const attachmentMatch = ATTACHMENT_MARKDOWN_INLINE_RE.exec(slice);
-      const generalMatch = attachmentMatch ? null : GENERAL_MARKDOWN_LINK_RE.exec(slice);
+      const attachmentMatch = parseAttachmentMarkdownFromStart(slice);
+      const generalMatch = attachmentMatch ? null : parseGeneralMarkdownLinkFromStart(slice);
       const match = attachmentMatch ?? generalMatch;
 
       if (!match) {

--- a/frontend/src/public/components/RichEditor/utils/converters/customMarkdownPlugins.ts
+++ b/frontend/src/public/components/RichEditor/utils/converters/customMarkdownPlugins.ts
@@ -8,6 +8,11 @@ import { TMentionData } from '../../types';
 import { ECustomEditorEntities } from '../types';
 import { getAttachmentEntityType } from '../getAttachmentEntityType';
 import { ContentToken } from 'remarkable/lib';
+import {
+  ATTACHMENT_MARKDOWN_INLINE_RE,
+  GENERAL_MARKDOWN_LINK_RE,
+  unescapeMarkdownLinkText,
+} from './markdownLinkText';
 
 export type TVariableToken = {
   title: string;
@@ -138,15 +143,17 @@ export const linksRemarkablePlugin = (remarkable: Remarkable) => {
         return false;
       }
 
-      const regEx =
-        /^!?\[([^\]]*)\]\((.*?)\s*(?:"(?:attachment_id:(\d*))?(?:\s+)?(?:entityType:([^"\s]*))?(?:[^"]*)?")?\s*\)/;
-      const match = regEx.exec(state.src.slice(state.pos));
+      const slice = state.src.slice(state.pos);
+      const attachmentMatch = ATTACHMENT_MARKDOWN_INLINE_RE.exec(slice);
+      const generalMatch = attachmentMatch ? null : GENERAL_MARKDOWN_LINK_RE.exec(slice);
+      const match = attachmentMatch ?? generalMatch;
 
       if (!match) {
         return false;
       }
 
-      const [matchString, name, url, id, type] = match;
+      const [matchString, nameRaw, url, id, type] = match;
+      const name = unescapeMarkdownLinkText(nameRaw);
 
       // valid match found, now we need to advance cursor
       state.pos += matchString.length;

--- a/frontend/src/public/components/RichEditor/utils/converters/markdownLinkText.ts
+++ b/frontend/src/public/components/RichEditor/utils/converters/markdownLinkText.ts
@@ -1,22 +1,182 @@
+const ATTACHMENT_LINK_SUFFIX_RE =
+  /^\]\((.*?)\s*"(?:attachment_id:(\d*)\s*)?entityType:(image|video|file)[^"]*"\)/;
+
+const GENERAL_LINK_SUFFIX_RE =
+  /^\]\((.*?)\s*(?:"(?:attachment_id:(\d*))?(?:\s+)?(?:entityType:([^"\s]*))?(?:[^"]*)?")?\s*\)/;
+
+const MARKDOWN_LINK_PREFIX_RE = /^!?\[/;
+
+type TMarkdownLinkParser = (text: string) => RegExpMatchArray | null;
+
+function toRegExpMatchArray(
+  match: RegExpMatchArray,
+  index: number,
+  input: string,
+): RegExpMatchArray {
+  const result = [...match] as RegExpMatchArray;
+  result.index = index;
+  result.input = input;
+
+  return result;
+}
+
+function createMarkdownLinkMatcher(
+  matchAt: (text: string) => RegExpMatchArray | null,
+): RegExp {
+  const matcher = {
+    exec(text: string): RegExpMatchArray | null {
+      const match = matchAt(text);
+
+      if (!match) {
+        return null;
+      }
+
+      return toRegExpMatchArray(match, match.index ?? 0, text);
+    },
+    [Symbol.match](text: string): RegExpMatchArray | null {
+      return matcher.exec(text);
+    },
+  };
+
+  return matcher as RegExp;
+}
+
 /**
- * Greedy link-text capture. Works for alt text with unescaped [ and ] because
- * parsing backtracks to the last ]( before the URL/title suffix.
+ * Finds the closing `]` of markdown link alt text (the one immediately before `(`).
+ * Respects backslash escapes in alt text.
  */
-export const MARKDOWN_LINK_TEXT_CAPTURE = '(.*)';
+function findMarkdownLinkAltCloseIndex(src: string, openBracketIndex: number): number | null {
+  let index = openBracketIndex + 1;
 
-export const ATTACHMENT_MARKDOWN_BODY =
-  `!?\\[${MARKDOWN_LINK_TEXT_CAPTURE}\\]\\((.*?)\\s*"(?:attachment_id:(\\d*)\\s*)?entityType:(image|video|file)[^"]*"\\)?`;
+  while (index < src.length) {
+    const char = src[index];
 
-export const ATTACHMENT_MARKDOWN_LINE_RE = new RegExp(`^${ATTACHMENT_MARKDOWN_BODY}$`);
+    if (char === '\\' && index + 1 < src.length) {
+      index += 2;
+    } else if (char === ']' && src[index + 1] === '(') {
+      return index;
+    } else {
+      index += 1;
+    }
+  }
 
-export const ATTACHMENT_MARKDOWN_INLINE_RE = new RegExp(ATTACHMENT_MARKDOWN_BODY);
+  return null;
+}
 
-export const GENERAL_MARKDOWN_LINK_BODY =
-  `!?\\[${MARKDOWN_LINK_TEXT_CAPTURE}\\]\\((.*?)\\s*(?:"(?:attachment_id:(\\d*))?(?:\\s+)?(?:entityType:([^"\\s]*))?(?:[^"]*)?")?\\s*\\)`;
+function buildMarkdownLinkMatch(
+  src: string,
+  openBracketIndex: number,
+  closeBracketIndex: number,
+  suffixMatch: RegExpMatchArray,
+): RegExpMatchArray {
+  const nameRaw = src.slice(openBracketIndex + 1, closeBracketIndex);
+  const fullMatch = src.slice(0, closeBracketIndex + suffixMatch[0].length);
+  const match = [fullMatch, nameRaw, ...suffixMatch.slice(1)] as RegExpMatchArray;
+  match.index = 0;
 
-export const GENERAL_MARKDOWN_LINK_RE = new RegExp(`^${GENERAL_MARKDOWN_LINK_BODY}`);
+  return match;
+}
 
-export const GENERAL_MARKDOWN_LINK_IMPORT_RE = new RegExp(GENERAL_MARKDOWN_LINK_BODY);
+function parseMarkdownLinkWithSuffix(
+  src: string,
+  suffixRegExp: RegExp,
+): RegExpMatchArray | null {
+  const prefixMatch = MARKDOWN_LINK_PREFIX_RE.exec(src);
+
+  if (!prefixMatch) {
+    return null;
+  }
+
+  const openBracketIndex = prefixMatch[0].length - 1;
+  const closeBracketIndex = findMarkdownLinkAltCloseIndex(src, openBracketIndex);
+
+  if (closeBracketIndex === null) {
+    return null;
+  }
+
+  const suffixMatch = suffixRegExp.exec(src.slice(closeBracketIndex));
+
+  if (!suffixMatch) {
+    return null;
+  }
+
+  return buildMarkdownLinkMatch(src, openBracketIndex, closeBracketIndex, suffixMatch);
+}
+
+export function parseAttachmentMarkdownFromStart(src: string): RegExpMatchArray | null {
+  return parseMarkdownLinkWithSuffix(src, ATTACHMENT_LINK_SUFFIX_RE);
+}
+
+export function parseGeneralMarkdownLinkFromStart(src: string): RegExpMatchArray | null {
+  return parseMarkdownLinkWithSuffix(src, GENERAL_LINK_SUFFIX_RE);
+}
+
+export function parseMarkdownLinkFromStart(src: string): RegExpMatchArray | null {
+  return parseAttachmentMarkdownFromStart(src) ?? parseGeneralMarkdownLinkFromStart(src);
+}
+
+function isMarkdownLinkStart(text: string, index: number): boolean {
+  if (text[index] === '[') {
+    return true;
+  }
+
+  return text[index] === '!' && text[index + 1] === '[';
+}
+
+function createMarkdownLinkSearchRegExp(parseFromStart: TMarkdownLinkParser): RegExp {
+  return createMarkdownLinkMatcher((text) => {
+    for (let index = 0; index < text.length; index += 1) {
+      if (isMarkdownLinkStart(text, index)) {
+        const match = parseFromStart(text.slice(index));
+
+        if (match) {
+          return toRegExpMatchArray(match, index, text);
+        }
+      }
+    }
+
+    return null;
+  });
+}
+
+function createMarkdownLinkLineRegExp(parseFromStart: TMarkdownLinkParser): RegExp {
+  return createMarkdownLinkMatcher((text) => {
+    const match = parseFromStart(text);
+
+    if (match && match[0].length === text.length) {
+      return toRegExpMatchArray(match, 0, text);
+    }
+
+    return null;
+  });
+}
+
+function createMarkdownLinkStartRegExp(parseFromStart: TMarkdownLinkParser): RegExp {
+  return createMarkdownLinkMatcher((text) => {
+    const match = parseFromStart(text);
+
+    if (!match) {
+      return null;
+    }
+
+    return toRegExpMatchArray(match, 0, text);
+  });
+}
+
+/** @deprecated Use parseAttachmentMarkdownFromStart. Kept for tests comparing RegExp API. */
+export const ATTACHMENT_MARKDOWN_INLINE_RE = createMarkdownLinkSearchRegExp(parseAttachmentMarkdownFromStart);
+
+/** @deprecated Use parseAttachmentMarkdownFromStart with full-line check. */
+export const ATTACHMENT_MARKDOWN_LINE_RE = createMarkdownLinkLineRegExp(parseAttachmentMarkdownFromStart);
+
+/** @deprecated Use parseGeneralMarkdownLinkFromStart. */
+export const GENERAL_MARKDOWN_LINK_RE = createMarkdownLinkStartRegExp(parseGeneralMarkdownLinkFromStart);
+
+/** @deprecated Use parseGeneralMarkdownLinkFromStart via search RegExp. */
+export const GENERAL_MARKDOWN_LINK_IMPORT_RE = createMarkdownLinkSearchRegExp(parseGeneralMarkdownLinkFromStart);
+
+/** Full-line match for block-level general link import. */
+export const GENERAL_MARKDOWN_LINK_LINE_RE = createMarkdownLinkLineRegExp(parseGeneralMarkdownLinkFromStart);
 
 /**
  * Escapes ] and \\ for markdown link alt text.
@@ -31,4 +191,14 @@ export function escapeMarkdownLinkText(text: string): string {
  */
 export function unescapeMarkdownLinkText(raw: string): string {
   return raw.replace(/\\(.)/g, (_, char: string) => char);
+}
+
+export function getMarkdownLinkMatchEndIndex(text: string, startIndex: number, parser: TMarkdownLinkParser): number | false {
+  const match = parser(text.slice(startIndex));
+
+  if (!match) {
+    return false;
+  }
+
+  return startIndex + match[0].length;
 }

--- a/frontend/src/public/components/RichEditor/utils/converters/markdownLinkText.ts
+++ b/frontend/src/public/components/RichEditor/utils/converters/markdownLinkText.ts
@@ -1,0 +1,34 @@
+/**
+ * Greedy link-text capture. Works for alt text with unescaped [ and ] because
+ * parsing backtracks to the last ]( before the URL/title suffix.
+ */
+export const MARKDOWN_LINK_TEXT_CAPTURE = '(.*)';
+
+export const ATTACHMENT_MARKDOWN_BODY =
+  `!?\\[${MARKDOWN_LINK_TEXT_CAPTURE}\\]\\((.*?)\\s*"(?:attachment_id:(\\d*)\\s*)?entityType:(image|video|file)[^"]*"\\)?`;
+
+export const ATTACHMENT_MARKDOWN_LINE_RE = new RegExp(`^${ATTACHMENT_MARKDOWN_BODY}$`);
+
+export const ATTACHMENT_MARKDOWN_INLINE_RE = new RegExp(ATTACHMENT_MARKDOWN_BODY);
+
+export const GENERAL_MARKDOWN_LINK_BODY =
+  `!?\\[${MARKDOWN_LINK_TEXT_CAPTURE}\\]\\((.*?)\\s*(?:"(?:attachment_id:(\\d*))?(?:\\s+)?(?:entityType:([^"\\s]*))?(?:[^"]*)?")?\\s*\\)`;
+
+export const GENERAL_MARKDOWN_LINK_RE = new RegExp(`^${GENERAL_MARKDOWN_LINK_BODY}`);
+
+export const GENERAL_MARKDOWN_LINK_IMPORT_RE = new RegExp(GENERAL_MARKDOWN_LINK_BODY);
+
+/**
+ * Escapes ] and \\ for markdown link alt text.
+ */
+export function escapeMarkdownLinkText(text: string): string {
+  return text.replace(/\\/g, '\\\\').replace(/]/g, '\\]');
+}
+
+/**
+ * Unescapes markdown link alt text (e.g. file\[1\] → file[1]).
+ * Plain names without escapes are returned unchanged.
+ */
+export function unescapeMarkdownLinkText(raw: string): string {
+  return raw.replace(/\\(.)/g, (_, char: string) => char);
+}

--- a/frontend/src/public/components/RichText/__tests__/RichText.test.tsx
+++ b/frontend/src/public/components/RichText/__tests__/RichText.test.tsx
@@ -1,6 +1,22 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
 import { RichText, IRichTextProps } from '../RichText';
+
+jest.mock('react-dom/server', () => ({
+  __esModule: true,
+  default: {
+    renderToStaticMarkup: jest.fn((element: React.ReactElement) => {
+      const props = element?.props as { name?: string; src?: string };
+      if (props?.name) {
+        return `<span>${props.name}</span>`;
+      }
+      if (props?.src) {
+        return `<video src="${props.src}" />`;
+      }
+      return '<mock />';
+    }),
+  },
+}));
 import { intlMock } from '../../../__stubs__/intlMock';
 import { EExtraFieldType } from '../../../types/template';
 import { TTaskVariable } from '../../TemplateEdit/types';
@@ -145,5 +161,82 @@ describe('RichText', () => {
     const { container } = render(<RichText {...props} />);
     expect(container.textContent).toContain('Client name');
     expect(container.textContent).not.toContain('{{client-name-3967}}');
+  });
+
+  it('renders file attachment with ] in filename', () => {
+    const props: IRichTextProps = {
+      text: '![report\\[Q1\\].pdf](https://example.com/f "entityType:file")',
+      isMarkdownMode: true,
+    };
+
+    const { container } = render(<RichText {...props} />);
+
+    expect(container.textContent).toContain('report[Q1].pdf');
+    expect(container.innerHTML).not.toContain('![report');
+  });
+
+  it('renders file attachment with unescaped brackets in filename', () => {
+    const props: IRichTextProps = {
+      text: '![report[Q1].pdf](https://example.com/f "entityType:file")',
+      isMarkdownMode: true,
+    };
+
+    const { container } = render(<RichText {...props} />);
+
+    expect(container.textContent).toContain('report[Q1].pdf');
+    expect(container.innerHTML).not.toContain('![report');
+  });
+
+  it('renders file attachment with [ and ] in filename', () => {
+    const props: IRichTextProps = {
+      text: '![file\\[1\\].pdf](https://example.com/f "entityType:file")',
+      isMarkdownMode: true,
+    };
+
+    const { container } = render(<RichText {...props} />);
+
+    expect(container.textContent).toContain('file[1].pdf');
+    expect(container.innerHTML).not.toContain('![file');
+  });
+
+  it('renders regular link with ] in link text', () => {
+    const props: IRichTextProps = {
+      text: '[click \\[here\\]](https://example.com)',
+      isMarkdownMode: true,
+    };
+
+    const { container } = render(<RichText {...props} />);
+    const link = container.querySelector('a[href="https://example.com"]');
+
+    expect(link).not.toBeNull();
+    expect(link?.textContent).toBe('click [here]');
+    expect(container.innerHTML).not.toContain('[click \\[here\\]]');
+  });
+
+  it('renders regular link with nested brackets in link text', () => {
+    const props: IRichTextProps = {
+      text: '[ewfer[ergerg]ergerg](http://localhost:8000/templates/edit/19755/)',
+      isMarkdownMode: true,
+    };
+
+    const { container } = render(<RichText {...props} />);
+    const link = container.querySelector('a[href="http://localhost:8000/templates/edit/19755/"]');
+
+    expect(link).not.toBeNull();
+    expect(link?.textContent).toBe('ewfer[ergerg]ergerg');
+    expect(container.innerHTML).not.toContain('[ewfer[ergerg]');
+  });
+
+  it('renders image attachment with ] in alt text', () => {
+    const props: IRichTextProps = {
+      text: '![img\\[v2\\]](https://example.com/img.png "entityType:image")',
+      isMarkdownMode: true,
+    };
+
+    const { container } = render(<RichText {...props} />);
+    const image = container.querySelector('img[src="https://example.com/img.png"]');
+
+    expect(image).not.toBeNull();
+    expect(container.innerHTML).not.toContain('![img');
   });
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core markdown import/export for links and attachments across Lexical and Remarkable; export now escapes `]` and backslashes in link text, which can alter stored markdown for existing content on re-save.
> 
> **Overview**
> Fixes markdown breaking when **file names** or **link text** contain `[` / `]` by replacing naive `[^\]]*` regexes with shared bracket-aware parsing in `markdownLinkText.ts` (escape/unescape, `parse*FromStart`, `getMarkdownLinkMatchEndIndex`).
> 
> **Lexical:** Swaps `@lexical/markdown`’s `LINK` for a custom `MARKDOWN_LINK` transformer that escapes link text on export and unescapes on import, skips attachment `entityType` links, and uses precise match boundaries for inline import. Attachment inline import now re-parses from the text node so merged lines resolve correctly.
> 
> **Remarkable / RichText:** The links Remarkable plugin uses the same parsers and unescape for read-only markdown rendering. Unit and `RichText` tests cover nested brackets, multiple links per line, and attachment filenames.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 946d5dfc92e7059984cc5c29a7ca9c1920f2963d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix markdown parsing to handle escaped and nested brackets in link and attachment names
> - Adds a new utility module [markdownLinkText.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/227/files#diff-5c953ee4127531912e389cdee2a7d20d5bd72fe0f04a6d7ea178f420396fbe86) with robust markdown link parsers that correctly find closing brackets while accounting for escape sequences (e.g. `\]`, `\\`).
> - Replaces the default Lexical `LINK` transformer with a custom [MARKDOWN_LINK](https://github.com/pneumaticapp/pneumaticworkflow/pull/227/files#diff-ba7858b9effd9b8a171fa282eb82ad10a992345391bb06fcd1661f3e4c01136e) transformer that uses these parsers for both import and export, including escaping link text on export.
> - Updates the attachment inline transformer and the Remarkable plugin to use the shared parsers, fixing cases where escaped brackets caused under- or over-consumption of characters.
> - Behavioral Change: link text containing `]` or `\` is now escaped on export to markdown, which changes the serialized form of existing content containing those characters.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 946d5df.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->