### PR TITLE
47550 frontend [ error ] fix message for users

### DIFF
--- a/frontend/src/public/api/__tests__/getResponseErrorMessage.test.ts
+++ b/frontend/src/public/api/__tests__/getResponseErrorMessage.test.ts
@@ -54,16 +54,8 @@ function makeAxiosError(data: unknown, status: number): AxiosError {
   } as AxiosError;
 }
 
-function makeNetworkError(message: string): AxiosError {
-  return {
-    message,
-    isAxiosError: true,
-    name: 'AxiosError',
-    toJSON: () => ({}),
-  } as AxiosError;
-}
 
-describe('response interceptor: Error.message for Sentry', () => {
+describe('response interceptor: payload propagation to InterceptorError', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -78,16 +70,6 @@ describe('response interceptor: Error.message for Sentry', () => {
     });
   });
 
-  it('falls back to JSON.stringify with status when payload has no message field', async () => {
-    const error = makeAxiosError({ detail: 'Not found.' }, 404);
-
-    await expect(responseErrorHandler(error)).rejects.toMatchObject({
-      message: JSON.stringify({ detail: 'Not found.', status: 404 }),
-      detail: 'Not found.',
-      status: 404,
-    });
-  });
-
   it('uses plain text from response.data as Error.error property', async () => {
     const error = makeAxiosError('Internal Server Error', 500);
 
@@ -95,20 +77,6 @@ describe('response interceptor: Error.message for Sentry', () => {
       error: 'Internal Server Error',
       status: 500,
     });
-  });
-
-  it('falls back to JSON.stringify with status when payload has no message or detail', async () => {
-    const error = makeAxiosError({ code: 'ERR_001' }, 422);
-
-    const rejected = responseErrorHandler(error);
-    await expect(rejected).rejects.toHaveProperty('message', JSON.stringify({ code: 'ERR_001', status: 422 }));
-  });
-
-  it('never produces empty Error.message', async () => {
-    const error = makeAxiosError({}, 500);
-
-    await expect(responseErrorHandler(error)).rejects.toHaveProperty('message');
-    await expect(responseErrorHandler(error)).rejects.not.toHaveProperty('message', '');
   });
 
   it('preserves all payload properties on the rejected Error', async () => {
@@ -120,25 +88,5 @@ describe('response interceptor: Error.message for Sentry', () => {
       status: 400,
     });
   });
-
-  it('uses Axios error.message when response is absent (network error)', async () => {
-    const error = makeNetworkError('Network Error');
-
-    await expect(responseErrorHandler(error)).rejects.toHaveProperty('message', 'Network Error');
-  });
-
-  it('uses Axios error.message on timeout (no response)', async () => {
-    const error = makeNetworkError('timeout of 10000ms exceeded');
-
-    await expect(responseErrorHandler(error)).rejects.toHaveProperty('message', 'timeout of 10000ms exceeded');
-  });
-
-  it('never produces empty message for network errors without response', async () => {
-    const error = makeNetworkError('');
-
-    const rejected = responseErrorHandler(error);
-    await expect(rejected).rejects.toHaveProperty('message');
-    await expect(responseErrorHandler(error)).rejects.not.toHaveProperty('message', '');
-    await expect(responseErrorHandler(error)).rejects.not.toHaveProperty('message', '{}');
-  });
 });
+

--- a/frontend/src/public/api/commonRequest.ts
+++ b/frontend/src/public/api/commonRequest.ts
@@ -109,13 +109,6 @@ axiosInstance.interceptors.response.use(
     const payload = typeof data === 'string' ? { error: data } : data ?? {};
     const rejectedError = Object.assign(new InterceptorError(), payload, { status: error.response?.status });
 
-    if (!rejectedError.message) {
-      const hasPayloadData = Object.keys(payload).length > 0;
-      rejectedError.message = hasPayloadData
-        ? JSON.stringify({ ...payload, status: error.response?.status })
-        : error.message || 'Request failed';
-    }
-
     return Promise.reject(rejectedError);
   },
 );


### PR DESCRIPTION
## 1. Release notes

Fixed: technical data (raw JSON or HTML) no longer appears in user-facing error notifications. When an API request fails, users now see a neutral "Something Went Wrong" message instead of server response internals.

---

## 2. Problem description

When the server responded with an error containing an HTML page or a JSON object without a `message` field, the notification toast displayed raw technical content — full HTML or JSON like `{"detail":"Not found.","status":404}`.

**Where it occurred:** any API error notification (toasts) triggered from sagas via `NotificationManager.notifyApiError`.

---

## 3. Context

- Part of the Sentry noise reduction series (PR1–PR3)
- PR #2 introduced an `if (!rejectedError.message)` block with `JSON.stringify` to ensure Sentry events had an informative message. However, the same message was passed to `NotificationManager` and displayed to users.
- Sentry continues to receive full technical context via `logger.error('Response Error:', status, responseData)` in the interceptor — this mechanism was not changed.

---

## 4. Solution

Removed the block that forced `Error.message` to be populated with a JSON-serialized payload. Now:
- Technical error context reaches Sentry via `logger.error` in the interceptor (unchanged)
- `InterceptorError.message` remains empty when the API payload has no `message` field
- `getErrorMessage()` returns `UNKNOWN_ERROR` ("Something Went Wrong") when `message` is empty — the toast shows a neutral message

---

## 5. Implementation details

**Before:**
```ts
if (!rejectedError.message) {
  const hasPayloadData = Object.keys(payload).length > 0;
  rejectedError.message = hasPayloadData
    ? JSON.stringify({ ...payload, status: error.response?.status })
    : error.message || 'Request failed';
}
```
A response `{"detail":"Not found."}` with status 404 → `message = '{"detail":"Not found.","status":404}'` → shown to the user in the toast.

**After:**
Block removed. `InterceptorError.message` is populated only via `Object.assign(new InterceptorError(), payload)` — meaning only when the API explicitly returns a `message` field (e.g. `{"message":"Validation failed"}`). Otherwise `message` is empty and `getErrorMessage` returns `UNKNOWN_ERROR`.

---

## 6. What to test

### 6.1 Preconditions

- Authenticated user in dev environment
- Any API request that returns an error (e.g. navigating to a non-existent template page)

### 6.2 Positive scenarios

| Scenario | Description | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| :--- | :--- | :--- | :--- | :--- | :--- |
| **404 error** | Open a page for a non-existent resource. Expect toast "Something Went Wrong" — no JSON or HTML in the text | [ ] | [ ] | [ ] | [ ] |
| **Network error** | Disconnect internet, trigger any API request. Expect toast "Something Went Wrong" — no technical text | [ ] | [ ] | [ ] | [ ] |
| **API with message field** | Trigger an error where backend returns `{"message":"Validation failed"}`. Expect toast with text "Validation failed" | [ ] | [ ] | [ ] | [ ] |

### 6.3 Negative scenarios

| Scenario | Description | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| :--- | :--- | :--- | :--- | :--- | :--- |
| **HTML in response body** | Trigger a Django 404 page response. Verify HTML does **not** appear in the toast | [ ] | [ ] | [ ] | [ ] |
| **JSON without message** | Response like `{"detail":"Not found.","code":"404"}`. Verify JSON does **not** appear in the toast | [ ] | [ ] | [ ] | [ ] |

### 6.4 Verification points

- Error toast contains no technical data (HTML, JSON, error codes)
- In Sentry (dev), the event contains full technical details (via interceptor logger)
- Browser console: `Response Error: 404 [html/json]` is expected — this is technical logging only

### 6.6 What was NOT tested

- Production environment (tested in dev only)
- Locales not verified
- Saga logger duplication ("No error message" in Sentry) — identified, planned in PR #3-A

---

## 9. Unit tests

Updated `src/public/api/__tests__/getResponseErrorMessage.test.ts`:
- Removed 6 tests that verified outdated behavior (`JSON.stringify` fallback, "never empty message", Axios message for network errors)
- Kept 3 tests covering actual `Object.assign` behavior: payload.message is preserved, string data maps to `error` field, all payload fields are copied
- Renamed `describe` from `Error.message for Sentry` to `payload propagation to InterceptorError`

---

## 10. Commits

- `fix: remove technical JSON payload from InterceptorError message`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared request error shaping used across the public frontend; callers that only read `error.message` may show emptier or less friendly text for responses without a `message` field.
> 
> **Overview**
> **Stops rewriting `Error.message` in the public API axios response interceptor** so callers get the API payload as-is on `InterceptorError`, instead of auto-filled strings like `JSON.stringify({ ...payload, status })` or generic Axios/network fallbacks.
> 
> Rejected errors are still built with `Object.assign(new InterceptorError(), payload, { status })` (string bodies become `{ error: data }`). When the body has no `message`, `message` is no longer forced—UI code that reads `detail`, `error`, or other fields should show user-facing text instead of a synthetic blob.
> 
> Tests in `getResponseErrorMessage.test.ts` are narrowed to **payload propagation** (message from body, plain text as `error`, extra fields preserved); cases for JSON fallback, non-empty message guarantees, and network/timeout `message` are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 536fccf8077773e398c790325cb84af800cdbae9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove synthesized error message fallback from Axios response interceptor
> Removes the logic in [commonRequest.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/236/files#diff-7d429e9cf8c4d29682c46cd3b707ccee5ef9388cdcddfbdbe8be6b034c1378aa) that populated `message` on `InterceptorError` when the server payload lacked one. Previously, missing messages were filled with a JSON-stringified payload+status or a fallback string (`'Request failed'`). Now the `message` field is left `undefined` if the server does not provide one.
>
> - Risk: consumers that relied on `error.message` always being a non-empty string will now receive `undefined` for non-JSON or empty error responses.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 536fccf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->