### PR TITLE
47293 frontend [ conditions ] Add Completed or skipped predicate operator

### DIFF
--- a/frontend/src/public/components/TemplateEdit/TaskForm/Conditions/Conditions.css
+++ b/frontend/src/public/components/TemplateEdit/TaskForm/Conditions/Conditions.css
@@ -117,6 +117,10 @@
   }
 }
 
+.condition-rule__operator-menu {
+  min-width: max-content;
+}
+
 .condition-rule__value {
   flex-basis: 0;
   flex-grow: 1;

--- a/frontend/src/public/components/TemplateEdit/TaskForm/Conditions/Predicate.tsx
+++ b/frontend/src/public/components/TemplateEdit/TaskForm/Conditions/Predicate.tsx
@@ -120,6 +120,7 @@ export function Predicate({
                 }}
                 isClearable={false}
                 options={dropdownOperators}
+                classNames={{ menu: () => styles['condition-rule__operator-menu'] }}
                 formatOptionLabel={(option: IDropdownOperator, { context }) =>
                   context === 'menu'
                     ? getFormattedDropdownOption({

--- a/frontend/src/public/components/TemplateEdit/TaskForm/Conditions/StartAfterCondition.tsx
+++ b/frontend/src/public/components/TemplateEdit/TaskForm/Conditions/StartAfterCondition.tsx
@@ -101,6 +101,7 @@ export function StartAfterCondition({ startingOrder, conditions, variables, isSu
                 dropdownOperators={dropdownOperators}
                 handleRemoveRule={handleRemoveRule}
                 options={options}
+                isCheckIs
               />
             );
           })}

--- a/frontend/src/public/components/TemplateEdit/TaskForm/Conditions/types.ts
+++ b/frontend/src/public/components/TemplateEdit/TaskForm/Conditions/types.ts
@@ -62,6 +62,7 @@ export enum EConditionOperators {
   MoreThan = 'more_than',
   LessThan = 'less_than',
   Completed = 'completed',
+  Skipped = 'skipped',
 }
 
 export enum EConditionLogicOperations {

--- a/frontend/src/public/components/TemplateEdit/TaskForm/Conditions/types.ts
+++ b/frontend/src/public/components/TemplateEdit/TaskForm/Conditions/types.ts
@@ -63,6 +63,7 @@ export enum EConditionOperators {
   LessThan = 'less_than',
   Completed = 'completed',
   Skipped = 'skipped',
+  CompletedOrSkipped = 'completed_or_skipped',
 }
 
 export enum EConditionLogicOperations {

--- a/frontend/src/public/components/TemplateEdit/TaskForm/Conditions/utils/__tests__/getDropdownOperators.test.ts
+++ b/frontend/src/public/components/TemplateEdit/TaskForm/Conditions/utils/__tests__/getDropdownOperators.test.ts
@@ -1,0 +1,95 @@
+import { EConditionOperators } from '../../types';
+import {
+  conditionsByFieldTypeMap,
+  EStartingType,
+  getDropdownOperators,
+  IDropdownOperator,
+  labelByOperatorMap,
+} from '../getDropdownOperators';
+import { CONDITION_DISABLED_OPERATOR, OPERATORS_WITHOUT_VALUE } from '../shared';
+
+describe('getDropdownOperators', () => {
+  const mockMessages: Record<string, string> = {
+    'templates.conditions.completed': 'Completed',
+    'templates.conditions.skipped': 'Skipped',
+    'templates.conditions.completed-or-skipped': 'Completed or Skipped',
+    'templates.conditions.equal': 'Equals',
+    'templates.conditions.not-equal': 'Not equals',
+    'templates.conditions.exist': 'Filled in',
+    'templates.conditions.not-exist': 'Not filled in',
+    'templates.conditions.contain': 'Contains',
+    'templates.conditions.not-contain': 'Not contains',
+    'templates.conditions.more-than': 'More than',
+    'templates.conditions.less-than': 'Less than',
+  };
+
+  describe('conditionsByFieldTypeMap', () => {
+    it('includes Completed, Skipped and CompletedOrSkipped for EStartingType.Task', () => {
+      const taskOperators = conditionsByFieldTypeMap[EStartingType.Task];
+
+      expect(taskOperators).toEqual([
+        EConditionOperators.Completed,
+        EConditionOperators.Skipped,
+        EConditionOperators.CompletedOrSkipped,
+      ]);
+    });
+
+    it('includes only Completed for EStartingType.Kickoff', () => {
+      const kickoffOperators = conditionsByFieldTypeMap[EStartingType.Kickoff];
+
+      expect(kickoffOperators).toEqual([EConditionOperators.Completed]);
+    });
+  });
+
+  describe('labelByOperatorMap', () => {
+    it('maps Skipped to the correct intl key', () => {
+      expect(labelByOperatorMap[EConditionOperators.Skipped]).toBe('templates.conditions.skipped');
+    });
+
+    it('maps CompletedOrSkipped to the correct intl key', () => {
+      expect(labelByOperatorMap[EConditionOperators.CompletedOrSkipped]).toBe(
+        'templates.conditions.completed-or-skipped',
+      );
+    });
+  });
+
+  describe('getDropdownOperators()', () => {
+    it('returns 3 operators with correct labels for Task', () => {
+      const result: IDropdownOperator[] = getDropdownOperators(EStartingType.Task, mockMessages);
+
+      expect(result).toHaveLength(3);
+      expect(result).toEqual([
+        { operator: EConditionOperators.Completed, label: mockMessages['templates.conditions.completed'] },
+        { operator: EConditionOperators.Skipped, label: mockMessages['templates.conditions.skipped'] },
+        { operator: EConditionOperators.CompletedOrSkipped, label: mockMessages['templates.conditions.completed-or-skipped'] },
+      ]);
+    });
+
+    it('returns only Completed for Kickoff', () => {
+      const result: IDropdownOperator[] = getDropdownOperators(EStartingType.Kickoff, mockMessages);
+
+      expect(result).toHaveLength(1);
+      expect(result).toEqual([
+        { operator: EConditionOperators.Completed, label: mockMessages['templates.conditions.completed'] },
+      ]);
+    });
+  });
+});
+
+describe('OPERATORS_WITHOUT_VALUE', () => {
+  it('contains all operators that do not require a value', () => {
+    expect(OPERATORS_WITHOUT_VALUE).toEqual([
+      EConditionOperators.Exist,
+      EConditionOperators.NotExist,
+      EConditionOperators.Completed,
+      EConditionOperators.Skipped,
+      EConditionOperators.CompletedOrSkipped,
+    ]);
+  });
+});
+
+describe('CONDITION_DISABLED_OPERATOR', () => {
+  it('contains only Kickoff (Task is no longer disabled)', () => {
+    expect(CONDITION_DISABLED_OPERATOR).toEqual([EStartingType.Kickoff]);
+  });
+});

--- a/frontend/src/public/components/TemplateEdit/TaskForm/Conditions/utils/getDropdownOperators.ts
+++ b/frontend/src/public/components/TemplateEdit/TaskForm/Conditions/utils/getDropdownOperators.ts
@@ -81,7 +81,7 @@ export const conditionsByFieldTypeMap: { [key in EExtraFieldType]: EConditionOpe
     EConditionOperators.Exist,
     EConditionOperators.NotExist,
   ],
-  [EStartingType.Task]: [EConditionOperators.Completed, EConditionOperators.Skipped],
+  [EStartingType.Task]: [EConditionOperators.Completed, EConditionOperators.Skipped, EConditionOperators.CompletedOrSkipped],
   [EStartingType.Kickoff]: [EConditionOperators.Completed],
 };
 
@@ -96,6 +96,7 @@ export const labelByOperatorMap: { [key in EConditionOperators]: string } = {
   [EConditionOperators.MoreThan]: 'templates.conditions.more-than',
   [EConditionOperators.Completed]: 'templates.conditions.completed',
   [EConditionOperators.Skipped]: 'templates.conditions.skipped',
+  [EConditionOperators.CompletedOrSkipped]: 'templates.conditions.completed-or-skipped',
 };
 
 export function getDropdownOperators(

--- a/frontend/src/public/components/TemplateEdit/TaskForm/Conditions/utils/getDropdownOperators.ts
+++ b/frontend/src/public/components/TemplateEdit/TaskForm/Conditions/utils/getDropdownOperators.ts
@@ -81,7 +81,7 @@ export const conditionsByFieldTypeMap: { [key in EExtraFieldType]: EConditionOpe
     EConditionOperators.Exist,
     EConditionOperators.NotExist,
   ],
-  [EStartingType.Task]: [EConditionOperators.Completed],
+  [EStartingType.Task]: [EConditionOperators.Completed, EConditionOperators.Skipped],
   [EStartingType.Kickoff]: [EConditionOperators.Completed],
 };
 
@@ -95,6 +95,7 @@ export const labelByOperatorMap: { [key in EConditionOperators]: string } = {
   [EConditionOperators.LessThan]: 'templates.conditions.less-than',
   [EConditionOperators.MoreThan]: 'templates.conditions.more-than',
   [EConditionOperators.Completed]: 'templates.conditions.completed',
+  [EConditionOperators.Skipped]: 'templates.conditions.skipped',
 };
 
 export function getDropdownOperators(

--- a/frontend/src/public/components/TemplateEdit/TaskForm/Conditions/utils/shared.tsx
+++ b/frontend/src/public/components/TemplateEdit/TaskForm/Conditions/utils/shared.tsx
@@ -35,13 +35,13 @@ interface IGetDropdownStepsProps {
 }
 
 export const CONDITION_DISABLED_OPERATOR: (EStartingType | EExtraFieldType)[] = [
-  EStartingType.Task,
-  EStartingType.Kickoff,
+  EStartingType.Kickoff
 ];
 export const OPERATORS_WITHOUT_VALUE = [
   EConditionOperators.Exist,
   EConditionOperators.NotExist,
   EConditionOperators.Completed,
+  EConditionOperators.Skipped,
 ];
 
 export const handleAddNewCondition = ({

--- a/frontend/src/public/components/TemplateEdit/TaskForm/Conditions/utils/shared.tsx
+++ b/frontend/src/public/components/TemplateEdit/TaskForm/Conditions/utils/shared.tsx
@@ -42,6 +42,7 @@ export const OPERATORS_WITHOUT_VALUE = [
   EConditionOperators.NotExist,
   EConditionOperators.Completed,
   EConditionOperators.Skipped,
+  EConditionOperators.CompletedOrSkipped,
 ];
 
 export const handleAddNewCondition = ({

--- a/frontend/src/public/lang/locales/en_US.ts
+++ b/frontend/src/public/lang/locales/en_US.ts
@@ -757,6 +757,7 @@ export const enMessages = {
   'templates.conditions.less-than': 'Less than',
   'templates.conditions.more-than': 'More than',
   'templates.conditions.completed': 'Completed',
+  'templates.conditions.skipped': 'Skipped',
   'templates.conditions.field-placeholder': 'if',
   'templates.conditions.operator-placeholder': 'is',
   'templates.conditions.value-placeholder': 'value',

--- a/frontend/src/public/lang/locales/en_US.ts
+++ b/frontend/src/public/lang/locales/en_US.ts
@@ -758,6 +758,7 @@ export const enMessages = {
   'templates.conditions.more-than': 'More than',
   'templates.conditions.completed': 'Completed',
   'templates.conditions.skipped': 'Skipped',
+  'templates.conditions.completed-or-skipped': 'Completed or Skipped',
   'templates.conditions.field-placeholder': 'if',
   'templates.conditions.operator-placeholder': 'is',
   'templates.conditions.value-placeholder': 'value',

--- a/frontend/src/public/lang/locales/ru_RU.ts
+++ b/frontend/src/public/lang/locales/ru_RU.ts
@@ -611,6 +611,7 @@ export const ruMessages = {
   'template.kick-off-form-delete-component': 'Удалить',
   'template.kick-off-form-workflow-name': 'Название процесса:',
   'templates.conditions.completed': 'Завершено',
+  'templates.conditions.skipped': 'Пропущено',
   'templates.conditions.starting-order': 'порядок запуска',
   'templates.conditions.starting-order.kick-off': 'Входные данные',
   'templates.conditions.variables-completed': 'Заполненные переменные',

--- a/frontend/src/public/lang/locales/ru_RU.ts
+++ b/frontend/src/public/lang/locales/ru_RU.ts
@@ -612,6 +612,7 @@ export const ruMessages = {
   'template.kick-off-form-workflow-name': 'Название процесса:',
   'templates.conditions.completed': 'Завершено',
   'templates.conditions.skipped': 'Пропущено',
+  'templates.conditions.completed-or-skipped': 'Завершено или пропущено',
   'templates.conditions.starting-order': 'порядок запуска',
   'templates.conditions.starting-order.kick-off': 'Входные данные',
   'templates.conditions.variables-completed': 'Заполненные переменные',


### PR DESCRIPTION
### 1. Release notes

In the template editor, the "Check If" and "Start After" blocks now display three operators when a task is selected in the "Starting Order" field: **Completed**, **Skipped**, and **Completed or Skipped**. Previously, only the "Completed" operator was available for tasks.

---

### 2. Context

- Ticket: **#47293** (frontend), depends on **#47292** (backend — new `completed_or_skipped` predicate type).
- Location in the app: **Template Editor → Task Form → "Check If" and "Start After" sections** → operator dropdown when a task is selected in the Starting Order field.
- Backend part (migration `0253`, enum, serializer, comparator, resolver) is included in the branch.

---

### 3. Solution

- Added two new operators `Skipped` and `CompletedOrSkipped` to the `EConditionOperators` enum.
- The operator dropdown for tasks (Task) now shows 3 options instead of 1: `Completed`, `Skipped`, `Completed or Skipped`.
- For Kickoff — still only `Completed` (disabled).
- Task was removed from `CONDITION_DISABLED_OPERATOR` — the operator dropdown for tasks is now **enabled** (user selects manually).
- Fixed operator dropdown menu width (CSS `min-width: max-content`) to prevent long options from being clipped.

---

### 4. Implementation details

**`types.ts` — enum EConditionOperators:**
- **Before:** 9 values (up to `Completed`)
- **After:** 11 values — added `Skipped = 'skipped'` and `CompletedOrSkipped = 'completed_or_skipped'`

**`getDropdownOperators.ts` — operator mapping by field type:**
- **Before:** `[EStartingType.Task]: [EConditionOperators.Completed]`
- **After:** `[EStartingType.Task]: [Completed, Skipped, CompletedOrSkipped]`
- **Before:** `labelByOperatorMap` — 9 entries
- **After:** 11 entries — added mappings for `Skipped` and `CompletedOrSkipped` to intl keys

**`shared.tsx` — constants:**
- **Before:** `CONDITION_DISABLED_OPERATOR = [Task, Kickoff]`
- **After:** `CONDITION_DISABLED_OPERATOR = [Kickoff]` — Task removed so the operator dropdown for tasks is enabled
- **Before:** `OPERATORS_WITHOUT_VALUE = [Exist, NotExist, Completed]`
- **After:** added `Skipped` and `CompletedOrSkipped` — these operators also don't require a value input

**`Predicate.tsx` / `StartAfterCondition.tsx`:**
- Added CSS class `condition-rule__operator-menu` for correct operator menu width

**`Conditions.css`:**
- Added rule `.condition-rule__operator-menu { min-width: max-content; }` — prevents clipping of long options

**Localization (en_US.ts, ru_RU.ts):**
- Added keys `templates.conditions.skipped` and `templates.conditions.completed-or-skipped` for both languages

---

### 5. Testing

#### 5.1 Preconditions

- Dev environment, frontend and backend running
- Template with at least 3 tasks
- Desktop Chromium

#### 5.2 Positive scenarios

| Scenario | Description (steps and expected result) | Verified by Developer (desktop) | Verified by Developer (mobile) | Verified by AI Agent (Chromium) |
| :--- | :--- | :--- | :--- | :--- |
| **Check If — 3 operators for task** | Open template → Task 3 → Check If → add rule → select a task (Task 1 or Task 2) → operator dropdown should show: Completed, Skipped, Completed or Skipped | [ ] | [ ] | [ ] |
| **Check If — select Skipped** | In the scenario above → select "Skipped" operator → operator displays correctly, value field does not appear | [ ] | [ ] | [ ] |
| **Check If — select Completed or Skipped** | In the scenario above → select "Completed or Skipped" → operator displays without clipping, value field does not appear | [ ] | [ ] | [ ] |
| **Start After — 3 operators for task** | Open template → Task 4 → Start After → add rule → select a task → operator dropdown shows: Completed, Skipped, Completed or Skipped |[ ] | [ ] | [ ] |
| **Kickoff — only Completed** | Check If → select Kickoff in Starting Order field → operator dropdown is disabled, shows "Completed" | [ ] | [ ] | [ ] |
| **Template save** | Select Completed or Skipped operator → save template → reload page → operator is persisted | [ ] | [ ] | [ ] |
| **Localization EN** | Switch to English → operators display as: "Completed", "Skipped", "Completed or Skipped" | [ ] | [ ] | [ ] |
| **Localization RU** | Switch to Russian → operators display correctly in Russian | [ ] | [ ] | [ ] |

#### 5.3 Negative scenarios

| Scenario | Description (steps and expected result) | Verified by Developer (desktop) | Verified by Developer (mobile) | Verified by AI Agent (Chromium) |
| :--- | :--- | :--- | :--- | :--- |
| **Switch task to another** | Check If → select Task 1, operator Skipped → switch to Task 2 → operator resets, needs to be re-selected | [ ] | [ ] | [ ] |
| **Switch task to Kickoff** | Check If → select Task, operator Completed or Skipped → switch to Kickoff → operator automatically becomes Completed, dropdown disabled | [ ] | [ ] | [ ] |

#### 5.4 Verification points

- In UI: operator dropdown shows correct options depending on selected type (Task / Kickoff)
- Operator menu width does not clip long options (especially "Completed or Skipped")

#### 5.5 Not tested

- Backend predicate processing logic (covered separately in #47292)
- Load testing
- Safari, Firefox, Mobile (handed off to QA)

---

### 6. Unit tests

Added new test file `getDropdownOperators.test.ts` (95 lines, 8 tests):

- **conditionsByFieldTypeMap:** Task contains [Completed, Skipped, CompletedOrSkipped]; Kickoff — only [Completed]
- **labelByOperatorMap:** Skipped and CompletedOrSkipped map to correct intl keys
- **getDropdownOperators():** returns 3 operators with correct labels for Task; 1 for Kickoff
- **OPERATORS_WITHOUT_VALUE:** contains Exist, NotExist, Completed, Skipped, CompletedOrSkipped
- **CONDITION_DISABLED_OPERATOR:** contains only Kickoff (Task removed)

---

### 7. Commits

| SHA | Message |
|-----|---------|
| `fcacac9a` | `47293 feat(check if): add skipped operator to task conditions in template editor` |
| `f8aca7ee` | `47293 feat(conditions): add completed_or_skipped operator and fix operator dropdown menu width` |
| `51fb5911` | `47293 test(conditions): add unit tests for skipped and completed_or_skipped operators` |
| `5c805f8d` | `47292 feat(conditions): add a new predicate type "completed_or_skipped"` (backend) |


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how start/skip conditions are authored and persisted for workflows; behavior at runtime depends on matching backend support (#47292).
> 
> **Overview**
> Adds **Skipped** and **Completed or Skipped** as task predicate operators in the template editor for **Check If** and **Start After** when a prior task is selected in starting order, instead of only **Completed**.
> 
> Task-type rules now use an **enabled** operator dropdown with three choices; kickoff rules stay locked to **Completed**. The new operators are treated like other completion predicates (no value field). Operator menu styling uses `min-width: max-content` so long labels are not clipped. **Start After** passes `isCheckIs` so the operator control renders there as well.
> 
> EN/RU copy and unit tests cover dropdown mappings, `OPERATORS_WITHOUT_VALUE`, and `CONDITION_DISABLED_OPERATOR` (kickoff only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cf9e910eb222858227ceef250c5185c2b7b17bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 'Skipped' and 'Completed or Skipped' predicate operators for task conditions
> - Adds `Skipped` and `CompletedOrSkipped` to `EConditionOperators` and exposes them in the task condition operator dropdown via `conditionsByFieldTypeMap`.
> - Both new operators require no value; selecting them clears any existing value via `OPERATORS_WITHOUT_VALUE`.
> - Removes `EStartingType.Task` from `CONDITION_DISABLED_OPERATOR`, so task starting type is no longer locked out of operator selection.
> - Adds English and Russian i18n labels for the new operators, and applies a `min-width: max-content` CSS fix to the operator dropdown menu to prevent label truncation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6cf9e91.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->