### PR TITLE
🔧 47561 frontend [ UI ] Banner in the Team section

### DIFF
--- a/frontend/src/public/components/TaskCard/GuestsController/GuestsController.tsx
+++ b/frontend/src/public/components/TaskCard/GuestsController/GuestsController.tsx
@@ -76,7 +76,7 @@ IGuestControllerProps
         <div className={styles['help']}>
           {formatMessage({id: 'task.add-guest-help-text'})}{' '}
           <a
-            href="https://support.pneumatic.app/en/articles/6145048-free-external-users"
+            href="https://support.pneumatic.app/articles/6145048-free-external-users"
             target="_blank"
             className={styles['link']}
           >

--- a/frontend/src/public/components/Team/Groups/AddGuestsBanner/AddGuestsBanner.tsx
+++ b/frontend/src/public/components/Team/Groups/AddGuestsBanner/AddGuestsBanner.tsx
@@ -12,7 +12,7 @@ export function AddGuestsBanner() {
       lsKey={ADD_GUESTS_BANNER_LS_KEY}
       text={formatMessage({ id: 'team.add-groups-banner-text' })}
       buttonText={formatMessage({ id: 'team.add-groups-banner-button' })}
-      link="https://support.pneumatic.app/en/articles/10837733-user-groups"
+      link="https://support.pneumatic.app/articles/10837733-user-groups"
     />
   );
 }

--- a/frontend/src/public/components/Team/Groups/AddGuestsBanner/AddGuestsBanner.tsx
+++ b/frontend/src/public/components/Team/Groups/AddGuestsBanner/AddGuestsBanner.tsx
@@ -2,14 +2,14 @@ import * as React from 'react';
 import { useIntl } from 'react-intl';
 import { Banner } from '../../../UI/Banner';
 
-const ADD_GUESTS_BANNER_LS_KEY = 'addGuestsBanner';
+const ADD_GROUPS_BANNER_LS_KEY = 'addGroupsBanner';
 
 export function AddGuestsBanner() {
   const { formatMessage } = useIntl();
 
   return (
     <Banner
-      lsKey={ADD_GUESTS_BANNER_LS_KEY}
+      lsKey={ADD_GROUPS_BANNER_LS_KEY}
       text={formatMessage({ id: 'team.add-groups-banner-text' })}
       buttonText={formatMessage({ id: 'team.add-groups-banner-button' })}
       link="https://support.pneumatic.app/articles/10837733-user-groups"

--- a/frontend/src/public/components/Team/Groups/Groups.tsx
+++ b/frontend/src/public/components/Team/Groups/Groups.tsx
@@ -103,8 +103,8 @@ export function Groups() {
 
   return (
     <div className={styles['container']}>
-      <PageTitle titleId={EPageTitle.Team} withUnderline={false} />
       <AddGuestsBanner />
+      <PageTitle titleId={EPageTitle.Team} withUnderline={false} />
       <section className={styles['search']}>{renderSearch()}</section>
       <AddButton
         title={formatMessage({ id: 'team.groups.add-group.title' })}

--- a/frontend/src/public/components/Team/Users/AddGuestsBanner/AddGuestsBanner.tsx
+++ b/frontend/src/public/components/Team/Users/AddGuestsBanner/AddGuestsBanner.tsx
@@ -12,7 +12,7 @@ export function AddGuestsBanner() {
       lsKey={ADD_GUESTS_BANNER_LS_KEY}
       text={formatMessage({ id: 'team.add-guests-banner-text' })}
       buttonText={formatMessage({ id: 'team.add-guests-banner-button' })}
-      link="https://support.pneumatic.app/en/articles/6145048-free-external-users"
+      link="https://support.pneumatic.app/articles/6145048-free-external-users"
     />
   );
 }

--- a/frontend/src/public/components/TemplateEdit/ConditionsBanner/ConditionsBanner.tsx
+++ b/frontend/src/public/components/TemplateEdit/ConditionsBanner/ConditionsBanner.tsx
@@ -12,7 +12,7 @@ export function ConditionsBanner() {
       lsKey={CONDITIONS_BANNER_LS_KEY}
       text={formatMessage({ id: 'templates.conditions-banner-text' })}
       buttonText={formatMessage({ id: 'templates.conditions-banner-button' })}
-      link="https://support.pneumatic.app/en/articles/5249989-conditional-workflow-logic"
+      link="https://support.pneumatic.app/articles/5249989-conditional-workflow-logic"
     />
   );
 }

--- a/frontend/src/public/components/TemplateEdit/InfoWarningsModal/warnings.tsx
+++ b/frontend/src/public/components/TemplateEdit/InfoWarningsModal/warnings.tsx
@@ -16,11 +16,11 @@ export function UnassignedTasksWarning() {
   const links = [
     {
       title: 'How to invite your team',
-      url: 'https://support.pneumatic.app/en/articles/5579977-inviting-your-team-to-pneumatic',
+      url: 'https://support.pneumatic.app/articles/5579977-inviting-your-team-to-pneumatic',
     },
     {
       title: 'How to add free external users',
-      url: 'https://support.pneumatic.app/en/articles/6145048-free-external-users',
+      url: 'https://support.pneumatic.app/articles/6145048-free-external-users',
     },
   ];
 

--- a/frontend/src/public/constants/defaultValues.ts
+++ b/frontend/src/public/constants/defaultValues.ts
@@ -121,16 +121,16 @@ export const enum EPageTitle {
 }
 
 export const enum ELearnMoreLinks {
-  Tasks = 'https://support.pneumatic.app/en/articles/5920342-video-task-management-in-pneumatic',
-  Workflows = 'https://support.pneumatic.app/en/articles/5605999-video-quick-product-overview',
+  Tasks = 'https://support.pneumatic.app/articles/5920342-video-task-management-in-pneumatic',
+  Workflows = 'https://support.pneumatic.app/articles/5605999-video-quick-product-overview',
   Templates = '',
   TemplatesSystem = '',
-  Highlights = 'https://support.pneumatic.app/en/articles/5249965-how-to-use-workflow-highlights',
-  Integrations = 'https://support.pneumatic.app/en/articles/6014550-integrations',
-  HowToCreateTemplate = 'https://support.pneumatic.app/en/articles/5534875-how-to-create-your-first-workflow-template',
+  Highlights = 'https://support.pneumatic.app/articles/5249965-how-to-use-workflow-highlights',
+  Integrations = 'https://support.pneumatic.app/articles/6014550-integrations',
+  HowToCreateTemplate = 'https://support.pneumatic.app/articles/5534875-how-to-create-your-first-workflow-template',
   Datasets = '',
-  GuestUsers = 'https://support.pneumatic.app/en/articles/6145048-free-external-users',
-  Checklists = 'https://support.pneumatic.app/en/articles/6145048-free-external-users',
+  GuestUsers = 'https://support.pneumatic.app/articles/6145048-free-external-users',
+  Checklists = 'https://support.pneumatic.app/articles/6145048-free-external-users',
   Tenants = 'https://www.pneumatic.app/partners/',
   TenantsModal = 'https://www.pneumatic.app/partners/',
   Team = '',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only link and layout changes with no auth or data handling impact; the new `lsKey` may briefly re-show the Groups banner for users who dismissed it under the old key.
> 
> **Overview**
> **Team → Groups** now shows the promotional banner **above** the page title, consistent with other Team section layouts.
> 
> The Groups banner’s **localStorage dismiss key** is renamed to `addGroupsBanner` so it no longer shares `addGuestsBanner` with the Users tab (dismiss state is independent).
> 
> **Support links** across banners, guest UI, template warnings, and `ELearnMoreLinks` drop the `/en` segment (`…/en/articles/…` → `…/articles/…`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26403bf84167ce13d42a75dbef15d6e11a173024. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `/en` path segment from support URLs and reorder banner in Groups view
> - Removes `/en` from all support article URLs across banners, modals, and the `ELearnMoreLinks` enum in [defaultValues.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/237/files#diff-52494fcdccc5c183b780194e43c83a5c3448c4f2ca2beef32efa759e70765da3).
> - Moves `<AddGuestsBanner />` above the page title in the [Groups](https://github.com/pneumaticapp/pneumaticworkflow/pull/237/files#diff-32b6621a14f1ca5c3b3be1556b56a61738a7b57a69af8a3f82325b04def6a041) view.
> - Renames the localStorage key in the Groups [AddGuestsBanner](https://github.com/pneumaticapp/pneumaticworkflow/pull/237/files#diff-73f5ee562f1f05a566f7c4fee0d568eb12317a3853edce916f744c5fd1b32917) from `addGuestsBanner` to `addGroupsBanner`.
> - Risk: users who previously dismissed the Groups banner will see it again due to the localStorage key change.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 26403bf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->