### PR TITLE
47589 frontend [workflows] Show workflow complete events as finished with ended icon

### DIFF
--- a/frontend/src/public/components/Highlights/FeedItemIcon.tsx
+++ b/frontend/src/public/components/Highlights/FeedItemIcon.tsx
@@ -6,7 +6,6 @@ import { ECommentType, EWorkflowLogEvent } from '../../types/workflow';
 import {
   CommentIcon,
   ProcessCompleteIcon,
-  ProcessFinishIcon,
   ProcessStartIcon,
   TaskCompleteIcon,
   TaskReturnIcon,
@@ -17,6 +16,7 @@ import {
   AlarmIcon,
   AlarmCrossedIcon,
   ClockIcon,
+  WorkflowEndedIcon,
 } from '../icons';
 import { IHighlightsItem } from '../../types/highlights';
 import { getDueInData } from '../DueIn/utils/getDueInData';
@@ -70,7 +70,7 @@ export function FeedItemIcon({ className, type, task }: IFeedItemIconProps) {
       tooltipMessage: formatMessage({ id: 'workflow-highlights.icon-process-completed' }),
     },
     [EWorkflowLogEvent.WorkflowFinished]: {
-      icon: <ProcessFinishIcon className={className} size="sm" />,
+      icon: <WorkflowEndedIcon />,
       tooltipMessage: formatMessage({ id: 'workflow-highlights.icon-process-finished' }),
     },
     [EWorkflowLogEvent.TaskComplete]: {

--- a/frontend/src/public/components/Highlights/FeedItemIcon.tsx
+++ b/frontend/src/public/components/Highlights/FeedItemIcon.tsx
@@ -70,7 +70,7 @@ export function FeedItemIcon({ className, type, task }: IFeedItemIconProps) {
       tooltipMessage: formatMessage({ id: 'workflow-highlights.icon-process-completed' }),
     },
     [EWorkflowLogEvent.WorkflowFinished]: {
-      icon: <WorkflowEndedIcon />,
+      icon: <WorkflowEndedIcon className={className} />,
       tooltipMessage: formatMessage({ id: 'workflow-highlights.icon-process-finished' }),
     },
     [EWorkflowLogEvent.TaskComplete]: {

--- a/frontend/src/public/components/Workflows/WorkflowLog/WorkflowLog.tsx
+++ b/frontend/src/public/components/Workflows/WorkflowLog/WorkflowLog.tsx
@@ -271,6 +271,7 @@ export const WorkflowLog = ({
           <WorkflowLogTaskComplete currentTask={eventTask} isOnlyAttachmentsShown={isOnlyAttachmentsShown} {...event} />
         ),
         [EWorkflowLogEvent.WorkflowFinished]: <WorkflowLogWorkflowFinished {...event} />,
+        [EWorkflowLogEvent.WorkflowComplete]: <WorkflowLogWorkflowFinished {...event} />,
         [EWorkflowLogEvent.WorkflowSnoozed]: <WorkflowLogDelay delay={delay} theme={theme} />,
         [EWorkflowLogEvent.WorkflowSnoozedManually]: <WorkflowLogWorkflowSnoozedManually {...event} delay={delay!} />,
         [EWorkflowLogEvent.WorkflowResumed]: <WorkflowLogWorkflowResumed {...event} />,
@@ -298,7 +299,6 @@ export const WorkflowLog = ({
         [EWorkflowLogEvent.AddedPerformer]: <WorkflowLogAddedPerformer {...event} />,
         [EWorkflowLogEvent.RemovedPerformer]: <WorkflowLogRemovedPerformer {...event} />,
         [EWorkflowLogEvent.DueDateChanged]: <WorkflowLogDueDateChanged {...event} />,
-        [EWorkflowLogEvent.WorkflowComplete]: null,
         [EWorkflowLogEvent.WorkflowRun]: null,
         [EWorkflowLogEvent.AddedPerformerGroup]: <WorkflowLogAddedPerformerGroup {...event} />,
         [EWorkflowLogEvent.RemovedPerformerGroup]: <WorkflowLogRemovedPerformerGroup {...event} />,

--- a/frontend/src/public/components/icons/WorkflowEndedIcon.tsx
+++ b/frontend/src/public/components/icons/WorkflowEndedIcon.tsx
@@ -2,9 +2,11 @@
 /* prettier-ignore */
 import * as React from 'react';
 
-export function WorkflowEndedIcon() {
+export type TWorkflowEndedIconProps = React.SVGAttributes<SVGElement>;
+
+export function WorkflowEndedIcon({ ...restProps }: TWorkflowEndedIconProps) {
   return (
-    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" {...restProps}>
       <path fillRule="evenodd" clipRule="evenodd" d="M2 4C2 2.89543 2.89543 2 4 2H9C10.6569 2 12 3.34315 12 5V11C12 12.1046 11.1046 13 10 13H4C2.89543 13 2 12.1046 2 11V4Z" fill="#5FAD56" />
       <path fillRule="evenodd" clipRule="evenodd" d="M10 6C10 4.89543 10.8954 4 12 4H15C16.6569 4 18 5.34315 18 7V12C18 13.6569 16.6569 15 15 15H13C11.3431 15 10 13.6569 10 12V6Z" fill="#5FAD56" />
       <path fillRule="evenodd" clipRule="evenodd" d="M3 10C3.55228 10 4 10.4477 4 11V17C4 17.5523 3.55228 18 3 18C2.44772 18 2 17.5523 2 17V11C2 10.4477 2.44772 10 3 10Z" fill="#5FAD56" />


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Display-only changes to workflow log and highlights icons with no auth, data, or API impact.
> 
> **Overview**
> **Workflow complete** log entries are no longer hidden: `EWorkflowLogEvent.WorkflowComplete` now uses the same **`WorkflowLogWorkflowFinished`** row as **workflow finished**, so both appear in the timeline.
> 
> In **highlights**, **workflow finished** feed icons switch from **`ProcessFinishIcon`** to **`WorkflowEndedIcon`**. **`WorkflowEndedIcon`** accepts standard SVG props (e.g. **`className`**) so it can match other feed icons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f44ff8d3f23ecde46d4910d13533988dc5482ed8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show workflow complete events as finished with the ended icon in workflow logs
> - `WorkflowComplete` events in [WorkflowLog.tsx](https://github.com/pneumaticapp/pneumaticworkflow/pull/239/files#diff-0b0edc51fe1521e87320e267fc936d52f89cfec6a15da694d2aeeee20623d06d) now render using `WorkflowLogWorkflowFinished` instead of being omitted.
> - The `WorkflowFinished` feed item icon in [FeedItemIcon.tsx](https://github.com/pneumaticapp/pneumaticworkflow/pull/239/files#diff-0e11568bdece52aec0aa63c35dbb24c603fd1a0fc14dc13683072ed898827ad8) now uses `WorkflowEndedIcon` instead of `ProcessFinishIcon`.
> - [WorkflowEndedIcon.tsx](https://github.com/pneumaticapp/pneumaticworkflow/pull/239/files#diff-b0537188bc2e685f2d9da6f11beef9e9f20cf00a5a00fd149d7f8bfe1bcb5750) is updated to accept and spread standard SVG attributes, allowing consumers to pass `className`, `width`, etc.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f44ff8d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->