### PR TITLE
⚙️ 47292 backend [ conditions ] Add Completed or skipped predicate operator

### DIFF
--- a/backend/src/processes/enums.py
+++ b/backend/src/processes/enums.py
@@ -250,6 +250,8 @@ class PredicateOperator:
     MORE_THAN = 'more_than'
     LESS_THAN = 'less_than'
     COMPLETED = 'completed'
+    COMPLETED_OR_SKIPPED = 'completed_or_skipped'
+    SKIPPED = 'skipped'
     CHOICES = (
         (EQUAL, 'Equal'),
         (NOT_EQUAL, 'Not equal'),
@@ -260,10 +262,12 @@ class PredicateOperator:
         (MORE_THAN, 'More than'),
         (LESS_THAN, 'Less than'),
         (COMPLETED, COMPLETED),
+        (SKIPPED, SKIPPED),
+        (COMPLETED_OR_SKIPPED, COMPLETED_OR_SKIPPED),
     )
     ALLOWED_OPERATORS = {
         PredicateType.KICKOFF: {COMPLETED},
-        PredicateType.TASK: {COMPLETED},
+        PredicateType.TASK: {COMPLETED, SKIPPED, COMPLETED_OR_SKIPPED},
         PredicateType.USER: {EQUAL, NOT_EQUAL, EXIST, NOT_EXIST},
         PredicateType.GROUP: {EQUAL, NOT_EQUAL, EXIST, NOT_EXIST},
         PredicateType.FILE: {EXIST, NOT_EXIST},
@@ -318,7 +322,13 @@ class PredicateOperator:
             NOT_EXIST,
         },
     }
-    UNARY_OPERATORS = {EXIST, NOT_EXIST, COMPLETED}
+    UNARY_OPERATORS = {
+        EXIST,
+        NOT_EXIST,
+        COMPLETED,
+        SKIPPED,
+        COMPLETED_OR_SKIPPED,
+    }
 
 
 class ConditionAction:

--- a/backend/src/processes/messages/template.py
+++ b/backend/src/processes/messages/template.py
@@ -245,7 +245,8 @@ MSG_PT_0063 = _('The value must be a number.')
 MSG_PT_0064 = lambda name: format_lazy(
     _(
         'Task condition "{name}": '
-        'Only the "completed" operator is allowed for the "start_task" action',
+        'Only the "completed", "skipped", or "completed_or_skipped" '
+        'operators are allowed for the "start_task" action',
     ),
     name=name,
 )

--- a/backend/src/processes/migrations/0253_add_completed_or_skipped_predicate.py
+++ b/backend/src/processes/migrations/0253_add_completed_or_skipped_predicate.py
@@ -1,0 +1,124 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('processes', '0252_add_manager_performer_type'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='predicate',
+            name='operator',
+            field=models.CharField(
+                choices=[('equals', 'Equal'), ('not_equals', 'Not equal'),
+                         ('exists', 'Exists'), ('not_exists', 'Not exists'),
+                         ('contains', 'Contains'),
+                         ('not_contains', 'Not contains'),
+                         ('more_than', 'More than'),
+                         ('less_than', 'Less than'),
+                         ('completed', 'completed'), ('skipped', 'skipped'),
+                         ('completed_or_skipped', 'completed_or_skipped')],
+                max_length=30),
+        ),
+        migrations.AlterField(
+            model_name='predicatetemplate',
+            name='operator',
+            field=models.CharField(
+                choices=[('equals', 'Equal'), ('not_equals', 'Not equal'),
+                         ('exists', 'Exists'), ('not_exists', 'Not exists'),
+                         ('contains', 'Contains'),
+                         ('not_contains', 'Not contains'),
+                         ('more_than', 'More than'),
+                         ('less_than', 'Less than'),
+                         ('completed', 'completed'), ('skipped', 'skipped'),
+                         ('completed_or_skipped', 'completed_or_skipped')],
+                max_length=30),
+        ),
+        migrations.RunSQL("""
+            UPDATE processes_predicate p
+            SET    operator = 'completed_or_skipped'
+            FROM   processes_rule r
+            WHERE  p.rule_id    = r.id
+              AND  p.operator   = 'completed'
+              AND  p.field_type = 'task'
+        """),
+            migrations.RunSQL("""
+            UPDATE processes_predicatetemplate pt
+            SET    operator = 'completed_or_skipped'
+            FROM   processes_ruletemplate rt
+            WHERE  pt.rule_id   = rt.id
+              AND  pt.operator  = 'completed'
+              AND  pt.field_type = 'task'
+        """),
+        migrations.RunSQL("""
+            UPDATE processes_templatedraft td
+            SET draft = (
+                SELECT jsonb_set(
+                    td.draft,
+                    '{tasks}',
+                    jsonb_agg(
+                        CASE
+                            WHEN jsonb_typeof(task->'conditions') = 'array' THEN
+                                jsonb_set(
+                                    task,
+                                    '{conditions}',
+                                    (
+                                        SELECT jsonb_agg(
+                                            CASE
+                                                WHEN jsonb_typeof(cond->'rules') = 'array' THEN
+                                                    jsonb_set(
+                                                        cond,
+                                                        '{rules}',
+                                                        (
+                                                            SELECT jsonb_agg(
+                                                                CASE
+                                                                    WHEN jsonb_typeof(rule->'predicates') = 'array' THEN
+                                                                        jsonb_set(
+                                                                            rule,
+                                                                            '{predicates}',
+                                                                            (
+                                                                                SELECT jsonb_agg(
+                                                                                    CASE
+                                                                                        WHEN (pred->>'operator') = 'completed'
+                                                                                         AND (pred->>'field_type') = 'task'
+                                                                                        THEN jsonb_set(pred, '{operator}', '"completed_or_skipped"')
+                                                                                        ELSE pred
+                                                                                    END
+                                                                                )
+                                                                                FROM jsonb_array_elements(rule->'predicates') AS pred
+                                                                            )
+                                                                        )
+                                                                    ELSE rule
+                                                                END
+                                                            )
+                                                            FROM jsonb_array_elements(cond->'rules') AS rule
+                                                        )
+                                                    )
+                                                ELSE cond
+                                            END
+                                        )
+                                        FROM jsonb_array_elements(task->'conditions') AS cond
+                                    )
+                                )
+                            ELSE task
+                        END
+                    )
+                )
+                FROM jsonb_array_elements(td.draft->'tasks') AS task
+            )
+            WHERE td.is_deleted = FALSE
+              AND td.draft IS NOT NULL
+              AND jsonb_typeof(td.draft->'tasks') = 'array'
+              AND EXISTS (
+                  SELECT 1
+                  FROM jsonb_array_elements(td.draft->'tasks') AS task,
+                       jsonb_array_elements(task->'conditions') AS cond,
+                       jsonb_array_elements(cond->'rules') AS rule,
+                       jsonb_array_elements(rule->'predicates') AS pred
+                  WHERE (pred->>'operator') = 'completed'
+                    AND (pred->>'field_type') = 'task'
+              )
+        """)
+    ]

--- a/backend/src/processes/migrations/0253_add_completed_or_skipped_predicate.py
+++ b/backend/src/processes/migrations/0253_add_completed_or_skipped_predicate.py
@@ -58,52 +58,64 @@ class Migration(migrations.Migration):
                 SELECT jsonb_set(
                     td.draft,
                     '{tasks}',
-                    jsonb_agg(
-                        CASE
-                            WHEN jsonb_typeof(task->'conditions') = 'array' THEN
-                                jsonb_set(
-                                    task,
-                                    '{conditions}',
-                                    (
-                                        SELECT jsonb_agg(
-                                            CASE
-                                                WHEN jsonb_typeof(cond->'rules') = 'array' THEN
-                                                    jsonb_set(
-                                                        cond,
-                                                        '{rules}',
-                                                        (
-                                                            SELECT jsonb_agg(
-                                                                CASE
-                                                                    WHEN jsonb_typeof(rule->'predicates') = 'array' THEN
-                                                                        jsonb_set(
-                                                                            rule,
-                                                                            '{predicates}',
-                                                                            (
-                                                                                SELECT jsonb_agg(
-                                                                                    CASE
-                                                                                        WHEN (pred->>'operator') = 'completed'
-                                                                                         AND (pred->>'field_type') = 'task'
-                                                                                        THEN jsonb_set(pred, '{operator}', '"completed_or_skipped"')
-                                                                                        ELSE pred
-                                                                                    END
-                                                                                )
-                                                                                FROM jsonb_array_elements(rule->'predicates') AS pred
-                                                                            )
+                    COALESCE(
+                        jsonb_agg(
+                            CASE
+                                WHEN jsonb_typeof(task->'conditions') = 'array' THEN
+                                    jsonb_set(
+                                        task,
+                                        '{conditions}',
+                                        COALESCE(
+                                            (
+                                                SELECT jsonb_agg(
+                                                    CASE
+                                                        WHEN jsonb_typeof(cond->'rules') = 'array' THEN
+                                                            jsonb_set(
+                                                                cond,
+                                                                '{rules}',
+                                                                COALESCE(
+                                                                    (
+                                                                        SELECT jsonb_agg(
+                                                                            CASE
+                                                                                WHEN jsonb_typeof(rule->'predicates') = 'array' THEN
+                                                                                    jsonb_set(
+                                                                                        rule,
+                                                                                        '{predicates}',
+                                                                                        COALESCE(
+                                                                                            (
+                                                                                                SELECT jsonb_agg(
+                                                                                                    CASE
+                                                                                                        WHEN (pred->>'operator') = 'completed'
+                                                                                                         AND (pred->>'field_type') = 'task'
+                                                                                                        THEN jsonb_set(pred, '{operator}', '"completed_or_skipped"')
+                                                                                                        ELSE pred
+                                                                                                    END
+                                                                                                )
+                                                                                                FROM jsonb_array_elements(rule->'predicates') AS pred
+                                                                                            ),
+                                                                                            '[]'::jsonb
+                                                                                        )
+                                                                                    )
+                                                                                ELSE rule
+                                                                            END
                                                                         )
-                                                                    ELSE rule
-                                                                END
+                                                                        FROM jsonb_array_elements(cond->'rules') AS rule
+                                                                    ),
+                                                                    '[]'::jsonb
+                                                                )
                                                             )
-                                                            FROM jsonb_array_elements(cond->'rules') AS rule
-                                                        )
-                                                    )
-                                                ELSE cond
-                                            END
+                                                        ELSE cond
+                                                    END
+                                                )
+                                                FROM jsonb_array_elements(task->'conditions') AS cond
+                                            ),
+                                            '[]'::jsonb
                                         )
-                                        FROM jsonb_array_elements(task->'conditions') AS cond
                                     )
-                                )
-                            ELSE task
-                        END
+                                ELSE task
+                            END
+                        ),
+                        '[]'::jsonb
                     )
                 )
                 FROM jsonb_array_elements(td.draft->'tasks') AS task

--- a/backend/src/processes/serializers/templates/predicate.py
+++ b/backend/src/processes/serializers/templates/predicate.py
@@ -85,7 +85,8 @@ class PredicateTemplateSerializer(
         condition = self.context['condition']
         if (
             condition.action == ConditionAction.START_TASK
-            and operator != PredicateOperator.COMPLETED
+            and operator not in
+                PredicateOperator.ALLOWED_OPERATORS[PredicateType.TASK]
         ):
             raise_validation_error(
                 message=MSG_PT_0064(name=task.name),

--- a/backend/src/processes/services/condition_check/comparator.py
+++ b/backend/src/processes/services/condition_check/comparator.py
@@ -57,3 +57,11 @@ class Comparator:
     @classmethod
     def completed(cls, a: bool):
         return a
+
+    @classmethod
+    def skipped(cls, a: bool):
+        return a
+
+    @classmethod
+    def completed_or_skipped(cls, a: bool):
+        return a

--- a/backend/src/processes/services/condition_check/resolvers/task.py
+++ b/backend/src/processes/services/condition_check/resolvers/task.py
@@ -1,3 +1,4 @@
+from src.processes.enums import PredicateOperator
 from src.processes.models.workflows.task import Task
 
 from .base import Resolver
@@ -10,4 +11,10 @@ class TaskResolver(Resolver):
             api_name=self._predicate.field,
             workflow_id=self._workflow_id,
         )
-        self.field_value = (task.is_completed or task.is_skipped)
+        operator = self._predicate.operator
+        if operator == PredicateOperator.SKIPPED:
+            self.field_value = task.is_skipped
+        elif operator == PredicateOperator.COMPLETED:
+            self.field_value = task.is_completed
+        else:
+            self.field_value = (task.is_completed or task.is_skipped)

--- a/backend/src/processes/tests/fixtures.py
+++ b/backend/src/processes/tests/fixtures.py
@@ -374,7 +374,7 @@ def create_test_template(
                 )
                 PredicateTemplate.objects.create(
                     rule=rule,
-                    operator=PredicateOperator.COMPLETED,
+                    operator=PredicateOperator.COMPLETED_OR_SKIPPED,
                     field_type=PredicateType.TASK,
                     field=parents[0],
                     value=None,

--- a/backend/src/processes/tests/test_services/test_condition_check/test_service.py
+++ b/backend/src/processes/tests/test_services/test_condition_check/test_service.py
@@ -3928,7 +3928,7 @@ def test_check__group__not_exist__group_set__fail():
 # region task / kickoff
 
 
-def test_check__task_completed__return_true():
+def test_check_task_completed__completed__return_true():
 
     """Check returns True when the referenced task has completed status."""
 
@@ -3963,7 +3963,7 @@ def test_check__task_completed__return_true():
     assert result is True
 
 
-def test_check__task_not_completed__return_false():
+def test_check_task_completed__not_completed__return_false():
 
     """Check returns False when the referenced task has not completed."""
 
@@ -3996,7 +3996,215 @@ def test_check__task_not_completed__return_false():
     assert result is False
 
 
-def test_check__kickoff_completed__return_true():
+def test_check_task_completed__skipped__return_false():
+
+    """Check returns False when the referenced task has skipped status."""
+
+    # arrange
+    owner = create_test_owner()
+    workflow = create_test_workflow(user=owner, tasks_count=2)
+    task_1 = workflow.tasks.get(number=1)
+    task_1.status = TaskStatus.SKIPPED
+    task_1.save()
+    task_2 = workflow.tasks.get(number=2)
+    condition = Condition.objects.create(
+        task=task_2,
+        action=ConditionAction.SKIP_TASK,
+        order=1,
+    )
+    rule = Rule.objects.create(condition=condition)
+    Predicate.objects.create(
+        rule=rule,
+        operator=PredicateOperator.COMPLETED,
+        field_type=PredicateType.TASK,
+        field=task_1.api_name,
+        value=None,
+    )
+
+    # act
+    result = ConditionCheckService.check(
+        condition=condition,
+        workflow_id=workflow.id,
+    )
+
+    # assert
+    assert result is False
+
+
+def test_check_task_skipped__skipped__return_true():
+
+    """Check returns True when the referenced task has skipped status."""
+
+    # arrange
+    owner = create_test_owner()
+    workflow = create_test_workflow(user=owner, tasks_count=2)
+    task_1 = workflow.tasks.get(number=1)
+    task_1.status = TaskStatus.SKIPPED
+    task_1.save()
+    task_2 = workflow.tasks.get(number=2)
+    condition = Condition.objects.create(
+        task=task_2,
+        action=ConditionAction.SKIP_TASK,
+        order=1,
+    )
+    rule = Rule.objects.create(condition=condition)
+    Predicate.objects.create(
+        rule=rule,
+        operator=PredicateOperator.SKIPPED,
+        field_type=PredicateType.TASK,
+        field=task_1.api_name,
+        value=None,
+    )
+
+    # act
+    result = ConditionCheckService.check(
+        condition=condition,
+        workflow_id=workflow.id,
+    )
+
+    # assert
+    assert result is True
+
+
+def test_check_task_skipped__not_skipped__return_false():
+
+    """Check returns True when the referenced task has skipped status."""
+
+    # arrange
+    owner = create_test_owner()
+    workflow = create_test_workflow(user=owner, tasks_count=2)
+    task_1 = workflow.tasks.get(number=1)
+    task_1.status = TaskStatus.COMPLETED
+    task_1.save()
+    task_2 = workflow.tasks.get(number=2)
+    condition = Condition.objects.create(
+        task=task_2,
+        action=ConditionAction.SKIP_TASK,
+        order=1,
+    )
+    rule = Rule.objects.create(condition=condition)
+    Predicate.objects.create(
+        rule=rule,
+        operator=PredicateOperator.SKIPPED,
+        field_type=PredicateType.TASK,
+        field=task_1.api_name,
+        value=None,
+    )
+
+    # act
+    result = ConditionCheckService.check(
+        condition=condition,
+        workflow_id=workflow.id,
+    )
+
+    # assert
+    assert result is False
+
+
+def test_check_task_completed_or_skipped__skipped__return_true():
+
+    """Check returns True when the referenced task has skipped status."""
+
+    # arrange
+    owner = create_test_owner()
+    workflow = create_test_workflow(user=owner, tasks_count=2)
+    task_1 = workflow.tasks.get(number=1)
+    task_1.status = TaskStatus.SKIPPED
+    task_1.save()
+    task_2 = workflow.tasks.get(number=2)
+    condition = Condition.objects.create(
+        task=task_2,
+        action=ConditionAction.SKIP_TASK,
+        order=1,
+    )
+    rule = Rule.objects.create(condition=condition)
+    Predicate.objects.create(
+        rule=rule,
+        operator=PredicateOperator.COMPLETED_OR_SKIPPED,
+        field_type=PredicateType.TASK,
+        field=task_1.api_name,
+        value=None,
+    )
+
+    # act
+    result = ConditionCheckService.check(
+        condition=condition,
+        workflow_id=workflow.id,
+    )
+
+    # assert
+    assert result is True
+
+
+def test_check_task_completed_or_skipped__completed__return_true():
+
+    """Check returns True when the referenced task has completed status."""
+
+    # arrange
+    owner = create_test_owner()
+    workflow = create_test_workflow(user=owner, tasks_count=2)
+    task_1 = workflow.tasks.get(number=1)
+    task_1.status = TaskStatus.COMPLETED
+    task_1.save()
+    task_2 = workflow.tasks.get(number=2)
+    condition = Condition.objects.create(
+        task=task_2,
+        action=ConditionAction.SKIP_TASK,
+        order=1,
+    )
+    rule = Rule.objects.create(condition=condition)
+    Predicate.objects.create(
+        rule=rule,
+        operator=PredicateOperator.COMPLETED_OR_SKIPPED,
+        field_type=PredicateType.TASK,
+        field=task_1.api_name,
+        value=None,
+    )
+
+    # act
+    result = ConditionCheckService.check(
+        condition=condition,
+        workflow_id=workflow.id,
+    )
+
+    # assert
+    assert result is True
+
+
+def test_check_task_completed_or_skipped__pending__return_false():
+
+    """Check returns False when the referenced task is still pending."""
+
+    # arrange
+    owner = create_test_owner()
+    workflow = create_test_workflow(user=owner, tasks_count=2)
+    task_1 = workflow.tasks.get(number=1)
+    task_2 = workflow.tasks.get(number=2)
+    condition = Condition.objects.create(
+        task=task_2,
+        action=ConditionAction.SKIP_TASK,
+        order=1,
+    )
+    rule = Rule.objects.create(condition=condition)
+    Predicate.objects.create(
+        rule=rule,
+        operator=PredicateOperator.COMPLETED_OR_SKIPPED,
+        field_type=PredicateType.TASK,
+        field=task_1.api_name,
+        value=None,
+    )
+
+    # act
+    result = ConditionCheckService.check(
+        condition=condition,
+        workflow_id=workflow.id,
+    )
+
+    # assert
+    assert result is False
+
+
+def test_check_kickoff_completed__return_true():
 
     """Check returns True when predicate type is kickoff (always completed)."""
 
@@ -4026,5 +4234,3 @@ def test_check__kickoff_completed__return_true():
 
     # assert
     assert result is True
-
-# endregion

--- a/backend/src/processes/tests/test_utils/test_get_tasks_parents.py
+++ b/backend/src/processes/tests/test_utils/test_get_tasks_parents.py
@@ -10,281 +10,830 @@ from src.processes.utils.common import (
 )
 
 
-def test_get_parents__task_without_conditions__ok():
+class TestCompletedTaskOperator:
 
-    # arrange
-    task_1_api_name = 'task-1'
-    task_2_api_name = 'task-2'
-    tasks_data = [
-        {
-            'number': 1,
-            'name': 'Task 1',
-            'api_name': task_1_api_name,
-        },
-        {
-            'number': 2,
-            'name': 'Task 2',
-            'api_name': task_2_api_name,
-            'conditions': [
+    def test_get_parents__task_without_conditions__ok(self):
+
+        # arrange
+        task_1_api_name = 'task-1'
+        task_2_api_name = 'task-2'
+        condition = {
+            'order': 1,
+            'action': ConditionAction.START_TASK,
+            'rules': [
                 {
-                    'order': 1,
-                    'action': ConditionAction.START_TASK,
-                    'rules': [
+                    'predicates': [
                         {
-                            'predicates': [
-                                {
-                                    'field_type': PredicateType.TASK,
-                                    'operator': PredicateOperator.COMPLETED,
-                                    'api_name': 'predicate-1',
-                                    'field': task_1_api_name,
-                                    'value': None,
-                                },
-                            ],
+                            'field_type': PredicateType.TASK,
+                            'operator': PredicateOperator.COMPLETED,
+                            'api_name': 'predicate-1',
+                            'field': task_1_api_name,
+                            'value': None,
                         },
                     ],
                 },
             ],
-        },
-    ]
+        }
+        tasks_data = [
+            {
+                'number': 1,
+                'name': 'Task 1',
+                'api_name': task_1_api_name,
+            },
+            {
+                'number': 2,
+                'name': 'Task 2',
+                'api_name': task_2_api_name,
+                'conditions': [condition],
+            },
+        ]
 
-    # act
-    ancestors = get_tasks_parents(tasks_data)
+        # act
+        ancestors = get_tasks_parents(tasks_data)
 
-    # assert
-    assert ancestors[task_1_api_name] == []
-    assert ancestors[task_2_api_name] == [task_1_api_name]
+        # assert
+        assert ancestors[task_1_api_name] == []
+        assert ancestors[task_2_api_name] == [task_1_api_name]
 
+    @pytest.mark.parametrize(
+        'cond_action',
+        (ConditionAction.SKIP_TASK, ConditionAction.END_WORKFLOW),
+    )
+    def test_get_parents__task_with_not_start_conditions__ok(
+        self,
+        cond_action,
+    ):
 
-@pytest.mark.parametrize(
-    'cond_action',
-    (ConditionAction.SKIP_TASK, ConditionAction.END_WORKFLOW),
-)
-def test_get_parents__task_with_not_start_conditions__ok(cond_action):
-
-    # arrange
-    task_1_api_name = 'task-1'
-    task_2_api_name = 'task-2'
-    tasks_data = [
-        {
-            'number': 1,
-            'name': 'Task 1',
-            'api_name': task_1_api_name,
-        },
-        {
-            'number': 2,
-            'name': 'Task 2',
-            'api_name': task_2_api_name,
-            'conditions': [
+        # arrange
+        task_1_api_name = 'task-1'
+        task_2_api_name = 'task-2'
+        condition = {
+            'order': 1,
+            'action': cond_action,
+            'rules': [
                 {
-                    'order': 1,
-                    'action': cond_action,
-                    'rules': [
+                    'predicates': [
                         {
-                            'predicates': [
-                                {
-                                    'field_type': PredicateType.TASK,
-                                    'operator': PredicateOperator.COMPLETED,
-                                    'api_name': 'predicate-1',
-                                    'field': task_1_api_name,
-                                    'value': None,
-                                },
-                            ],
+                            'field_type': PredicateType.TASK,
+                            'operator': PredicateOperator.COMPLETED,
+                            'api_name': 'predicate-1',
+                            'field': task_1_api_name,
+                            'value': None,
                         },
                     ],
                 },
             ],
-        },
-    ]
+        }
+        tasks_data = [
+            {
+                'number': 1,
+                'name': 'Task 1',
+                'api_name': task_1_api_name,
+            },
+            {
+                'number': 2,
+                'name': 'Task 2',
+                'api_name': task_2_api_name,
+                'conditions': [condition],
+            },
+        ]
 
-    # act
-    ancestors = get_tasks_parents(tasks_data)
+        # act
+        ancestors = get_tasks_parents(tasks_data)
 
-    # assert
-    assert ancestors[task_1_api_name] == []
-    assert ancestors[task_2_api_name] == []
+        # assert
+        assert ancestors[task_1_api_name] == []
+        assert ancestors[task_2_api_name] == []
 
+    def test_get_parents__two_start_predicates__ok(self):
 
-def test_get_parents__two_start_predicates__ok():
-
-    # arrange
-    task_1_api_name = 'task-1'
-    task_2_api_name = 'task-2'
-    task_3_api_name = 'task-3'
-    tasks_data = [
-        {
-            'number': 1,
-            'name': 'Task 1',
-            'api_name': task_1_api_name,
-            'conditions': [
+        # arrange
+        task_1_api_name = 'task-1'
+        task_2_api_name = 'task-2'
+        task_3_api_name = 'task-3'
+        condition = {
+            'order': 1,
+            'action': ConditionAction.START_TASK,
+            'rules': [
                 {
-                    'order': 1,
-                    'action': ConditionAction.START_TASK,
-                    'rules': [
+                    'predicates': [
                         {
-                            'predicates': [
-                                {
-                                    'field_type': PredicateType.TASK,
-                                    'operator': PredicateOperator.COMPLETED,
-                                    'field': task_2_api_name,
-                                    'value': None,
-                                },
-                                {
-                                    'field_type': PredicateType.TASK,
-                                    'operator': PredicateOperator.COMPLETED,
-                                    'field': task_3_api_name,
-                                    'value': None,
-                                },
-                            ],
+                            'field_type': PredicateType.TASK,
+                            'operator': PredicateOperator.COMPLETED,
+                            'field': task_2_api_name,
+                            'value': None,
+                        },
+                        {
+                            'field_type': PredicateType.TASK,
+                            'operator': PredicateOperator.COMPLETED,
+                            'field': task_3_api_name,
+                            'value': None,
                         },
                     ],
                 },
             ],
-        },
-        {
-            'number': 2,
-            'name': 'Task 2',
-            'api_name': task_2_api_name,
-        },
-        {
-            'number': 3,
-            'name': 'Task 3',
-            'api_name': task_3_api_name,
-        },
-    ]
+        }
+        tasks_data = [
+            {
+                'number': 1,
+                'name': 'Task 1',
+                'api_name': task_1_api_name,
+                'conditions': [condition],
+            },
+            {
+                'number': 2,
+                'name': 'Task 2',
+                'api_name': task_2_api_name,
+            },
+            {
+                'number': 3,
+                'name': 'Task 3',
+                'api_name': task_3_api_name,
+            },
+        ]
 
-    # act
-    ancestors = get_tasks_parents(tasks_data)
+        # act
+        ancestors = get_tasks_parents(tasks_data)
 
-    # assert
-    assert ancestors[task_1_api_name] == [task_2_api_name, task_3_api_name]
-    assert ancestors[task_2_api_name] == []
-    assert ancestors[task_3_api_name] == []
+        # assert
+        assert ancestors[task_1_api_name] == [task_2_api_name, task_3_api_name]
+        assert ancestors[task_2_api_name] == []
+        assert ancestors[task_3_api_name] == []
 
+    def test_get_parents__linear_template__ok(self):
 
-def test_get_parents__linear_template__ok():
-
-    # arrange
-    task_1_api_name = 'task-1'
-    task_2_api_name = 'task-2'
-    tasks_data = [
-        {
-            'number': 1,
-            'name': 'Task 1',
-            'api_name': task_1_api_name,
-            'conditions': [
+        # arrange
+        task_1_api_name = 'task-1'
+        task_2_api_name = 'task-2'
+        condition_1 = {
+            'order': 1,
+            'action': ConditionAction.START_TASK,
+            'rules': [
                 {
-                    'order': 1,
-                    'action': ConditionAction.START_TASK,
-                    'rules': [
+                    'predicates': [
                         {
-                            'predicates': [
-                                {
-                                    'field_type': PredicateType.KICKOFF,
-                                    'operator': PredicateOperator.COMPLETED,
-                                    'api_name': 'predicate-1',
-                                    'field': None,
-                                    'value': None,
-                                },
-                            ],
+                            'field_type': PredicateType.KICKOFF,
+                            'operator': PredicateOperator.COMPLETED,
+                            'api_name': 'predicate-1',
+                            'field': None,
+                            'value': None,
                         },
                     ],
                 },
             ],
-        },
-        {
-            'number': 2,
-            'name': 'Task 2',
-            'api_name': task_2_api_name,
-            'conditions': [
+        }
+        condition_2 = {
+            'order': 1,
+            'action': ConditionAction.START_TASK,
+            'rules': [
                 {
-                    'order': 1,
-                    'action': ConditionAction.START_TASK,
-                    'rules': [
+                    'predicates': [
                         {
-                            'predicates': [
-                                {
-                                    'field_type': PredicateType.TASK,
-                                    'operator': PredicateOperator.COMPLETED,
-                                    'api_name': 'predicate-1',
-                                    'field': task_1_api_name,
-                                    'value': None,
-                                },
-                            ],
+                            'field_type': PredicateType.TASK,
+                            'operator': PredicateOperator.COMPLETED,
+                            'api_name': 'predicate-1',
+                            'field': task_1_api_name,
+                            'value': None,
                         },
                     ],
                 },
             ],
-        },
-    ]
+        }
+        tasks_data = [
+            {
+                'number': 1,
+                'name': 'Task 1',
+                'api_name': task_1_api_name,
+                'conditions': [condition_1],
+            },
+            {
+                'number': 2,
+                'name': 'Task 2',
+                'api_name': task_2_api_name,
+                'conditions': [condition_2],
+            },
+        ]
 
-    # act
-    ancestors = get_tasks_parents(tasks_data)
+        # act
+        ancestors = get_tasks_parents(tasks_data)
 
-    # assert
-    assert ancestors[task_1_api_name] == []
-    assert ancestors[task_2_api_name] == [task_1_api_name]
+        # assert
+        assert ancestors[task_1_api_name] == []
+        assert ancestors[task_2_api_name] == [task_1_api_name]
 
+    def test_get_parents__deleted_task_in_conditions__skip(self):
 
-def test_get_parents__deleted_task_in_conditions__skip():
-
-    # arrange
-    task_1_api_name = 'task-1'
-    task_2_api_name = 'task-2'
-    deleted_task_api_name = 'task-3'
-    tasks_data = [
-        {
-            'number': 1,
-            'name': 'Task 1',
-            'api_name': task_1_api_name,
-            'conditions': [
+        # arrange
+        task_1_api_name = 'task-1'
+        task_2_api_name = 'task-2'
+        deleted_task_api_name = 'task-3'
+        condition_1 = {
+            'order': 1,
+            'action': ConditionAction.START_TASK,
+            'rules': [
                 {
-                    'order': 1,
-                    'action': ConditionAction.START_TASK,
-                    'rules': [
+                    'predicates': [
                         {
-                            'predicates': [
-                                {
-                                    'field_type': PredicateType.TASK,
-                                    'operator': PredicateOperator.COMPLETED,
-                                    'api_name': 'predicate-1',
-                                    'field': deleted_task_api_name,
-                                    'value': None,
-                                },
-                            ],
+                            'field_type': PredicateType.TASK,
+                            'operator': PredicateOperator.COMPLETED,
+                            'api_name': 'predicate-1',
+                            'field': deleted_task_api_name,
+                            'value': None,
                         },
                     ],
                 },
             ],
-        },
-        {
-            'number': 2,
-            'name': 'Task 2',
-            'api_name': task_2_api_name,
-            'conditions': [
+        }
+
+        condition_2 = {
+            'order': 1,
+            'action': ConditionAction.START_TASK,
+            'rules': [
                 {
-                    'order': 1,
-                    'action': ConditionAction.START_TASK,
-                    'rules': [
+                    'predicates': [
                         {
-                            'predicates': [
-                                {
-                                    'field_type': PredicateType.TASK,
-                                    'operator': PredicateOperator.COMPLETED,
-                                    'api_name': 'predicate-1',
-                                    'field': task_1_api_name,
-                                    'value': None,
-                                },
-                            ],
+                            'field_type': PredicateType.TASK,
+                            'operator': PredicateOperator.COMPLETED,
+                            'api_name': 'predicate-1',
+                            'field': task_1_api_name,
+                            'value': None,
                         },
                     ],
                 },
             ],
-        },
-    ]
+        }
+        tasks_data = [
+            {
+                'number': 1,
+                'name': 'Task 1',
+                'api_name': task_1_api_name,
+                'conditions': [condition_1],
+            },
+            {
+                'number': 2,
+                'name': 'Task 2',
+                'api_name': task_2_api_name,
+                'conditions': [condition_2],
+            },
+        ]
 
-    # act
-    ancestors = get_tasks_parents(tasks_data)
+        # act
+        ancestors = get_tasks_parents(tasks_data)
 
-    # assert
-    assert ancestors[task_1_api_name] == []
-    assert ancestors[task_2_api_name] == [task_1_api_name]
+        # assert
+        assert ancestors[task_1_api_name] == []
+        assert ancestors[task_2_api_name] == [task_1_api_name]
+
+
+class TestSkippedTaskOperator:
+
+    def test_get_parents__task_without_conditions__ok(self):
+
+        # arrange
+        task_1_api_name = 'task-1'
+        task_2_api_name = 'task-2'
+        tasks_data = [
+            {
+                'number': 1,
+                'name': 'Task 1',
+                'api_name': task_1_api_name,
+            },
+            {
+                'number': 2,
+                'name': 'Task 2',
+                'api_name': task_2_api_name,
+                'conditions': [
+                    {
+                        'order': 1,
+                        'action': ConditionAction.START_TASK,
+                        'rules': [
+                            {
+                                'predicates': [
+                                    {
+                                        'field_type': PredicateType.TASK,
+                                        'operator': PredicateOperator.SKIPPED,
+                                        'api_name': 'predicate-1',
+                                        'field': task_1_api_name,
+                                        'value': None,
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+        ]
+
+        # act
+        ancestors = get_tasks_parents(tasks_data)
+
+        # assert
+        assert ancestors[task_1_api_name] == []
+        assert ancestors[task_2_api_name] == [task_1_api_name]
+
+    @pytest.mark.parametrize(
+        'cond_action',
+        (ConditionAction.SKIP_TASK, ConditionAction.END_WORKFLOW),
+    )
+    def test_get_parents__task_with_not_start_conditions__ok(
+        self,
+        cond_action,
+    ):
+
+        # arrange
+        task_1_api_name = 'task-1'
+        task_2_api_name = 'task-2'
+        tasks_data = [
+            {
+                'number': 1,
+                'name': 'Task 1',
+                'api_name': task_1_api_name,
+            },
+            {
+                'number': 2,
+                'name': 'Task 2',
+                'api_name': task_2_api_name,
+                'conditions': [
+                    {
+                        'order': 1,
+                        'action': cond_action,
+                        'rules': [
+                            {
+                                'predicates': [
+                                    {
+                                        'field_type': PredicateType.TASK,
+                                        'operator': PredicateOperator.SKIPPED,
+                                        'api_name': 'predicate-1',
+                                        'field': task_1_api_name,
+                                        'value': None,
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+        ]
+
+        # act
+        ancestors = get_tasks_parents(tasks_data)
+
+        # assert
+        assert ancestors[task_1_api_name] == []
+        assert ancestors[task_2_api_name] == []
+
+    def test_get_parents__two_start_predicates__ok(self):
+
+        # arrange
+        task_1_api_name = 'task-1'
+        task_2_api_name = 'task-2'
+        task_3_api_name = 'task-3'
+        tasks_data = [
+            {
+                'number': 1,
+                'name': 'Task 1',
+                'api_name': task_1_api_name,
+                'conditions': [
+                    {
+                        'order': 1,
+                        'action': ConditionAction.START_TASK,
+                        'rules': [
+                            {
+                                'predicates': [
+                                    {
+                                        'field_type': PredicateType.TASK,
+                                        'operator': PredicateOperator.SKIPPED,
+                                        'field': task_2_api_name,
+                                        'value': None,
+                                    },
+                                    {
+                                        'field_type': PredicateType.TASK,
+                                        'operator': PredicateOperator.SKIPPED,
+                                        'field': task_3_api_name,
+                                        'value': None,
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                'number': 2,
+                'name': 'Task 2',
+                'api_name': task_2_api_name,
+            },
+            {
+                'number': 3,
+                'name': 'Task 3',
+                'api_name': task_3_api_name,
+            },
+        ]
+
+        # act
+        ancestors = get_tasks_parents(tasks_data)
+
+        # assert
+        assert ancestors[task_1_api_name] == [task_2_api_name, task_3_api_name]
+        assert ancestors[task_2_api_name] == []
+        assert ancestors[task_3_api_name] == []
+
+    def test_get_parents__linear_template__ok(self):
+
+        # arrange
+        task_1_api_name = 'task-1'
+        task_2_api_name = 'task-2'
+        condition_1 = {
+            'order': 1,
+            'action': ConditionAction.START_TASK,
+            'rules': [
+                {
+                    'predicates': [
+                        {
+                            'field_type': PredicateType.KICKOFF,
+                            'operator': PredicateOperator.COMPLETED,
+                            'api_name': 'predicate-1',
+                            'field': None,
+                            'value': None,
+                        },
+                    ],
+                },
+            ],
+        }
+        condition_2 = {
+            'order': 1,
+            'action': ConditionAction.START_TASK,
+            'rules': [
+                {
+                    'predicates': [
+                        {
+                            'field_type': PredicateType.TASK,
+                            'operator': PredicateOperator.SKIPPED,
+                            'api_name': 'predicate-1',
+                            'field': task_1_api_name,
+                            'value': None,
+                        },
+                    ],
+                },
+            ],
+        }
+        tasks_data = [
+            {
+                'number': 1,
+                'name': 'Task 1',
+                'api_name': task_1_api_name,
+                'conditions': [condition_1],
+            },
+            {
+                'number': 2,
+                'name': 'Task 2',
+                'api_name': task_2_api_name,
+                'conditions': [condition_2],
+            },
+        ]
+
+        # act
+        ancestors = get_tasks_parents(tasks_data)
+
+        # assert
+        assert ancestors[task_1_api_name] == []
+        assert ancestors[task_2_api_name] == [task_1_api_name]
+
+    def test_get_parents__deleted_task_in_conditions__skip(self):
+
+        # arrange
+        task_1_api_name = 'task-1'
+        task_2_api_name = 'task-2'
+        deleted_task_api_name = 'task-3'
+        tasks_data = [
+            {
+                'number': 1,
+                'name': 'Task 1',
+                'api_name': task_1_api_name,
+                'conditions': [
+                    {
+                        'order': 1,
+                        'action': ConditionAction.START_TASK,
+                        'rules': [
+                            {
+                                'predicates': [
+                                    {
+                                        'field_type': PredicateType.TASK,
+                                        'operator': PredicateOperator.SKIPPED,
+                                        'api_name': 'predicate-1',
+                                        'field': deleted_task_api_name,
+                                        'value': None,
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                'number': 2,
+                'name': 'Task 2',
+                'api_name': task_2_api_name,
+                'conditions': [
+                    {
+                        'order': 1,
+                        'action': ConditionAction.START_TASK,
+                        'rules': [
+                            {
+                                'predicates': [
+                                    {
+                                        'field_type': PredicateType.TASK,
+                                        'operator': PredicateOperator.SKIPPED,
+                                        'api_name': 'predicate-1',
+                                        'field': task_1_api_name,
+                                        'value': None,
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+        ]
+
+        # act
+        ancestors = get_tasks_parents(tasks_data)
+
+        # assert
+        assert ancestors[task_1_api_name] == []
+        assert ancestors[task_2_api_name] == [task_1_api_name]
+
+
+class TestCompletedOrSkippedTaskOperator:
+
+    def test_get_parents__task_without_conditions__ok(self):
+
+        # arrange
+        task_1_api_name = 'task-1'
+        task_2_api_name = 'task-2'
+        conditions_1 = {
+            'order': 1,
+            'action': ConditionAction.START_TASK,
+            'rules': [
+                {
+                    'predicates': [
+                        {
+                            'field_type': PredicateType.TASK,
+                            'operator': PredicateOperator.COMPLETED_OR_SKIPPED,
+                            'api_name': 'predicate-1',
+                            'field': task_1_api_name,
+                            'value': None,
+                        },
+                    ],
+                },
+            ],
+        }
+
+        tasks_data = [
+            {
+                'number': 1,
+                'name': 'Task 1',
+                'api_name': task_1_api_name,
+            },
+            {
+                'number': 2,
+                'name': 'Task 2',
+                'api_name': task_2_api_name,
+                'conditions': [conditions_1],
+            },
+        ]
+
+        # act
+        ancestors = get_tasks_parents(tasks_data)
+
+        # assert
+        assert ancestors[task_1_api_name] == []
+        assert ancestors[task_2_api_name] == [task_1_api_name]
+
+    @pytest.mark.parametrize(
+        'cond_action',
+        (ConditionAction.SKIP_TASK, ConditionAction.END_WORKFLOW),
+    )
+    def test_get_parents__task_with_not_start_conditions__ok(
+        self,
+        cond_action,
+    ):
+
+        # arrange
+        task_1_api_name = 'task-1'
+        task_2_api_name = 'task-2'
+        condition_1 = {
+            'order': 1,
+            'action': cond_action,
+            'rules': [
+                {
+                    'predicates': [
+                        {
+                            'field_type': PredicateType.TASK,
+                            'operator': PredicateOperator.COMPLETED_OR_SKIPPED,
+                            'api_name': 'predicate-1',
+                            'field': task_1_api_name,
+                            'value': None,
+                        },
+                    ],
+                },
+            ],
+        }
+        tasks_data = [
+            {
+                'number': 1,
+                'name': 'Task 1',
+                'api_name': task_1_api_name,
+            },
+            {
+                'number': 2,
+                'name': 'Task 2',
+                'api_name': task_2_api_name,
+                'conditions': [condition_1],
+            },
+        ]
+
+        # act
+        ancestors = get_tasks_parents(tasks_data)
+
+        # assert
+        assert ancestors[task_1_api_name] == []
+        assert ancestors[task_2_api_name] == []
+
+    def test_get_parents__two_start_predicates__ok(self):
+
+        # arrange
+        task_1_api_name = 'task-1'
+        task_2_api_name = 'task-2'
+        task_3_api_name = 'task-3'
+        condition_1 = {
+            'order': 1,
+            'action': ConditionAction.START_TASK,
+            'rules': [
+                {
+                    'predicates': [
+                        {
+                            'field_type': PredicateType.TASK,
+                            'operator': PredicateOperator.COMPLETED_OR_SKIPPED,
+                            'field': task_2_api_name,
+                            'value': None,
+                        },
+                        {
+                            'field_type': PredicateType.TASK,
+                            'operator': PredicateOperator.COMPLETED_OR_SKIPPED,
+                            'field': task_3_api_name,
+                            'value': None,
+                        },
+                    ],
+                },
+            ],
+        }
+        tasks_data = [
+            {
+                'number': 1,
+                'name': 'Task 1',
+                'api_name': task_1_api_name,
+                'conditions': [condition_1],
+            },
+            {
+                'number': 2,
+                'name': 'Task 2',
+                'api_name': task_2_api_name,
+            },
+            {
+                'number': 3,
+                'name': 'Task 3',
+                'api_name': task_3_api_name,
+            },
+        ]
+
+        # act
+        ancestors = get_tasks_parents(tasks_data)
+
+        # assert
+        assert ancestors[task_1_api_name] == [task_2_api_name, task_3_api_name]
+        assert ancestors[task_2_api_name] == []
+        assert ancestors[task_3_api_name] == []
+
+    def test_get_parents__linear_template__ok(self):
+
+        # arrange
+        task_1_api_name = 'task-1'
+        task_2_api_name = 'task-2'
+        condition_1 = {
+            'order': 1,
+            'action': ConditionAction.START_TASK,
+            'rules': [
+                {
+                    'predicates': [
+                        {
+                            'field_type': PredicateType.KICKOFF,
+                            'operator': PredicateOperator.COMPLETED,
+                            'api_name': 'predicate-1',
+                            'field': None,
+                            'value': None,
+                        },
+                    ],
+                },
+            ],
+        }
+        condition_2 = {
+            'order': 1,
+            'action': ConditionAction.START_TASK,
+            'rules': [
+                {
+                    'predicates': [
+                        {
+                            'field_type': PredicateType.TASK,
+                            'operator': PredicateOperator.COMPLETED_OR_SKIPPED,
+                            'api_name': 'predicate-1',
+                            'field': task_1_api_name,
+                            'value': None,
+                        },
+                    ],
+                },
+            ],
+        }
+        tasks_data = [
+            {
+                'number': 1,
+                'name': 'Task 1',
+                'api_name': task_1_api_name,
+                'conditions': [condition_1],
+            },
+            {
+                'number': 2,
+                'name': 'Task 2',
+                'api_name': task_2_api_name,
+                'conditions': [condition_2],
+            },
+        ]
+
+        # act
+        ancestors = get_tasks_parents(tasks_data)
+
+        # assert
+        assert ancestors[task_1_api_name] == []
+        assert ancestors[task_2_api_name] == [task_1_api_name]
+
+    def test_get_parents__deleted_task_in_conditions__skip(self):
+
+        # arrange
+        task_1_api_name = 'task-1'
+        task_2_api_name = 'task-2'
+        deleted_task_api_name = 'task-3'
+        condition_1 = {
+            'order': 1,
+            'action': ConditionAction.START_TASK,
+            'rules': [
+                {
+                    'predicates': [
+                        {
+                            'field_type': PredicateType.TASK,
+                            'operator': PredicateOperator.COMPLETED_OR_SKIPPED,
+                            'api_name': 'predicate-1',
+                            'field': deleted_task_api_name,
+                            'value': None,
+                        },
+                    ],
+                },
+            ],
+        }
+        condition_2 = {
+            'order': 1,
+            'action': ConditionAction.START_TASK,
+            'rules': [
+                {
+                    'predicates': [
+                        {
+                            'field_type': PredicateType.TASK,
+                            'operator': PredicateOperator.COMPLETED_OR_SKIPPED,
+                            'api_name': 'predicate-1',
+                            'field': task_1_api_name,
+                            'value': None,
+                        },
+                    ],
+                },
+            ],
+        }
+        tasks_data = [
+            {
+                'number': 1,
+                'name': 'Task 1',
+                'api_name': task_1_api_name,
+                'conditions': [condition_1],
+            },
+            {
+                'number': 2,
+                'name': 'Task 2',
+                'api_name': task_2_api_name,
+                'conditions': [condition_2],
+            },
+        ]
+
+        # act
+        ancestors = get_tasks_parents(tasks_data)
+
+        # assert
+        assert ancestors[task_1_api_name] == []
+        assert ancestors[task_2_api_name] == [task_1_api_name]

--- a/backend/src/processes/tests/test_views/test_templates/test_create/test_condition_template.py
+++ b/backend/src/processes/tests/test_views/test_templates/test_create/test_condition_template.py
@@ -1944,7 +1944,7 @@ def test_create__predicates_with_equal_api_names__validation_error(
     assert response.data['details']['api_name'] == predicate_api_name
 
 
-def test_create__predicate_type_kickoff_completed__ok(
+def test_create__start_task_predicate_kickoff_completed__ok(
     mocker,
     api_client,
 ):
@@ -2026,7 +2026,107 @@ def test_create__predicate_type_kickoff_completed__ok(
     assert predicate['field'] is None
 
 
-def test_create__predicate_type_task__completed__ok(
+@pytest.mark.parametrize(
+    'operator',
+    (
+        PredicateOperator.SKIPPED,
+        PredicateOperator.COMPLETED,
+        PredicateOperator.COMPLETED_OR_SKIPPED,
+    ),
+)
+def test_create__start_task_allowed_predicates__ok(
+    mocker,
+    operator,
+    api_client,
+):
+
+    # arrange
+    account = create_test_account()
+    user = create_test_user(account=account)
+    mocker.patch(
+        'src.processes.serializers.templates.'
+        'condition.AnalyticService.templates_task_condition_created',
+    )
+    predicate_api_name = 'predicate-skip'
+    task_1_api_name = 'task-1'
+    task_2_api_name = 'task-2'
+    # START_TASK condition with COMPLETED makes task-1 an ancestor of task-2
+    start_condition_data = {
+        'order': 1,
+        'action': ConditionAction.START_TASK,
+        'rules': [
+            {
+                'predicates': [
+                    {
+                        'field_type': PredicateType.TASK,
+                        'operator': operator,
+                        'api_name': predicate_api_name,
+                        'field': task_1_api_name,
+                        'value': None,
+                    },
+                ],
+            },
+        ],
+    }
+
+    api_client.token_authenticate(user)
+
+    # act
+    response = api_client.post(
+        path='/templates',
+        data={
+            'name': 'Template',
+            'is_active': True,
+            'owners': [
+                {
+                    'type': OwnerType.USER,
+                    'source_id': user.id,
+                    'role': OwnerRole.OWNER,
+                },
+            ],
+            'kickoff': {},
+            'tasks': [
+                {
+                    'number': 1,
+                    'name': 'Step 1',
+                    'api_name': task_1_api_name,
+                    'raw_performers': [
+                        {
+                            'type': PerformerType.USER,
+                            'source_id': user.id,
+                        },
+                    ],
+                },
+                {
+                    'number': 2,
+                    'name': 'Step 2',
+                    'api_name': task_2_api_name,
+                    'conditions': [
+                        start_condition_data,
+                    ],
+                    'raw_performers': [
+                        {
+                            'type': PerformerType.USER,
+                            'source_id': user.id,
+                        },
+                    ],
+                },
+            ],
+        },
+    )
+
+    # assert
+    assert response.status_code == 200
+    condition = response.data['tasks'][1]['conditions'][0]
+    predicate = condition['rules'][0]['predicates'][0]
+    assert predicate['field_type'] == PredicateType.TASK
+    assert predicate['api_name'] == predicate_api_name
+    assert predicate['operator'] == operator
+    assert predicate['value'] is None
+    assert predicate['field'] == task_1_api_name
+
+
+def test_create__skip_task_predicate_task_skipped__ok(
     mocker,
     api_client,
 ):
@@ -2037,10 +2137,12 @@ def test_create__predicate_type_task__completed__ok(
         'src.processes.serializers.templates.'
         'condition.AnalyticService.templates_task_condition_created',
     )
-    predicate_api_name = 'predicate-1'
+    predicate_api_name = 'predicate-skip'
     task_1_api_name = 'task-1'
     task_2_api_name = 'task-2'
-    condition_data = {
+    task_3_api_name = 'task-3'
+    # START_TASK condition with COMPLETED makes task-1 an ancestor of task-3
+    start_condition_data = {
         'order': 1,
         'action': ConditionAction.START_TASK,
         'rules': [
@@ -2049,6 +2151,24 @@ def test_create__predicate_type_task__completed__ok(
                     {
                         'field_type': PredicateType.TASK,
                         'operator': PredicateOperator.COMPLETED,
+                        'api_name': 'predicate-start',
+                        'field': task_1_api_name,
+                        'value': None,
+                    },
+                ],
+            },
+        ],
+    }
+    # SKIP_TASK condition with SKIPPED checks if task-1 was skipped
+    skip_condition_data = {
+        'order': 2,
+        'action': ConditionAction.SKIP_TASK,
+        'rules': [
+            {
+                'predicates': [
+                    {
+                        'field_type': PredicateType.TASK,
+                        'operator': PredicateOperator.SKIPPED,
                         'api_name': predicate_api_name,
                         'field': task_1_api_name,
                         'value': None,
@@ -2099,7 +2219,21 @@ def test_create__predicate_type_task__completed__ok(
                     'number': 2,
                     'name': 'Step 2',
                     'api_name': task_2_api_name,
-                    'conditions': [condition_data],
+                    'raw_performers': [
+                        {
+                            'type': PerformerType.USER,
+                            'source_id': user.id,
+                        },
+                    ],
+                },
+                {
+                    'number': 3,
+                    'name': 'Step 3',
+                    'api_name': task_3_api_name,
+                    'conditions': [
+                        start_condition_data,
+                        skip_condition_data,
+                    ],
                     'raw_performers': [
                         {
                             'type': PerformerType.USER,
@@ -2113,13 +2247,246 @@ def test_create__predicate_type_task__completed__ok(
 
     # assert
     assert response.status_code == 200
-    condition = response.data['tasks'][1]['conditions'][0]
+    condition = response.data['tasks'][2]['conditions'][1]
     predicate = condition['rules'][0]['predicates'][0]
     assert predicate['field_type'] == PredicateType.TASK
     assert predicate['api_name'] == predicate_api_name
-    assert predicate['operator'] == PredicateOperator.COMPLETED
+    assert predicate['operator'] == PredicateOperator.SKIPPED
     assert predicate['value'] is None
     assert predicate['field'] == task_1_api_name
+
+
+def test_create__skip_task_predicate_type_task_completed_or_skipped__ok(
+    mocker,
+    api_client,
+):
+    # arrange
+    account = create_test_account(plan=BillingPlanType.UNLIMITED)
+    user = create_test_user(account=account)
+    mocker.patch(
+        'src.processes.serializers.templates.'
+        'condition.AnalyticService.templates_task_condition_created',
+    )
+    predicate_api_name = 'predicate-completed-or-skipped'
+    task_1_api_name = 'task-1'
+    task_2_api_name = 'task-2'
+    task_3_api_name = 'task-3'
+    # START_TASK condition with COMPLETED makes task-1 an ancestor of task-3
+    start_condition_data = {
+        'order': 1,
+        'action': ConditionAction.START_TASK,
+        'rules': [
+            {
+                'predicates': [
+                    {
+                        'field_type': PredicateType.TASK,
+                        'operator': PredicateOperator.COMPLETED,
+                        'api_name': 'predicate-start',
+                        'field': task_1_api_name,
+                        'value': None,
+                    },
+                ],
+            },
+        ],
+    }
+    # SKIP_TASK condition with COMPLETED_OR_SKIPPED
+    skip_condition_data = {
+        'order': 2,
+        'action': ConditionAction.SKIP_TASK,
+        'rules': [
+            {
+                'predicates': [
+                    {
+                        'field_type': PredicateType.TASK,
+                        'operator': PredicateOperator.COMPLETED_OR_SKIPPED,
+                        'api_name': predicate_api_name,
+                        'field': task_1_api_name,
+                        'value': None,
+                    },
+                ],
+            },
+        ],
+    }
+    api_client.token_authenticate(user)
+
+    # act
+    response = api_client.post(
+        path='/templates',
+        data={
+            'name': 'Template',
+            'is_active': True,
+            'owners': [
+                {
+                    'type': OwnerType.USER,
+                    'source_id': user.id,
+                    'role': OwnerRole.OWNER,
+                },
+            ],
+            'kickoff': {
+                'fields': [
+                    {
+                        'order': 1,
+                        'name': 'First step performer',
+                        'type': FieldType.USER,
+                        'api_name': 'user-field-1',
+                        'is_required': True,
+                    },
+                ],
+            },
+            'tasks': [
+                {
+                    'number': 1,
+                    'name': 'Step 1',
+                    'api_name': task_1_api_name,
+                    'raw_performers': [
+                        {
+                            'type': PerformerType.USER,
+                            'source_id': user.id,
+                        },
+                    ],
+                },
+                {
+                    'number': 2,
+                    'name': 'Step 2',
+                    'api_name': task_2_api_name,
+                    'raw_performers': [
+                        {
+                            'type': PerformerType.USER,
+                            'source_id': user.id,
+                        },
+                    ],
+                },
+                {
+                    'number': 3,
+                    'name': 'Step 3',
+                    'api_name': task_3_api_name,
+                    'conditions': [
+                        start_condition_data,
+                        skip_condition_data,
+                    ],
+                    'raw_performers': [
+                        {
+                            'type': PerformerType.USER,
+                            'source_id': user.id,
+                        },
+                    ],
+                },
+            ],
+        },
+    )
+
+    # assert
+    assert response.status_code == 200
+    condition = response.data['tasks'][2]['conditions'][1]
+    predicate = condition['rules'][0]['predicates'][0]
+    assert predicate['field_type'] == PredicateType.TASK
+    assert predicate['api_name'] == predicate_api_name
+    assert predicate['operator'] == PredicateOperator.COMPLETED_OR_SKIPPED
+    assert predicate['value'] is None
+    assert predicate['field'] == task_1_api_name
+
+
+@pytest.mark.parametrize(
+    'operator',
+    (PredicateOperator.SKIPPED, PredicateOperator.COMPLETED_OR_SKIPPED),
+)
+def test_create__start_and_skip_condition_on_the_same_task__allowed(
+    mocker,
+    operator,
+    api_client,
+):
+    # arrange
+    account = create_test_account()
+    user = create_test_owner(account=account)
+    mocker.patch(
+        'src.processes.serializers.templates.'
+        'condition.AnalyticService.templates_task_condition_created',
+    )
+    task_1_api_name = 'task-1'
+    task_2_api_name = 'task-2'
+    condition_1 = {
+        'order': 1,
+        'action': ConditionAction.START_TASK,
+        'rules': [
+            {
+                'predicates': [
+                    {
+                        'field_type': PredicateType.TASK,
+                        'operator': operator,
+                        'api_name': 'predicate-start',
+                        'field': task_1_api_name,
+                        'value': None,
+                    },
+                ],
+            },
+        ],
+    }
+    condition_2 = {
+        'order': 2,
+        'action': ConditionAction.SKIP_TASK,
+        'rules': [
+            {
+                'predicates': [
+                    {
+                        'field_type': PredicateType.TASK,
+                        'operator': operator,
+                        'api_name': 'predicate-skip',
+                        'field': task_1_api_name,
+                        'value': None,
+                    },
+                ],
+            },
+        ],
+    }
+    api_client.token_authenticate(user)
+
+    # act
+    response = api_client.post(
+        path='/templates',
+        data={
+            'name': 'Template',
+            'is_active': True,
+            'owners': [
+                {
+                    'type': OwnerType.USER,
+                    'source_id': user.id,
+                    'role': OwnerRole.OWNER,
+                },
+            ],
+            'kickoff': {},
+            'tasks': [
+                {
+                    'number': 1,
+                    'name': 'Step 1',
+                    'api_name': task_1_api_name,
+                    'raw_performers': [
+                        {
+                            'type': PerformerType.USER,
+                            'source_id': user.id,
+                        },
+                    ],
+                },
+                {
+                    'number': 2,
+                    'name': 'Step 2',
+                    'api_name': task_2_api_name,
+                    'raw_performers': [
+                        {
+                            'type': PerformerType.USER,
+                            'source_id': user.id,
+                        },
+                    ],
+                    'conditions': [
+                        condition_1,
+                        condition_2,
+                    ],
+                },
+            ],
+        },
+    )
+
+    # assert
+    assert response.status_code == 200
 
 
 @pytest.mark.parametrize(

--- a/backend/src/processes/tests/test_views/test_templates/test_update/test_condition_template.py
+++ b/backend/src/processes/tests/test_views/test_templates/test_update/test_condition_template.py
@@ -476,6 +476,359 @@ def test_update__predicate_to_type_kickoff_completed__ok(
     assert predicate.operator == PredicateOperator.COMPLETED
 
 
+def test_update__predicate_to_type_task_skipped__ok(
+    mocker,
+    api_client,
+):
+    # arrange
+    account = create_test_account(plan=BillingPlanType.UNLIMITED)
+    user = create_test_user(account=account)
+    mocker.patch(
+        'src.processes.services.templates.'
+        'integrations.TemplateIntegrationsService.template_updated',
+    )
+    template = create_test_template(
+        user=user,
+        tasks_count=3,
+        is_active=True,
+    )
+    first_task = template.tasks.order_by('number').first()
+    second_task = template.tasks.get(number=2)
+    third_task = template.tasks.get(number=3)
+
+    # START_TASK condition on third_task with COMPLETED on first_task
+    # to establish first_task as an ancestor of third_task
+    start_condition = ConditionTemplate.objects.create(
+        action=ConditionAction.START_TASK,
+        order=1,
+        task=third_task,
+        template=template,
+    )
+    start_rule = RuleTemplate.objects.create(
+        condition=start_condition,
+        template=template,
+    )
+    PredicateTemplate.objects.create(
+        rule=start_rule,
+        operator=PredicateOperator.COMPLETED,
+        field_type=PredicateType.TASK,
+        field=first_task.api_name,
+        value=None,
+        template=template,
+    )
+
+    # SKIP_TASK condition on third_task (will be updated to use SKIPPED)
+    skip_condition = ConditionTemplate.objects.create(
+        action=ConditionAction.SKIP_TASK,
+        order=2,
+        task=third_task,
+        template=template,
+    )
+    skip_rule = RuleTemplate.objects.create(
+        condition=skip_condition,
+        template=template,
+    )
+    predicate = PredicateTemplate.objects.create(
+        rule=skip_rule,
+        operator=PredicateOperator.COMPLETED,
+        field_type=PredicateType.TASK,
+        field=first_task.api_name,
+        value=None,
+        template=template,
+    )
+
+    start_request_data = {
+        'api_name': start_condition.api_name,
+        'order': start_condition.order,
+        'action': ConditionAction.START_TASK,
+        'rules': [
+            {
+                'api_name': start_rule.api_name,
+                'predicates': [
+                    {
+                        'api_name': start_rule.predicates.first().api_name,
+                        'field_type': PredicateType.TASK,
+                        'operator': PredicateOperator.COMPLETED,
+                        'field': first_task.api_name,
+                        'value': None,
+                    },
+                ],
+            },
+        ],
+    }
+    skip_request_data = {
+        'api_name': skip_condition.api_name,
+        'order': skip_condition.order,
+        'action': ConditionAction.SKIP_TASK,
+        'rules': [
+            {
+                'api_name': skip_rule.api_name,
+                'predicates': [
+                    {
+                        'api_name': predicate.api_name,
+                        'field_type': PredicateType.TASK,
+                        'operator': PredicateOperator.SKIPPED,
+                        'field': first_task.api_name,
+                        'value': None,
+                    },
+                ],
+            },
+        ],
+    }
+    api_client.token_authenticate(user)
+
+    # act
+    response = api_client.put(
+        path=f'/templates/{template.id}',
+        data={
+            'id': template.id,
+            'name': template.name,
+            'is_active': True,
+            'owners': [
+                {
+                    'type': OwnerType.USER,
+                    'source_id': user.id,
+                    'role': OwnerRole.OWNER,
+                },
+            ],
+            'kickoff': {'id': template.kickoff_instance.id},
+            'tasks': [
+                {
+                    'id': first_task.id,
+                    'number': first_task.number,
+                    'name': first_task.name,
+                    'api_name': first_task.api_name,
+                    'raw_performers': [
+                        {
+                            'type': PerformerType.USER,
+                            'source_id': user.id,
+                        },
+                    ],
+                },
+                {
+                    'id': second_task.id,
+                    'number': second_task.number,
+                    'name': second_task.name,
+                    'api_name': second_task.api_name,
+                    'raw_performers': [
+                        {
+                            'type': PerformerType.USER,
+                            'source_id': user.id,
+                        },
+                    ],
+                },
+                {
+                    'id': third_task.id,
+                    'number': third_task.number,
+                    'name': third_task.name,
+                    'api_name': third_task.api_name,
+                    'conditions': [
+                        start_request_data,
+                        skip_request_data,
+                    ],
+                    'raw_performers': [
+                        {
+                            'type': PerformerType.USER,
+                            'source_id': user.id,
+                        },
+                    ],
+                },
+            ],
+        },
+    )
+
+    # assert
+    assert response.status_code == 200
+    condition_data = response.data['tasks'][2]['conditions'][1]
+    predicate_data = condition_data['rules'][0]['predicates'][0]
+    assert predicate_data['field_type'] == PredicateType.TASK
+    assert predicate_data['api_name'] == predicate.api_name
+    assert predicate_data['operator'] == PredicateOperator.SKIPPED
+    assert predicate_data['value'] is None
+    assert predicate_data['field'] == first_task.api_name
+
+    predicate.refresh_from_db()
+    assert predicate.field_type == PredicateType.TASK
+    assert predicate.operator == PredicateOperator.SKIPPED
+
+
+def test_update__predicate_to_type_task_completed_or_skipped__ok(
+    mocker,
+    api_client,
+):
+    # arrange
+    account = create_test_account(plan=BillingPlanType.UNLIMITED)
+    user = create_test_user(account=account)
+    mocker.patch(
+        'src.processes.services.templates.'
+        'integrations.TemplateIntegrationsService.template_updated',
+    )
+    template = create_test_template(
+        user=user,
+        tasks_count=3,
+        is_active=True,
+    )
+    first_task = template.tasks.order_by('number').first()
+    second_task = template.tasks.get(number=2)
+    third_task = template.tasks.get(number=3)
+
+    # START_TASK condition on third_task with COMPLETED on first_task
+    # to establish first_task as an ancestor of third_task
+    start_condition = ConditionTemplate.objects.create(
+        action=ConditionAction.START_TASK,
+        order=1,
+        task=third_task,
+        template=template,
+    )
+    start_rule = RuleTemplate.objects.create(
+        condition=start_condition,
+        template=template,
+    )
+    PredicateTemplate.objects.create(
+        rule=start_rule,
+        operator=PredicateOperator.COMPLETED,
+        field_type=PredicateType.TASK,
+        field=first_task.api_name,
+        value=None,
+        template=template,
+    )
+
+    # SKIP_TASK condition on third_task
+    # (will be updated to use COMPLETED_OR_SKIPPED)
+    skip_condition = ConditionTemplate.objects.create(
+        action=ConditionAction.SKIP_TASK,
+        order=2,
+        task=third_task,
+        template=template,
+    )
+    skip_rule = RuleTemplate.objects.create(
+        condition=skip_condition,
+        template=template,
+    )
+    predicate = PredicateTemplate.objects.create(
+        rule=skip_rule,
+        operator=PredicateOperator.COMPLETED,
+        field_type=PredicateType.TASK,
+        field=first_task.api_name,
+        value=None,
+        template=template,
+    )
+
+    start_request_data = {
+        'api_name': start_condition.api_name,
+        'order': start_condition.order,
+        'action': ConditionAction.START_TASK,
+        'rules': [
+            {
+                'api_name': start_rule.api_name,
+                'predicates': [
+                    {
+                        'api_name': start_rule.predicates.first().api_name,
+                        'field_type': PredicateType.TASK,
+                        'operator': PredicateOperator.COMPLETED,
+                        'field': first_task.api_name,
+                        'value': None,
+                    },
+                ],
+            },
+        ],
+    }
+    skip_request_data = {
+        'api_name': skip_condition.api_name,
+        'order': skip_condition.order,
+        'action': ConditionAction.SKIP_TASK,
+        'rules': [
+            {
+                'api_name': skip_rule.api_name,
+                'predicates': [
+                    {
+                        'api_name': predicate.api_name,
+                        'field_type': PredicateType.TASK,
+                        'operator': PredicateOperator.COMPLETED_OR_SKIPPED,
+                        'field': first_task.api_name,
+                        'value': None,
+                    },
+                ],
+            },
+        ],
+    }
+    api_client.token_authenticate(user)
+
+    # act
+    response = api_client.put(
+        path=f'/templates/{template.id}',
+        data={
+            'id': template.id,
+            'name': template.name,
+            'is_active': True,
+            'owners': [
+                {
+                    'type': OwnerType.USER,
+                    'source_id': user.id,
+                    'role': OwnerRole.OWNER,
+                },
+            ],
+            'kickoff': {'id': template.kickoff_instance.id},
+            'tasks': [
+                {
+                    'id': first_task.id,
+                    'number': first_task.number,
+                    'name': first_task.name,
+                    'api_name': first_task.api_name,
+                    'raw_performers': [
+                        {
+                            'type': PerformerType.USER,
+                            'source_id': user.id,
+                        },
+                    ],
+                },
+                {
+                    'id': second_task.id,
+                    'number': second_task.number,
+                    'name': second_task.name,
+                    'api_name': second_task.api_name,
+                    'raw_performers': [
+                        {
+                            'type': PerformerType.USER,
+                            'source_id': user.id,
+                        },
+                    ],
+                },
+                {
+                    'id': third_task.id,
+                    'number': third_task.number,
+                    'name': third_task.name,
+                    'api_name': third_task.api_name,
+                    'conditions': [
+                        start_request_data,
+                        skip_request_data,
+                    ],
+                    'raw_performers': [
+                        {
+                            'type': PerformerType.USER,
+                            'source_id': user.id,
+                        },
+                    ],
+                },
+            ],
+        },
+    )
+
+    # assert
+    assert response.status_code == 200
+    condition_data = response.data['tasks'][2]['conditions'][1]
+    predicate_data = condition_data['rules'][0]['predicates'][0]
+    assert predicate_data['field_type'] == PredicateType.TASK
+    assert predicate_data['api_name'] == predicate.api_name
+    assert predicate_data['operator'] == PredicateOperator.COMPLETED_OR_SKIPPED
+    assert predicate_data['value'] is None
+    assert predicate_data['field'] == first_task.api_name
+
+    predicate.refresh_from_db()
+    assert predicate.field_type == PredicateType.TASK
+    assert predicate.operator == PredicateOperator.COMPLETED_OR_SKIPPED
+
+
 def test_update__predicate_to_type_number__ok(
     mocker,
     api_client,

--- a/backend/src/processes/utils/common.py
+++ b/backend/src/processes/utils/common.py
@@ -166,6 +166,11 @@ def get_tasks_parents(tasks_data: List[Dict]) -> dict:
 
     """ Find and return task parents api_names """
 
+    allowed_operators = {
+        PredicateOperator.COMPLETED,
+        PredicateOperator.SKIPPED,
+        PredicateOperator.COMPLETED_OR_SKIPPED,
+    }
     parents_by_tasks = {}
     available_api_names = {
         e['api_name'] for e in tasks_data if e.get('api_name')
@@ -181,7 +186,7 @@ def get_tasks_parents(tasks_data: List[Dict]) -> dict:
                     for p in rule.get('predicates', ()):
                         try:
                             if (
-                                p['operator'] == PredicateOperator.COMPLETED
+                                p['operator'] in allowed_operators
                                 and p['field_type'] == PredicateType.TASK
                                 and p['field'] in available_api_names
                             ):


### PR DESCRIPTION
# Problem

When building automated workflows, users can set rules that depend on whether a previous step has finished. Until now, the system treated a skipped step the same as a completed step for these rules. Users could not create conditions that react differently when a step was completed versus when it was skipped. This limited the ability to build precise branching logic in multi-step processes.

# Fix / Solution

Add two new task predicate operators — `skipped` and `completed_or_skipped` — and change the existing `completed` operator so it matches only truly completed steps (not skipped ones). Update condition evaluation logic, allowed operator lists, and ancestor resolution for `start_task` conditions to support the new operators. Run a data migration that converts existing `completed` task predicates to `completed_or_skipped` to preserve current workflow behavior.

# Release notes

Task conditions now support two new operators when checking another step's status: **skipped**, and **completed or skipped**. 

# Changes

## API

**Templates**
- `POST /templates` — predicate `operator` accepts `skipped` and `completed_or_skipped` when `field_type` is `task`; `completed` now matches only completed steps; `skipped` and `completed_or_skipped` are allowed in `start_task` conditions
- `PUT /templates/{id}` — same predicate operator changes as create

## Web-client

No changes in this branch.

# Test cases

## API

### POST /templates

| Authorization | Test case | Expected result |
|---|---|---|
| Authenticated admin or account owner, valid subscription | Create a template with a `skip_task` condition; predicate `field_type` is `task`, `operator` is `skipped`, `field` references an ancestor task, `value` is `null` | Status 200; response predicate `operator` is `skipped`, `value` is `null` |
| Authenticated admin or account owner, valid subscription | Create a template with a `skip_task` condition; predicate `field_type` is `task`, `operator` is `completed_or_skipped`, `field` references an ancestor task, `value` is `null` | Status 200; response predicate `operator` is `completed_or_skipped`, `value` is `null` |
| Authenticated admin or account owner, valid subscription | Create a template with a `start_task` condition; predicate `field_type` is `task`, `operator` is `skipped` or `completed_or_skipped`, `field` references a prior task, `value` is `null` | Status 200; response predicate `operator` matches the request; referenced task is treated as an ancestor |
| Authenticated admin or account owner, valid subscription | Create a template with both `start_task` and `skip_task` conditions on the same task using `skipped` or `completed_or_skipped` operator on a task predicate | Status 200; both conditions are saved successfully |
| Authenticated admin or account owner, valid subscription | Create a template with a `skip_task` condition; predicate `field_type` is `task`, `operator` is `completed`, only required predicate fields provided | Status 200; response predicate `operator` is `completed`, `value` is `null` |
| Authenticated admin or account owner, valid subscription | Create a template with a `skip_task` condition; predicate `field_type` is `task`, `operator` is `skipped`, all predicate and template fields provided | Status 200; response contains the saved operator and field values |
| No authentication | Send `POST /templates` without a token | Status 401 |
| Authenticated user, expired subscription | Send `POST /templates` with an expired subscription | Status 403 |
| Authenticated user, billing plan limit exceeded | Send `POST /templates` when the billing plan limit is exceeded | Status 403 |
| Authenticated user, users over limit | Send `POST /templates` when the account has more users than allowed | Status 403 |
| Authenticated non-admin user | Send `POST /templates` as a user who is not admin or account owner | Status 403 |
| Authenticated admin or account owner, valid subscription | Create a template with a `start_task` condition; predicate uses a non-task `field_type` with an incompatible operator (e.g. `equals` on a string field) | Status 400; response body contains MSG_PT_0064 |
| Authenticated admin or account owner, valid subscription | Create a template with a task predicate using an operator not allowed for `field_type` `task` (e.g. `equals`) | Status 400; response body contains MSG_PT_0044 |
| Authenticated admin or account owner, valid subscription | Create a template with a `skip_task` condition; predicate `field` references a task that does not exist in the template | Status 400; response body contains MSG_PT_0067 |
| Authenticated admin or account owner, valid subscription | Create a template with a `skip_task` condition; predicate `field` references a task that is not an ancestor of the current task | Status 400; response body contains MSG_PT_0068 |
| Authenticated admin or account owner, valid subscription | Create a template with a `start_task` condition; predicate `field` references a task that does not exist in the template | Status 400; response body contains MSG_PT_0066 |
| Authenticated admin or account owner, valid subscription | Create a template with a `start_task` condition that creates a circular dependency between tasks | Status 400; response body contains MSG_PT_0065 |

### PUT /templates/{id}

| Authorization | Test case | Expected result |
|---|---|---|
| Authenticated admin or account owner, template owner, valid subscription | Update an existing template; change a task predicate `operator` from `completed` to `skipped` on a `skip_task` condition | Status 200; response and database predicate `operator` is `skipped` |
| Authenticated admin or account owner, template owner, valid subscription | Update an existing template; change a task predicate `operator` from `completed` to `completed_or_skipped` on a `skip_task` condition | Status 200; response and database predicate `operator` is `completed_or_skipped` |
| Authenticated admin or account owner, template owner, valid subscription | Update a template with a task predicate; only required fields provided, `operator` is `skipped`, `value` is `null` | Status 200; response predicate `operator` is `skipped`, `value` is `null` |
| Authenticated admin or account owner, template owner, valid subscription | Update a template with a task predicate; all fields provided, `operator` is `completed_or_skipped` | Status 200; response contains the updated operator and field values |
| No authentication | Send `PUT /templates/{id}` without a token | Status 401 |
| Authenticated user, expired subscription | Send `PUT /templates/{id}` with an expired subscription | Status 403 |
| Authenticated user, billing plan limit exceeded | Send `PUT /templates/{id}` when the billing plan limit is exceeded | Status 403 |
| Authenticated user, users over limit | Send `PUT /templates/{id}` when the account has more users than allowed | Status 403 |
| Authenticated user who is not template admin/owner | Send `PUT /templates/{id}` as a user without template admin/owner access | Status 403 |
| Authenticated admin or account owner, template owner, valid subscription | Update a template with a `skip_task` condition; predicate `field` references a task that does not exist | Status 400; response body contains MSG_PT_0067 |
| Authenticated admin or account owner, template owner, valid subscription | Update a template with a `skip_task` condition; predicate `field` references a task that is not an ancestor | Status 400; response body contains MSG_PT_0068 |
| Authenticated admin or account owner, template owner, valid subscription | Update a template with a task predicate using an operator not allowed for `field_type` `task` | Status 400; response body contains MSG_PT_0044 |
| Authenticated admin or account owner, template owner, valid subscription | Update a template with a `start_task` condition; predicate uses a non-task `field_type` with an incompatible operator | Status 400; response body contains MSG_PT_0064 |

### Runtime condition evaluation (workflow execution)

| Authorization | Test case | Expected result |
|---|---|---|
| N/A (service-level) | Run a workflow where a `skip_task` condition uses `completed` operator and the referenced task is completed | Condition evaluates to `true` |
| N/A (service-level) | Run a workflow where a `skip_task` condition uses `completed` operator and the referenced task is skipped | Condition evaluates to `false` |
| N/A (service-level) | Run a workflow where a `skip_task` condition uses `skipped` operator and the referenced task is skipped | Condition evaluates to `true` |
| N/A (service-level) | Run a workflow where a `skip_task` condition uses `skipped` operator and the referenced task is completed | Condition evaluates to `false` |
| N/A (service-level) | Run a workflow where a `skip_task` condition uses `completed_or_skipped` operator and the referenced task is completed or skipped | Condition evaluates to `true` |
| N/A (service-level) | Run a workflow where a `skip_task` condition uses `completed_or_skipped` operator and the referenced task is still pending | Condition evaluates to `false` |

### Data migration

| Authorization | Test case | Expected result |
|---|---|---|
| N/A (migration) | Apply migration on templates with existing `completed` task predicates | All such predicates are converted to `completed_or_skipped`; workflow behavior is preserved |
| N/A (migration) | Apply migration on template drafts containing `completed` task predicates | Draft JSON predicates are updated to `completed_or_skipped` |

## Web-client

No changes in this branch — web-client test cases are not applicable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workflow condition semantics and runs a broad data migration on predicates and drafts; incorrect migration or evaluation could alter when tasks start or skip.
> 
> **Overview**
> Adds **`skipped`** and **`completed_or_skipped`** task predicate operators and narrows **`completed`** so it only matches truly completed steps (skipped steps no longer satisfy it).
> 
> **Runtime evaluation** (`TaskResolver`) sets the compared value from `is_skipped`, `is_completed`, or their union depending on the operator; comparators gain matching unary methods.
> 
> **Templates API**: task predicates may use the new operators; `start_task` validation accepts all allowed task operators (not only `completed`). **`get_tasks_parents`** treats `skipped` and `completed_or_skipped` like `completed` when wiring **start after** dependencies.
> 
> **Migration** `0253` extends model choices and rewrites existing task predicates (and matching template-draft JSON) from `completed` → `completed_or_skipped` so prior “finished step” behavior is preserved. Test fixtures for auto-linked start conditions default to `completed_or_skipped`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 408e3f5e2cfafe25cff502cc3014e092e9fcb32c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `SKIPPED` and `COMPLETED_OR_SKIPPED` predicate operators for task conditions
> - Adds two new `PredicateOperator` values (`SKIPPED`, `COMPLETED_OR_SKIPPED`) and registers them as unary operators allowed on `TASK` predicates.
> - `TaskResolver._prepare_args` now resolves `field_value` based on the operator: `task.is_skipped` for `SKIPPED`, `task.is_completed` for `COMPLETED`, and `task.is_completed or task.is_skipped` for `COMPLETED_OR_SKIPPED`.
> - `get_tasks_parents` and the `PredicateTemplateSerializer` are updated to treat all three operators as valid parent-detection and `START_TASK`/`SKIP_TASK` operators.
> - A Django migration adds the new choices to `Predicate.operator` and `PredicateTemplate.operator`.
> - Behavioral Change: the default predicate operator in test fixtures changes from `completed` to `completed_or_skipped`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 408e3f5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->