### PR TITLE
40784 frontend [ groups ] User Field Dropdown does not filter user type

### DIFF
--- a/frontend/src/public/components/TaskCard/TaskCard.tsx
+++ b/frontend/src/public/components/TaskCard/TaskCard.tsx
@@ -46,7 +46,7 @@ import { IAuthUser, IWorkflowLog } from '../../types/redux';
 import { WorkflowLog } from '../Workflows/WorkflowLog';
 import { DoneInfoIcon, InfoIcon, PlayLogoIcon, ReturnTaskInfoIcon, ReturnToIcon } from '../icons';
 import { WorkflowLogSkeleton } from '../Workflows/WorkflowLog/WorkflowLogSkeleton';
-import { EOptionTypes, TUsersDropdownOption, UsersDropdown } from '../UI/form/UsersDropdown';
+import { EOptionTypes, TUsersDropdownOption, UsersDropdown, getUsersDropdownOptionValue } from '../UI/form/UsersDropdown';
 import { TUserListItem } from '../../types/user';
 import { trackInviteTeamInPage } from '../../utils/analytics';
 import { Tooltip } from '../UI';
@@ -292,19 +292,22 @@ export function TaskCard({
         ...item,
         optionType: EOptionTypes.User,
         label: getUserFullName(item),
-        value: String(item.id),
+        value: getUsersDropdownOptionValue(EOptionTypes.User, item.id),
       };
     });
 
     const mapPerformersDropdownValue = users.filter((user) =>
-      task.performers.find(({ sourceId }) => user.id === sourceId),
+      task.performers.find(
+        ({ sourceId, type }) =>
+          Number(sourceId) === user.id && type === ETemplateOwnerType.User,
+      ),
     );
     const performerDropdownValue = mapPerformersDropdownValue.map((item) => {
       return {
         ...item,
         optionType: EOptionTypes.User,
         label: getUserFullName(item),
-        value: String(item.id),
+        value: getUsersDropdownOptionValue(EOptionTypes.User, item.id),
       };
     });
 
@@ -314,12 +317,15 @@ export function TaskCard({
         optionType: EOptionTypes.Group,
         type: ETaskPerformerType.UserGroup,
         label: group.name,
-        value: String(group.id),
+        value: getUsersDropdownOptionValue(EOptionTypes.Group, group.id),
       };
     });
 
-    const mapGroupDropdownValue = groups.filter((user) =>
-      task.performers.find(({ sourceId }) => Number(sourceId) === user.id),
+    const mapGroupDropdownValue = groups.filter((group) =>
+      task.performers.find(
+        ({ sourceId, type }) =>
+          Number(sourceId) === group.id && type === ETemplateOwnerType.UserGroup,
+      ),
     );
 
     const performerGroupDropdownValue = mapGroupDropdownValue.map((group) => {
@@ -327,7 +333,7 @@ export function TaskCard({
         ...group,
         optionType: EOptionTypes.Group,
         label: group.name,
-        value: String(group.id),
+        value: getUsersDropdownOptionValue(EOptionTypes.Group, group.id),
       };
     });
 

--- a/frontend/src/public/components/TaskCard/__tests__/TaskCard.test.tsx
+++ b/frontend/src/public/components/TaskCard/__tests__/TaskCard.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 
 import { TaskCard, ETaskCardViewMode } from '../TaskCard';
-import { EExtraFieldType, IExtraField } from '../../../types/template';
+import { EExtraFieldType, ETemplateOwnerType, IExtraField } from '../../../types/template';
 import { ETaskStatus } from '../../../redux/actions';
 import { EWorkflowStatus, EWorkflowsLogSorting } from '../../../types/workflow';
 
@@ -23,9 +23,23 @@ jest.mock('../../../hooks/useCheckDevice', () => ({
   useCheckDevice: () => ({ isMobile: false, isDesktop: true }),
 }));
 
+jest.mock('react-redux', () => ({
+  useSelector: (selector: () => unknown) => selector(),
+}));
+
+jest.mock('../../../redux/selectors/groups', () => ({
+  getRegularGroupsList: () => [{ id: 5, name: 'Group Five', type: 'regular' }],
+}));
+
+const mockUsersDropdown = jest.fn((_props?: unknown) => null);
+
 jest.mock('../../UI/form/UsersDropdown', () => ({
-  UsersDropdown: () => null,
+  UsersDropdown: (props: unknown) => {
+    mockUsersDropdown(props);
+    return null;
+  },
   EOptionTypes: { User: 'user', Group: 'group' },
+  getUsersDropdownOptionValue: (optionType: string, id: number | string) => `${optionType}-${id}`,
 }));
 
 jest.mock('../../../utils/history', () => ({
@@ -251,6 +265,53 @@ const baseProps = {
 describe('TaskCard', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  describe('Performer dropdown', () => {
+    it('does not cross-select user and group performers with the same id', async () => {
+      const task = {
+        ...baseTask,
+        performers: [
+          { sourceId: 5, type: ETemplateOwnerType.User, label: 'John Doe' },
+        ],
+      };
+
+      render(
+        <TaskCard
+          {...baseProps}
+          task={task}
+          authUser={{ ...baseAuthUser, isAdmin: true }}
+          users={[
+            {
+              id: 5,
+              firstName: 'John',
+              lastName: 'Doe',
+              email: 'john@test.com',
+              status: 'active',
+            } as any,
+          ]}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(mockUsersDropdown).toHaveBeenCalled();
+      });
+
+      const lastCall = mockUsersDropdown.mock.calls[mockUsersDropdown.mock.calls.length - 1];
+      const dropdownProps = lastCall?.[0] as {
+        value: Array<{ optionType: string; id: number }>;
+        options: Array<{ optionType: string; id: number; value: string }>;
+      };
+
+      expect(dropdownProps.value).toHaveLength(1);
+      expect(dropdownProps.value[0]).toMatchObject({ optionType: 'user', id: 5 });
+
+      const userOption = dropdownProps.options.find((option) => option.optionType === 'user' && option.id === 5);
+      const groupOption = dropdownProps.options.find((option) => option.optionType === 'group' && option.id === 5);
+
+      expect(userOption?.value).toBe('user-5');
+      expect(groupOption?.value).toBe('group-5');
+    });
   });
 
   describe('Filtering output fields by isHidden', () => {

--- a/frontend/src/public/components/TemplateEdit/ExtraFields/User/ExtraFieldUser.tsx
+++ b/frontend/src/public/components/TemplateEdit/ExtraFields/User/ExtraFieldUser.tsx
@@ -3,7 +3,7 @@ import { ChangeEvent, ReactNode, useCallback } from 'react';
 import classnames from 'classnames';
 import { useSelector } from 'react-redux';
 import { useIntl } from 'react-intl';
-import { EOptionTypes, UsersDropdown } from '../../../UI/form/UsersDropdown';
+import { EOptionTypes, UsersDropdown, getUsersDropdownOptionValue } from '../../../UI/form/UsersDropdown';
 import { getUsers } from '../../../../redux/selectors/user';
 import { EUserDropdownOptionType, TUserListItem } from '../../../../types/user';
 import { trackInviteTeamInPage } from '../../../../utils/analytics';
@@ -87,7 +87,7 @@ export function ExtraFieldUser({
         ...item,
         optionType: EOptionTypes.User,
         label: getUserFullName(item),
-        value: `${EOptionTypes.User}-${item.id}`,
+        value: getUsersDropdownOptionValue(EOptionTypes.User, item.id),
       };
     });
     const groupsDropdownOption = groups.map((item) => {
@@ -95,7 +95,7 @@ export function ExtraFieldUser({
         ...item,
         optionType: EOptionTypes.Group,
         label: item.name,
-        value: `${EOptionTypes.Group}-${item.id}`,
+        value: getUsersDropdownOptionValue(EOptionTypes.Group, item.id),
         type: ETaskPerformerType.UserGroup,
       };
     });
@@ -133,8 +133,8 @@ export function ExtraFieldUser({
           isDisabled={isDisabled}
           value={selectionsDropdownOption.find(
             (item) =>
-              item.value === `${EOptionTypes.User}-${field.userId}` ||
-              item.value === `${EOptionTypes.Group}-${field.groupId}`,
+              item.value === getUsersDropdownOptionValue(EOptionTypes.User, field.userId ?? '') ||
+              item.value === getUsersDropdownOptionValue(EOptionTypes.Group, field.groupId ?? ''),
           )}
           onClickInvite={() => trackInviteTeamInPage('From users field')}
           inviteLabel={formatMessage({ id: 'template.invite-team-member' })}

--- a/frontend/src/public/components/TemplateEdit/ExtraFields/User/__tests__/ExtraFieldUser.test.tsx
+++ b/frontend/src/public/components/TemplateEdit/ExtraFields/User/__tests__/ExtraFieldUser.test.tsx
@@ -20,6 +20,7 @@ jest.mock('react-intl', () => ({
 jest.mock('../../../../UI/form/UsersDropdown', () => ({
   UsersDropdown: jest.fn(() => null),
   EOptionTypes: { User: 'user', Group: 'group' },
+  getUsersDropdownOptionValue: (optionType: string, id: number | string) => `${optionType}-${id}`,
 }));
 
 jest.mock('../../utils/FieldWithName', () => ({

--- a/frontend/src/public/components/TemplateEdit/TaskForm/Conditions/ConditionValueField/ConditionValueField.tsx
+++ b/frontend/src/public/components/TemplateEdit/TaskForm/Conditions/ConditionValueField/ConditionValueField.tsx
@@ -133,13 +133,27 @@ export function ConditionValueField({
   function renderUserField() {
     interface IDropdownUser extends TUserListItem {
       label: string;
+      entityType: 'user' | 'group';
+      value: string;
     }
 
     const activeUsers = users.filter((user) => user.status === EUserStatus.Active);
-    const labelUsers = activeUsers.map((user) => ({ ...user, label: getUserFullName(user), entityType: 'user' }));
-    const labelGroups = groups.map((group) => ({ ...group, label: group.name, entityType: 'group' }));
+    const labelUsers = activeUsers.map((user) => ({
+      ...user,
+      label: getUserFullName(user),
+      entityType: 'user' as const,
+      value: `user-${user.id}`,
+    }));
+    const labelGroups = groups.map((group) => ({
+      ...group,
+      label: group.name,
+      entityType: 'group' as const,
+      value: `group-${group.id}`,
+    }));
     const dropdownEntities = [...labelGroups, ...labelUsers];
-    const selectedEntity = dropdownEntities.find((user) => user.id === Number(rule.value)) || null;
+    const selectedEntity = dropdownEntities.find(
+      (entity) => entity.id === Number(rule.value) && entity.entityType === rule.fieldType,
+    ) || null;
 
     return (
       <DropdownList
@@ -157,7 +171,7 @@ export function ConditionValueField({
           context === 'menu'
             ? getFormattedDropdownOption({
                 label: option.label,
-                isSelected: option.id === rule.value,
+                isSelected: option.id === rule.value && option.entityType === rule.fieldType,
                 isTooltip: true,
               })
             : option.label

--- a/frontend/src/public/components/TemplateEdit/TaskForm/Conditions/ConditionValueField/__tests__/ConditionValueField.test.tsx
+++ b/frontend/src/public/components/TemplateEdit/TaskForm/Conditions/ConditionValueField/__tests__/ConditionValueField.test.tsx
@@ -1,0 +1,45 @@
+/// <reference types="jest" />
+
+type TConditionEntity = {
+  id: number;
+  entityType: 'user' | 'group';
+  value: string;
+};
+
+const buildDropdownEntities = (): TConditionEntity[] => {
+  const labelUsers: TConditionEntity[] = [{ id: 5, entityType: 'user', value: 'user-5' }];
+  const labelGroups: TConditionEntity[] = [{ id: 5, entityType: 'group', value: 'group-5' }];
+
+  return [...labelGroups, ...labelUsers];
+};
+
+const findSelectedEntity = (
+  entities: TConditionEntity[],
+  rule: { value: number; fieldType: 'user' | 'group' },
+) =>
+  entities.find(
+    (entity) => entity.id === Number(rule.value) && entity.entityType === rule.fieldType,
+  ) || null;
+
+describe('ConditionValueField user/group selection logic', () => {
+  const dropdownEntities = buildDropdownEntities();
+
+  it('selects user entity by id and fieldType when user and group share the same id', () => {
+    const selectedEntity = findSelectedEntity(dropdownEntities, { value: 5, fieldType: 'user' });
+
+    expect(selectedEntity).toMatchObject({ id: 5, entityType: 'user' });
+  });
+
+  it('selects group entity by id and fieldType when user and group share the same id', () => {
+    const selectedEntity = findSelectedEntity(dropdownEntities, { value: 5, fieldType: 'group' });
+
+    expect(selectedEntity).toMatchObject({ id: 5, entityType: 'group' });
+  });
+
+  it('does not mark group as selected when only user is chosen', () => {
+    const rule = { value: 5, fieldType: 'user' as const };
+    const groupEntity = dropdownEntities.find((entity) => entity.entityType === 'group');
+
+    expect(groupEntity?.id === rule.value && groupEntity?.entityType === rule.fieldType).toBe(false);
+  });
+});

--- a/frontend/src/public/components/TemplateEdit/TaskForm/TaskPerformers.tsx
+++ b/frontend/src/public/components/TemplateEdit/TaskForm/TaskPerformers.tsx
@@ -8,7 +8,7 @@ import { TUserListItem } from '../../../types/user';
 import { ETaskPerformerType, ITemplateTask, ITemplateTaskPerformer } from '../../../types/template';
 import { TTaskVariable } from '../types';
 import { trackInviteTeamInPage } from '../../../utils/analytics';
-import { TUsersDropdownOption, UsersDropdown } from '../../UI/form/UsersDropdown';
+import { EOptionTypes, TUsersDropdownOption, UsersDropdown, getUsersDropdownOptionValue } from '../../UI/form/UsersDropdown';
 import { getUserFullName } from '../../../utils/users';
 import { getPerformersForDropdown } from './utils/getPerformersForDropdown';
 import { EBgColorTypes, UserPerformer } from '../../UI/UserPerformer';
@@ -41,12 +41,23 @@ export function TaskPerformers({ task, tasks, users, variables, setCurrentTask }
     task,
     tasks,
   );
-  const selectedPerformerOption = rawPerformers.map((user) => {
+  const selectedPerformerOption = rawPerformers.map((performer) => {
+    const getPerformerValue = () => {
+      if (performer.type === ETaskPerformerType.Manager) {
+        return `manager-${performer.sourceId}`;
+      }
+      if (performer.type === ETaskPerformerType.UserGroup) {
+        return getUsersDropdownOptionValue(EOptionTypes.Group, performer.sourceId ?? '');
+      }
+      if (performer.type === ETaskPerformerType.User) {
+        return getUsersDropdownOptionValue(EOptionTypes.User, performer.sourceId ?? '');
+      }
+      return String(performer.sourceId);
+    };
+
     return {
-      ...user,
-      value: user.type === ETaskPerformerType.Manager
-        ? `manager-${user.sourceId}`
-        : String(user.sourceId),
+      ...performer,
+      value: getPerformerValue(),
     };
   });
 

--- a/frontend/src/public/components/TemplateEdit/TaskForm/utils/__tests__/getPerformersForDropdown.test.ts
+++ b/frontend/src/public/components/TemplateEdit/TaskForm/utils/__tests__/getPerformersForDropdown.test.ts
@@ -95,6 +95,19 @@ describe('getPerformersForDropdown', () => {
       expect(managerOptions).toHaveLength(0);
     });
 
+    it('generates unique values for user and group with the same id', () => {
+      const users = [{ id: 5, firstName: 'John', lastName: 'Doe' } as any];
+      const groups = [{ id: 5, name: 'Team A', type: 'regular' } as any];
+
+      const result = getPerformersForDropdown(users, groups, [], intlMock.formatMessage);
+
+      const userOption = result.find((option) => option.optionType === EOptionTypes.User);
+      const groupOption = result.find((option) => option.optionType === EOptionTypes.Group);
+
+      expect(userOption?.value).toBe('user-5');
+      expect(groupOption?.value).toBe('group-5');
+    });
+
     it('Manager option has a unique value with manager- prefix', () => {
       const currentTask = makeTask({ apiName: 'task-2', number: 2 });
       const tasks = [makeTask(), currentTask];

--- a/frontend/src/public/components/TemplateEdit/TaskForm/utils/getPerformersForDropdown.ts
+++ b/frontend/src/public/components/TemplateEdit/TaskForm/utils/getPerformersForDropdown.ts
@@ -3,7 +3,7 @@ import { EExtraFieldType, ETaskPerformerType, ITemplateTask, ITemplateTaskPerfor
 import { TUserListItem } from '../../../../types/user';
 import { getUserFullName } from '../../../../utils/users';
 import { TTaskVariable } from '../../types';
-import { EOptionTypes, TUsersDropdownOption } from '../../../UI/form/UsersDropdown';
+import { EOptionTypes, TUsersDropdownOption, getUsersDropdownOptionValue } from '../../../UI/form/UsersDropdown';
 import { IGroup } from '../../../../redux/team/types';
 
 export function getPerformersForDropdown(
@@ -22,7 +22,7 @@ export function getPerformersForDropdown(
     type: ETaskPerformerType.User,
     sourceId: String(user.id),
     label: getUserFullName(user),
-    value: String(user.id),
+    value: getUsersDropdownOptionValue(EOptionTypes.User, user.id),
   }));
 
   const outputUsersPerformers: TUsersDropdownOption[] = variables
@@ -46,7 +46,7 @@ export function getPerformersForDropdown(
     type: ETaskPerformerType.UserGroup,
     sourceId: String(group.id),
     label: group.name,
-    value: String(group.id),
+    value: getUsersDropdownOptionValue(EOptionTypes.Group, group.id),
   }));
 
   const workflowStarterPerformers: Omit<ITemplateTaskPerformer, 'apiName'> & TUsersDropdownOption = {

--- a/frontend/src/public/components/TemplateEdit/TemplateOwners/TemplateOwners.tsx
+++ b/frontend/src/public/components/TemplateEdit/TemplateOwners/TemplateOwners.tsx
@@ -7,7 +7,7 @@ import { ESubscriptionPlan } from '../../../types/account';
 import { createOwnerApiName } from '../../../utils/createId';
 import { trackInviteTeamInPage } from '../../../utils/analytics';
 import { getNotDeletedUsers, getUserFullName } from '../../../utils/users';
-import { EOptionTypes, TUsersDropdownOption, UsersDropdown } from '../../UI/form/UsersDropdown';
+import { EOptionTypes, TUsersDropdownOption, UsersDropdown, getUsersDropdownOptionValue } from '../../UI/form/UsersDropdown';
 import { getIsUserSubsribed, getSubscriptionPlan, getUsers } from '../../../redux/selectors/user';
 import { ETaskPerformerType, ETemplateOwnerRole, ETemplateOwnerType, ITemplate, ITemplateOwner } from '../../../types/template';
 import OwnerItem from './components';
@@ -48,7 +48,7 @@ export function TemplateOwners({ templateOwners = [], onChangeTemplateOwners }: 
       optionType: EOptionTypes.Group,
       type: ETaskPerformerType.UserGroup,
       label: group.name,
-      value: `${EOptionTypes.Group}-${group.id}`,
+      value: getUsersDropdownOptionValue(EOptionTypes.Group, group.id),
     };
   });
 
@@ -59,7 +59,7 @@ export function TemplateOwners({ templateOwners = [], onChangeTemplateOwners }: 
       lastName: '',
       optionType: EOptionTypes.User,
       label: getUserFullName(item),
-      value: `${EOptionTypes.User}-${item.id}`,
+      value: getUsersDropdownOptionValue(EOptionTypes.User, item.id),
     };
   });
 
@@ -73,7 +73,7 @@ export function TemplateOwners({ templateOwners = [], onChangeTemplateOwners }: 
       ...item,
       optionType: EOptionTypes.User,
       label: getUserFullName(item),
-      value: `${EOptionTypes.User}-${item.id}`,
+      value: getUsersDropdownOptionValue(EOptionTypes.User, item.id),
     };
   });
 
@@ -82,7 +82,7 @@ export function TemplateOwners({ templateOwners = [], onChangeTemplateOwners }: 
       ...item,
       optionType: EOptionTypes.Group,
       label: item.name,
-      value: `${EOptionTypes.Group}-${item.id}`,
+      value: getUsersDropdownOptionValue(EOptionTypes.Group, item.id),
     };
   });
 

--- a/frontend/src/public/components/TemplateEdit/TemplateStarters/TemplateStarters.tsx
+++ b/frontend/src/public/components/TemplateEdit/TemplateStarters/TemplateStarters.tsx
@@ -7,7 +7,7 @@ import { ESubscriptionPlan } from '../../../types/account';
 import { createStarterApiName } from '../../../utils/createId';
 import { trackInviteTeamInPage } from '../../../utils/analytics';
 import { getNotDeletedUsers, getUserFullName } from '../../../utils/users';
-import { EOptionTypes, TUsersDropdownOption, UsersDropdown } from '../../UI/form/UsersDropdown';
+import { EOptionTypes, TUsersDropdownOption, UsersDropdown, getUsersDropdownOptionValue } from '../../UI/form/UsersDropdown';
 import { getIsUserSubsribed, getSubscriptionPlan, getUsers } from '../../../redux/selectors/user';
 import {
   ETaskPerformerType,
@@ -55,7 +55,7 @@ export function TemplateStarters({ templateStarters = [], onChangeTemplateStarte
       optionType: EOptionTypes.Group,
       type: ETaskPerformerType.UserGroup,
       label: group.name,
-      value: `${EOptionTypes.Group}-${group.id}`,
+      value: getUsersDropdownOptionValue(EOptionTypes.Group, group.id),
     };
   });
 
@@ -66,7 +66,7 @@ export function TemplateStarters({ templateStarters = [], onChangeTemplateStarte
       lastName: '',
       optionType: EOptionTypes.User,
       label: getUserFullName(item),
-      value: `${EOptionTypes.User}-${item.id}`,
+      value: getUsersDropdownOptionValue(EOptionTypes.User, item.id),
     };
   });
 
@@ -80,7 +80,7 @@ export function TemplateStarters({ templateStarters = [], onChangeTemplateStarte
       ...item,
       optionType: EOptionTypes.User,
       label: getUserFullName(item),
-      value: `${EOptionTypes.User}-${item.id}`,
+      value: getUsersDropdownOptionValue(EOptionTypes.User, item.id),
     };
   });
 
@@ -89,7 +89,7 @@ export function TemplateStarters({ templateStarters = [], onChangeTemplateStarte
       ...item,
       optionType: EOptionTypes.Group,
       label: item.name,
-      value: `${EOptionTypes.Group}-${item.id}`,
+      value: getUsersDropdownOptionValue(EOptionTypes.Group, item.id),
     };
   });
 

--- a/frontend/src/public/components/TemplateEdit/TemplateViewers/TemplateViewers.tsx
+++ b/frontend/src/public/components/TemplateEdit/TemplateViewers/TemplateViewers.tsx
@@ -7,7 +7,7 @@ import { ESubscriptionPlan } from '../../../types/account';
 import { createViewerApiName } from '../../../utils/createId';
 import { trackInviteTeamInPage } from '../../../utils/analytics';
 import { getNotDeletedUsers, getUserFullName } from '../../../utils/users';
-import { EOptionTypes, TUsersDropdownOption, UsersDropdown } from '../../UI/form/UsersDropdown';
+import { EOptionTypes, TUsersDropdownOption, UsersDropdown, getUsersDropdownOptionValue } from '../../UI/form/UsersDropdown';
 import { getIsUserSubsribed, getSubscriptionPlan, getUsers } from '../../../redux/selectors/user';
 import {
   ETaskPerformerType,
@@ -55,7 +55,7 @@ export function TemplateViewers({ templateViewers = [], onChangeTemplateViewers 
       optionType: EOptionTypes.Group,
       type: ETaskPerformerType.UserGroup,
       label: group.name,
-      value: `${EOptionTypes.Group}-${group.id}`,
+      value: getUsersDropdownOptionValue(EOptionTypes.Group, group.id),
     };
   });
 
@@ -66,7 +66,7 @@ export function TemplateViewers({ templateViewers = [], onChangeTemplateViewers 
       lastName: '',
       optionType: EOptionTypes.User,
       label: getUserFullName(item),
-      value: `${EOptionTypes.User}-${item.id}`,
+      value: getUsersDropdownOptionValue(EOptionTypes.User, item.id),
     };
   });
 
@@ -80,7 +80,7 @@ export function TemplateViewers({ templateViewers = [], onChangeTemplateViewers 
       ...item,
       optionType: EOptionTypes.User,
       label: getUserFullName(item),
-      value: `${EOptionTypes.User}-${item.id}`,
+      value: getUsersDropdownOptionValue(EOptionTypes.User, item.id),
     };
   });
 
@@ -89,7 +89,7 @@ export function TemplateViewers({ templateViewers = [], onChangeTemplateViewers 
       ...item,
       optionType: EOptionTypes.Group,
       label: item.name,
-      value: `${EOptionTypes.Group}-${item.id}`,
+      value: getUsersDropdownOptionValue(EOptionTypes.Group, item.id),
     };
   });
 

--- a/frontend/src/public/components/UI/Select/FilterSelect.tsx
+++ b/frontend/src/public/components/UI/Select/FilterSelect.tsx
@@ -54,6 +54,7 @@ interface IFilterSelectCommonProps<
   Icon?(props: SVGAttributes<SVGElement>): JSX.Element;
   renderPlaceholder(options: TOption[]): string | JSX.Element;
   positionFixed?: boolean;
+  getOptionSelectionKey?: (option: TOption) => TOptionId;
 }
 
 interface IFilterSelectMultiOptionsProps {
@@ -107,8 +108,10 @@ export function FilterSelect<
     selectedOption,
     renderPlaceholder,
     positionFixed = false,
+    getOptionSelectionKey,
   } = props;
   const allOptions = flatGroupedOptions || options;
+  const getSelectionKey = getOptionSelectionKey ?? ((option: TOption) => option[optionIdKey]);
   const [searchText, setSearchText] = useState('');
   const [isSelectAll, setIsSelectAll] = useState(false);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
@@ -124,6 +127,7 @@ export function FilterSelect<
     }
 
     const optionId = option[optionIdKey];
+    const selectionKey = getSelectionKey(option);
 
     if (!isMultiple) {
       onChange(optionId);
@@ -131,13 +135,13 @@ export function FilterSelect<
       return;
     }
 
-    const newIsChecked = !selectedOptions.includes(optionId);
+    const newIsChecked = !selectedOptions.includes(selectionKey);
 
     const newSelectedOptions = newIsChecked
-      ? [...selectedOptions, optionId]
-      : selectedOptions.filter((selectedOptionElement) => selectedOptionElement !== optionId);
+      ? [...selectedOptions, selectionKey]
+      : selectedOptions.filter((selectedOptionElement) => selectedOptionElement !== selectionKey);
 
-    const mapSelectedOption = allOptions.filter((item) => newSelectedOptions.includes(item[optionIdKey]));
+    const mapSelectedOption = allOptions.filter((item) => newSelectedOptions.includes(getSelectionKey(item)));
 
     onChange(newSelectedOptions, mapSelectedOption);
 
@@ -254,7 +258,7 @@ export function FilterSelect<
         if (!isSelectAll) {
           setIsSelectAll(true);
           onChange(
-            allOptions.map((option) => option[optionIdKey]),
+            allOptions.map((option) => getSelectionKey(option)),
             allOptions,
           );
         } else {
@@ -312,7 +316,7 @@ export function FilterSelect<
             >
               {isMultiple && typeof option !== 'string' ? (
                 <Checkbox
-                  checked={selectedOptions.includes(option[optionIdKey])}
+                  checked={selectedOptions.includes(getSelectionKey(option))}
                   title={label}
                   onClick={(e) => e.stopPropagation()}
                   onChange={() => {}}

--- a/frontend/src/public/components/UI/Select/__tests__/FilterSelect.test.tsx
+++ b/frontend/src/public/components/UI/Select/__tests__/FilterSelect.test.tsx
@@ -1,0 +1,28 @@
+/// <reference types="jest" />
+
+type TTestOption = {
+  id: number;
+  displayName: string;
+  type: string;
+};
+
+const getSelectionKey = (option: TTestOption) => `${option.type}-${option.id}`;
+
+describe('FilterSelect selection key logic', () => {
+  it('does not treat user and group with the same id as the same selected option', () => {
+    const selectedOptions = ['user-5'];
+    const groupOption: TTestOption = { id: 5, displayName: 'Group Five', type: 'group' };
+
+    expect(selectedOptions.includes(getSelectionKey(groupOption))).toBe(false);
+  });
+
+  it('adds group selection without removing user selection when ids collide', () => {
+    const selectedOptions = ['user-5'];
+    const groupOption: TTestOption = { id: 5, displayName: 'Group Five', type: 'group' };
+    const selectionKey = getSelectionKey(groupOption);
+
+    const newSelectedOptions = [...selectedOptions, selectionKey];
+
+    expect(newSelectedOptions).toEqual(['user-5', 'group-5']);
+  });
+});

--- a/frontend/src/public/components/UI/form/UsersDropdown/UsersDropdown.tsx
+++ b/frontend/src/public/components/UI/form/UsersDropdown/UsersDropdown.tsx
@@ -197,8 +197,6 @@ export function UsersDropdownComponent<TOption extends TUsersDropdownOption>({
     );
   };
 
-  console.log(normalizedOptions);
-
   return (
     <DropdownList
       isMulti={isMulti}

--- a/frontend/src/public/components/UI/form/UsersDropdown/UsersDropdown.tsx
+++ b/frontend/src/public/components/UI/form/UsersDropdown/UsersDropdown.tsx
@@ -8,6 +8,8 @@ import { BoldPlusIcon } from '../../../icons';
 import { ETaskPerformerType } from '../../../../types/template';
 import { getUserById } from '../../../UserData/utils/getUserById';
 
+import { isUsersDropdownOptionSelected } from './usersDropdownOptionValue';
+
 import styles from './UsersDropdown.css';
 
 export enum EOptionTypes {
@@ -149,7 +151,7 @@ export function UsersDropdownComponent<TOption extends TUsersDropdownOption>({
 
     if (formatOptionLabel) return formatOptionLabel(option, formatOptionLabelMeta);
 
-    const isSelected = !!formatOptionLabelMeta.selectValue.find((item: any) => item.value === option.value);
+    const isSelected = isUsersDropdownOptionSelected(formatOptionLabelMeta.selectValue, option);
 
     const renderLabel = () => {
       const currentUser: TUserListItem | TUsersDropdownOption | null =
@@ -194,6 +196,8 @@ export function UsersDropdownComponent<TOption extends TUsersDropdownOption>({
       </div>
     );
   };
+
+  console.log(normalizedOptions);
 
   return (
     <DropdownList

--- a/frontend/src/public/components/UI/form/UsersDropdown/__tests__/usersDropdownOptionValue.test.ts
+++ b/frontend/src/public/components/UI/form/UsersDropdown/__tests__/usersDropdownOptionValue.test.ts
@@ -1,0 +1,46 @@
+/// <reference types="jest" />
+import { EOptionTypes } from '../UsersDropdown';
+import {
+  getUsersDropdownOptionValue,
+  isUsersDropdownOptionEqual,
+  isUsersDropdownOptionSelected,
+} from '../usersDropdownOptionValue';
+
+describe('usersDropdownOptionValue', () => {
+  it('generates prefixed value for user and group', () => {
+    expect(getUsersDropdownOptionValue(EOptionTypes.User, 5)).toBe('user-5');
+    expect(getUsersDropdownOptionValue(EOptionTypes.Group, 5)).toBe('group-5');
+  });
+
+  it('compares options by optionType and id', () => {
+    expect(
+      isUsersDropdownOptionEqual(
+        { optionType: EOptionTypes.User, id: 5 },
+        { optionType: EOptionTypes.Group, id: 5 },
+      ),
+    ).toBe(false);
+
+    expect(
+      isUsersDropdownOptionEqual(
+        { optionType: EOptionTypes.User, id: 5 },
+        { optionType: EOptionTypes.User, id: 5 },
+      ),
+    ).toBe(true);
+  });
+
+  it('does not cross-match user and group with the same id when checking selection', () => {
+    const selected = [{ optionType: EOptionTypes.User, id: 5, value: 'user-5' }];
+    const userOption = { optionType: EOptionTypes.User, id: 5, value: 'user-5' };
+    const groupOption = { optionType: EOptionTypes.Group, id: 5, value: 'group-5' };
+
+    expect(isUsersDropdownOptionSelected(selected, userOption)).toBe(true);
+    expect(isUsersDropdownOptionSelected(selected, groupOption)).toBe(false);
+  });
+
+  it('falls back to value comparison for backward compatibility', () => {
+    const selected = [{ optionType: EOptionTypes.User, id: 1, value: 'legacy-value' }];
+    const option = { optionType: EOptionTypes.Group, id: 99, value: 'legacy-value' };
+
+    expect(isUsersDropdownOptionSelected(selected, option)).toBe(true);
+  });
+});

--- a/frontend/src/public/components/UI/form/UsersDropdown/index.ts
+++ b/frontend/src/public/components/UI/form/UsersDropdown/index.ts
@@ -1,4 +1,5 @@
 /* eslint-disable */
 /* prettier-ignore */
 export * from './UsersDropdown';
+export * from './usersDropdownOptionValue';
 export * from './container';

--- a/frontend/src/public/components/UI/form/UsersDropdown/usersDropdownOptionValue.ts
+++ b/frontend/src/public/components/UI/form/UsersDropdown/usersDropdownOptionValue.ts
@@ -1,0 +1,19 @@
+import { EOptionTypes, TUsersDropdownOption } from './UsersDropdown';
+
+export const getUsersDropdownOptionValue = (optionType: EOptionTypes, id: number | string): string =>
+  `${optionType}-${id}`;
+
+export const isUsersDropdownOptionEqual = (
+  a: Pick<TUsersDropdownOption, 'optionType' | 'id'>,
+  b: Pick<TUsersDropdownOption, 'optionType' | 'id'>,
+): boolean => a.optionType === b.optionType && a.id === b.id;
+
+export const isUsersDropdownOptionSelected = (
+  selectedOptions: ReadonlyArray<Pick<TUsersDropdownOption, 'optionType' | 'id' | 'value'>>,
+  option: Pick<TUsersDropdownOption, 'optionType' | 'id' | 'value'>,
+): boolean =>
+  selectedOptions.some(
+    (item) =>
+      isUsersDropdownOptionEqual(item, option) ||
+      (item.value !== undefined && option.value !== undefined && item.value === option.value),
+  );

--- a/frontend/src/public/layout/WorkflowsLayout/PerformerFilterSelect.tsx
+++ b/frontend/src/public/layout/WorkflowsLayout/PerformerFilterSelect.tsx
@@ -95,6 +95,8 @@ export function PerformerFilterSelect() {
   const isOneFilterId = filterIds.length === 1;
   const filterType = isOneFilterId && performersIdsFilter.length === 1 ? 'userType' : 'groupType';
 
+  console.log(performersGroupOptions, performersOptions);
+
   return (
     <div className={styles['performer-filter']}>
       <FilterSelect
@@ -103,9 +105,13 @@ export function PerformerFilterSelect() {
         isSearchShown
         placeholderText={formatMessage({ id: 'workflows.filter-no-user' })}
         searchPlaceholder={formatMessage({ id: 'sorting.search-placeholder' })}
-        selectedOptions={[...performersGroupIdsFilter, ...performersIdsFilter]}
+        selectedOptions={[
+          ...performersGroupIdsFilter.map((id) => `${ETemplateOwnerType.UserGroup}-${id}`),
+          ...performersIdsFilter.map((id) => `${ETemplateOwnerType.User}-${id}`),
+        ]}
         optionIdKey="id"
         optionLabelKey="displayName"
+        getOptionSelectionKey={(opt) => `${opt.type}-${opt.id}`}
         options={[...performersGroupOptions, ...performersOptions]}
         onChange={(_, options: any) => {
           const performers = options

--- a/frontend/src/public/layout/WorkflowsLayout/PerformerFilterSelect.tsx
+++ b/frontend/src/public/layout/WorkflowsLayout/PerformerFilterSelect.tsx
@@ -95,8 +95,6 @@ export function PerformerFilterSelect() {
   const isOneFilterId = filterIds.length === 1;
   const filterType = isOneFilterId && performersIdsFilter.length === 1 ? 'userType' : 'groupType';
 
-  console.log(performersGroupOptions, performersOptions);
-
   return (
     <div className={styles['performer-filter']}>
       <FilterSelect


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches many UI selection paths (tasks, templates, workflow filters); behavior is localized to frontend with legacy value fallback, but wrong mapping could still affect who is assigned or filtered until selections are refreshed.
> 
> **Overview**
> Fixes **user vs. group dropdown collisions** when both share the same numeric ID by using **type-prefixed option values** (e.g. `user-5` / `group-5`) and matching selections on **option type + id**, not id alone.
> 
> Adds shared helpers in `usersDropdownOptionValue` (`getUsersDropdownOptionValue`, `isUsersDropdownOptionSelected`) and wires them through **`UsersDropdown`**, task/template performer pickers (**`TaskCard`**, **`TaskPerformers`**, owners/starters/viewers**, **`ExtraFieldUser`**), **`getPerformersForDropdown`**, and **condition user/group** values in **`ConditionValueField`**.
> 
> **`FilterSelect`** gains optional **`getOptionSelectionKey`** for multi-select; **`PerformerFilterSelect`** uses prefixed keys so workflow performer filters don’t conflate user and group with the same id. Tests cover the collision scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6740090b43d5d5ecf1fc59d507a6a40c3e2bcacf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix user/group cross-selection in dropdowns when user and group share the same ID
> - Introduces `getUsersDropdownOptionValue` in [usersDropdownOptionValue.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/229/files#diff-fc4a21fd6703b3e7c5ed1b9f5aea43defdc4421e06f11624f415f783e3f65cdc) to build type-prefixed values (e.g. `user-5` vs `group-5`), replacing raw numeric ID strings across all user/group dropdowns.
> - Applies prefixed values in `TaskCard`, `TaskPerformers`, `TemplateOwners`, `TemplateStarters`, `TemplateViewers`, `ExtraFieldUser`, `ConditionValueField`, and `getPerformersForDropdown` so selected state no longer collides when a user and group share the same ID.
> - Adds an optional `getOptionSelectionKey` prop to `FilterSelect` to support composite selection identity, used by `PerformerFilterSelect` to distinguish performers by type+id.
> - Behavioral Change: all dropdown option values now carry a type prefix; components relying on raw numeric ID equality for selection will need to adopt the new helpers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6740090.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->