### PR TITLE
15984 frontend [ tasks ] Filters dropdowns - Show preloader

### DIFF
--- a/frontend/src/public/components/UI/Select/FilterSelect.tsx
+++ b/frontend/src/public/components/UI/Select/FilterSelect.tsx
@@ -1,4 +1,5 @@
-import React, { ChangeEvent, ReactNode, SVGAttributes, useState } from 'react';
+import * as React from 'react';
+import { ChangeEvent, ReactNode, SVGAttributes, useState } from 'react';
 import classnames from 'classnames';
 import * as PerfectScrollbar from 'react-perfect-scrollbar';
 import { DropdownItem, DropdownMenu, DropdownToggle, Dropdown } from 'reactstrap';
@@ -12,6 +13,9 @@ import { Checkbox, InputField } from '..';
 import styles from './Select.css';
 
 const ScrollBar = PerfectScrollbar as unknown as Function;
+
+const DROPDOWN_SKELETON_ROW_COUNT = 5;
+const DROPDOWN_SKELETON_WIDTHS = ['80%', '60%', '80%', '60%', '70%'];
 
 type TOptionId = number | string | null;
 export type TOptionBase<IdKey extends string, LabelKey extends string> = {
@@ -149,7 +153,7 @@ export function FilterSelect<
   };
 
   const renderSearchInput = () => {
-    if (!isSearchShown) {
+    if (!isSearchShown || isLoading) {
       return null;
     }
 
@@ -345,11 +349,29 @@ export function FilterSelect<
     setSearchText('');
   };
 
-  if (isLoading) {
-    const loaderClassName = classnames('dropdown-menu-right ml-sm-4 dropdown');
+  const renderDropdownSkeleton = () => (
+    <div className={styles['dropdown-menu__skeleton']}>
+      {Array.from({ length: DROPDOWN_SKELETON_ROW_COUNT }, (_, index) => (
+        <div
+          key={index}
+          className={classnames(
+            styles['dropdown-menu__skeleton-item'],
+            index === DROPDOWN_SKELETON_ROW_COUNT - 1 && styles['dropdown-menu__skeleton-item_last'],
+          )}
+        >
+          <Skeleton display="block" height="2.4rem" width={DROPDOWN_SKELETON_WIDTHS[index]} />
+        </div>
+      ))}
+    </div>
+  );
 
-    return <Skeleton className={loaderClassName} />;
-  }
+  const renderDropdownContent = () => {
+    if (isLoading) {
+      return renderDropdownSkeleton();
+    }
+
+    return renderDropdownList();
+  };
 
   return (
     <OutsideClickHandler disabled={!isDropdownOpen} onOutsideClick={handleToggleDropdown}>
@@ -423,7 +445,7 @@ export function FilterSelect<
             className={styles['dropdown-menu__scrollbar']}
             options={{ suppressScrollX: true, wheelPropagation: false }}
           >
-            {renderDropdownList()}
+            {renderDropdownContent()}
           </ScrollBar>
         </DropdownMenu>
       </Dropdown>

--- a/frontend/src/public/components/UI/Select/Select.css
+++ b/frontend/src/public/components/UI/Select/Select.css
@@ -261,3 +261,15 @@
   @mixin text-small-extra bold;
   @mixin text-truncate;
 }
+
+.dropdown-menu__skeleton {
+  padding: 0.4rem 1.2rem;
+}
+
+.dropdown-menu__skeleton-item {
+  margin-bottom: 0.8rem;
+}
+
+.dropdown-menu__skeleton-item_last {
+  margin-bottom: 0;
+}

--- a/frontend/src/public/components/UI/Select/__tests__/FilterSelect.test.tsx
+++ b/frontend/src/public/components/UI/Select/__tests__/FilterSelect.test.tsx
@@ -1,0 +1,102 @@
+/* eslint-disable */
+import * as React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+jest.mock('reactstrap', () => ({
+  Dropdown: ({ children, isOpen }: { children: React.ReactNode; isOpen: boolean }) => (
+    <div data-testid="dropdown" data-open={isOpen}>
+      {children}
+    </div>
+  ),
+  DropdownToggle: ({ children, ...props }: { children: React.ReactNode }) => (
+    <button type="button" data-testid="filter-select-toggle" {...props}>
+      {children}
+    </button>
+  ),
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <div role="menu">{children}</div>,
+  DropdownItem: ({
+    children,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+  }) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+jest.mock('react-perfect-scrollbar', () => {
+  const Scrollbar = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+  Object.assign(Scrollbar, { __esModule: true, default: Scrollbar });
+  return Scrollbar;
+});
+
+jest.mock('react-outside-click-handler', () => {
+  const OutsideClick = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+  return {
+    __esModule: true,
+    default: OutsideClick,
+  };
+});
+
+jest.mock('../../../icons', () => ({
+  ClearIcon: () => null,
+  ExpandIcon: () => null,
+}));
+
+jest.mock('../../Fields/Checkbox', () => ({
+  Checkbox: ({ title }: { title: React.ReactNode }) => <label>{title}</label>,
+}));
+
+jest.mock('../../Fields/InputField', () => ({
+  InputField: () => <input />,
+}));
+
+const defaultProps = {
+  options: [] as { id: number; name: string }[],
+  optionIdKey: 'id' as const,
+  optionLabelKey: 'name' as const,
+  placeholderText: 'No items found',
+  selectedOption: null,
+  resetFilter: jest.fn(),
+  onChange: jest.fn(),
+  renderPlaceholder: () => 'All templates',
+};
+
+const openDropdown = () => {
+  fireEvent.click(screen.getByTestId('filter-select-toggle'));
+};
+
+describe('FilterSelect', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { FilterSelect } = require('../FilterSelect') as typeof import('../FilterSelect');
+
+  it('shows skeleton rows in dropdown menu when isLoading is true', () => {
+    const { container } = render(<FilterSelect {...defaultProps} isLoading />);
+
+    openDropdown();
+
+    expect(screen.queryByText('No items found')).not.toBeInTheDocument();
+    expect(container.querySelectorAll('.dropdown-menu__skeleton-item').length).toBe(5);
+  });
+
+  it('shows options in dropdown menu when isLoading is false', () => {
+    render(
+      <FilterSelect
+        {...defaultProps}
+        options={[
+          { id: 1, name: 'Template A' },
+          { id: 2, name: 'Template B' },
+        ]}
+      />,
+    );
+
+    openDropdown();
+
+    expect(screen.getByText('Template A')).toBeInTheDocument();
+    expect(screen.getByText('Template B')).toBeInTheDocument();
+    expect(screen.queryByText('No items found')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/public/layout/TasksLayout/TasksLayout.tsx
+++ b/frontend/src/public/layout/TasksLayout/TasksLayout.tsx
@@ -31,6 +31,8 @@ export interface ITasksLayoutStoreProps {
   sorting: ETaskListSorting | ETaskListCompleteSorting;
   filterTemplates: ITemplateTitleBaseWithCount[];
   filterSteps: ITemplateStep[];
+  areFilterTemplatesLoading: boolean;
+  areFilterStepsLoading: boolean;
   templateIdFilter: number | null;
   taskApiNameFilter: string | null;
   completionStatus: ETaskListCompletionStatus;
@@ -55,6 +57,8 @@ export function TasksLayoutComponent({
   sorting,
   filterTemplates,
   filterSteps,
+  areFilterTemplatesLoading,
+  areFilterStepsLoading,
   templateIdFilter,
   taskApiNameFilter,
   completionStatus,
@@ -171,6 +175,7 @@ export function TasksLayoutComponent({
           />
           <div className={styles['template-filter']}>
             <FilterSelect
+              isLoading={areFilterTemplatesLoading}
               isSearchShown
               noValueLabel={formatMessage({ id: 'sorting.all-templates' })}
               placeholderText={formatMessage({ id: 'sorting.no-template-found' })}
@@ -191,6 +196,7 @@ export function TasksLayoutComponent({
           {templateIdFilter && (
             <div className={styles['step-filter']}>
               <FilterSelect
+                isLoading={areFilterStepsLoading}
                 isSearchShown
                 noValueLabel={formatMessage({ id: 'sorting.all-steps' })}
                 placeholderText={formatMessage({ id: 'sorting.no-step-found' })}

--- a/frontend/src/public/layout/TasksLayout/container.ts
+++ b/frontend/src/public/layout/TasksLayout/container.ts
@@ -31,6 +31,8 @@ const mapStateToProps = ({
     sorting,
     filterTemplates: templateList.items,
     filterSteps: templateStepList.items,
+    areFilterTemplatesLoading: templateList.isLoading,
+    areFilterStepsLoading: templateStepList.isLoading,
     templateIdFilter,
     taskApiNameFilter,
     completionStatus,

--- a/frontend/src/public/layout/WorkflowsLayout/TaskFilterSelect.tsx
+++ b/frontend/src/public/layout/WorkflowsLayout/TaskFilterSelect.tsx
@@ -40,6 +40,8 @@ export function TaskFilterSelect({ selectedTemplates }: { selectedTemplates: ITe
 
   const mustDisableFilter = !isArrayWithItems(templatesIdsFilter) || !canFilterByTemplateStep(statusFilter);
 
+  const areStepsLoading = selectedTemplates.some((template) => template.areStepsLoading);
+
   const groupedSteps: IGroupedTasksMap | null = useMemo(() => {
     if (selectedTemplates.length === 0) {
       return new Map();
@@ -68,6 +70,7 @@ export function TaskFilterSelect({ selectedTemplates }: { selectedTemplates: ITe
   return (
     <FilterSelect
       isDisabled={mustDisableFilter}
+      isLoading={!mustDisableFilter && areStepsLoading}
       isMultiple
       isSearchShown
       placeholderText={formatMessage({ id: 'workflows.filter-no-step' })}

--- a/frontend/src/public/layout/WorkflowsLayout/TemplateFilterSelect.tsx
+++ b/frontend/src/public/layout/WorkflowsLayout/TemplateFilterSelect.tsx
@@ -15,6 +15,7 @@ import styles from './WorkflowsLayout.css';
 
 import {
   getWorkflowsStatus,
+  getWorkflowTemplateListIsLoading,
   getWorkflowTemplateListItems,
   getWorkflowTemplatesIdsFilter,
 } from '../../redux/selectors/workflows';
@@ -26,6 +27,7 @@ export function TemplateFilterSelect() {
   const dispatch = useDispatch();
   const templatesIdsFilter = useSelector(getWorkflowTemplatesIdsFilter);
   const filterTemplates = useSelector(getWorkflowTemplateListItems);
+  const areFilterTemplatesLoading = useSelector(getWorkflowTemplateListIsLoading);
   const statusFilter = useSelector(getWorkflowsStatus);
 
   const { isMobile } = useCheckDevice();
@@ -40,6 +42,7 @@ export function TemplateFilterSelect() {
   return (
     <div className={styles['template-filter']}>
       <FilterSelect
+        isLoading={areFilterTemplatesLoading}
         isMultiple
         isSearchShown
         placeholderText={formatMessage({ id: 'sorting.no-template-found' })}

--- a/frontend/src/public/redux/selectors/tasks.ts
+++ b/frontend/src/public/redux/selectors/tasks.ts
@@ -19,3 +19,9 @@ export const getTasksSorting = (state: IApplicationState): ETaskListSorting | ET
 export const getTotalTasksCount = (state: IApplicationState): number | null => {
   return state.tasks.tasksCount;
 };
+
+export const getTasksFilterTemplatesIsLoading = (state: IApplicationState): boolean =>
+  state.tasks.tasksSettings.templateList.isLoading;
+
+export const getTasksFilterStepsIsLoading = (state: IApplicationState): boolean =>
+  state.tasks.tasksSettings.templateStepList.isLoading;

--- a/frontend/src/public/redux/selectors/workflows.ts
+++ b/frontend/src/public/redux/selectors/workflows.ts
@@ -36,6 +36,9 @@ export const getLastLoadedTemplateIdForTable = (state: IApplicationState): strin
 export const getWorkflowTemplateListItems = (state: IApplicationState): ITemplateFilterItem[] =>
   state.workflows.workflowsSettings.templateList.items;
 
+export const getWorkflowTemplateListIsLoading = (state: IApplicationState): boolean =>
+  state.workflows.workflowsSettings.templateList.isLoading;
+
 export const getWorkflowsStatus = (state: IApplicationState): EWorkflowsStatus =>
   state.workflows.workflowsSettings.values.statusFilter;
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only loading states and selectors; no auth, API, or data-model changes.
> 
> **Overview**
> **FilterSelect** now shows a **five-row skeleton inside the open dropdown** while `isLoading` is true, instead of replacing the whole control with a single skeleton. The search field is **hidden during loading**, and the toggle stays usable so users can open the menu and see the placeholder.
> 
> **Tasks** and **Workflows** filter dropdowns pass through existing Redux `isLoading` state (template lists and step lists), including new selectors for workflows template list loading and tasks filter loading flags wired via `TasksLayout` container.
> 
> Adds skeleton styles in `Select.css` and **unit tests** for loading vs loaded dropdown content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bb0dbd8e0fa215d65f697a41f1b9f75efb27374. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show skeleton preloader inside filter dropdowns while data is loading
> - Replaces the single full-control skeleton in `FilterSelect` with a list of 5 skeleton rows rendered inside the open dropdown menu while `isLoading` is true; the search input is hidden during loading.
> - Adds CSS classes in [Select.css](https://github.com/pneumaticapp/pneumaticworkflow/pull/230/files#diff-266d0e0cfa338a0d3b19fe8e8e4c04fdc23e2e37aa4a560cd980e3c42bc09171) to style skeleton row spacing within the dropdown menu.
> - Wires `isLoading` into the template and step filter dropdowns in both [TasksLayout](https://github.com/pneumaticapp/pneumaticworkflow/pull/230/files#diff-8fc77258a36524fc7ff46d4122657aec684d1dafaf681d728227e456b0261cf3) and [WorkflowsLayout](https://github.com/pneumaticapp/pneumaticworkflow/pull/230/files#diff-b4382551b99d68c2f6b6a753dcb45b98affd443e48f2488a7ad7c5230990f80e), sourced from new Redux selectors for `templateList.isLoading` and `templateStepList.isLoading`.
> - Behavioral Change: the filter dropdown control stays open and interactive while loading instead of being replaced by a placeholder skeleton.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8bb0dbd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->