### PR TITLE
47593 frontend [ websocket ] Catch errors for websockets

### DIFF
--- a/frontend/src/public/layout/MainLayout/MainLayout.tsx
+++ b/frontend/src/public/layout/MainLayout/MainLayout.tsx
@@ -27,9 +27,6 @@ import { isEnvAnalytics, isEnvPush } from '../../constants/enviroment';
 import { IUnsavedUser, TUserListItem } from '../../types/user';
 import { checkIsTemplateOwner, loadGroups } from '../../redux/actions';
 import { getIsAdmin } from '../../redux/selectors/user';
-import { closeAllConnections, hasActiveConnections } from '../../redux/utils/webSocketConnections';
-import { promiseDelay } from '../../utils/timeouts';
-
 import styles from './MainLayout.css';
 
 export interface IMainLayoutComponentStoreProps {
@@ -101,13 +98,7 @@ export function MainLayout({
 
   React.useEffect(() => {
     if (billingPlan) {
-      if (hasActiveConnections()) {
-        closeAllConnections()
-          .then(() => promiseDelay(500))
-          .then(() => watchUserWSEventsAction());
-      } else {
-        watchUserWSEventsAction();
-      }
+      watchUserWSEventsAction();
 
       loadNotificationsList();
       loadTasksCount();

--- a/frontend/src/public/redux/auth/saga.ts
+++ b/frontend/src/public/redux/auth/saga.ts
@@ -1,4 +1,5 @@
-import { all, call, fork, put, takeEvery, takeLatest, select, takeLeading } from 'redux-saga/effects';
+import type { Task } from 'redux-saga';
+import { all, call, cancel, fork, put, takeEvery, takeLatest, select, takeLeading } from 'redux-saga/effects';
 import { auth } from '../../api/auth';
 import {
   accountEditFailed,
@@ -66,6 +67,7 @@ import { getUTMParams, IUserUtm } from '../../views/user/utils/utmParams';
 import { clearAppFilters, setGeneralLoaderVisibility } from '../general/actions';
 import { getQueryStringParams, history } from '../../utils/history';
 import { watchWsEvents } from '../realtime/watchWsEvents';
+import { closeAllConnections } from '../utils/webSocketConnections';
 import { TUploadedFile, uploadUserAvatar } from '../../utils/uploadFiles';
 import { changePhotoProfile } from '../../api/changePhotoProfile';
 import { ELoggedState, IAuthUser } from '../../types/redux';
@@ -268,6 +270,7 @@ export function* registerWithInvite({ payload }: TRegisterUserInvited) {
 }
 
 function* handleLogoutUnsubscribing({ shouldExpireToken }: { shouldExpireToken: boolean }) {
+  yield call(stopWatchWsEvents);
   yield put(clearAppFilters());
   resetFirebaseDeviceToken();
   resetSuperuserToken();
@@ -688,12 +691,24 @@ export function* watchSetUserToken() {
   yield takeEvery(EAuthActions.SetToken, handleSetUserToken);
 }
 
+let watchWsEventsTask: Task | undefined;
+
+function* stopWatchWsEvents() {
+  if (watchWsEventsTask) {
+    yield cancel(watchWsEventsTask);
+    watchWsEventsTask = undefined;
+  }
+
+  yield call(closeAllConnections);
+}
+
 function* handleWatchUserWSEvents() {
-  yield fork(watchWsEvents);
+  yield call(stopWatchWsEvents);
+  watchWsEventsTask = yield fork(watchWsEvents);
 }
 
 export function* watchUserWSEvents() {
-  yield takeEvery(EAuthActions.WatchUserWSEvents, handleWatchUserWSEvents);
+  yield takeLeading(EAuthActions.WatchUserWSEvents, handleWatchUserWSEvents);
 }
 
 export function* watchUploadUserPhoto() {

--- a/frontend/src/public/redux/realtime/utils/routeRealtimeEvent.ts
+++ b/frontend/src/public/redux/realtime/utils/routeRealtimeEvent.ts
@@ -1,6 +1,7 @@
 import { call, put, select } from 'redux-saga/effects';
 
 import type { IRealtimeWsEnvelope } from '../types';
+import type { IStoreTask, IStoreWorkflows } from '../../../types/redux';
 import { ERealtimeEnvelopeType } from '../types';
 
 import { handleAddTask, handleRemoveTask } from '../../tasks/saga';
@@ -17,7 +18,6 @@ import { getUserTimezone } from '../../selectors/user';
 import { updateWorkflowLogItem } from '../../workflows/slice';
 import { isWorkflowEndedEventType } from './isWorkflowEndedEventType';
 import { mapBackendNewEventToRedux } from '../../../utils/mappers';
-import type { IStoreTask, IStoreWorkflows } from '../../../types/redux';
 import { getWorkflowsStore } from '../../selectors/workflows';
 import { getTaskStore } from '../../selectors/task';
 
@@ -86,16 +86,14 @@ export function* routeRealtimeEvent(envelope: IRealtimeWsEnvelope) {
       if (item) {
         yield call(prependNotificationItem, item);
       } else {
-        logger.error(`unhandled WebSocket event: ${envelope.type}, id=${envelope.id}`);
+        logger.error(`unhandled WebSocket event: ${envelope.type}`);
       }
 
       break;
     }
     default: {
       const unexpectedEnvelope = envelope as IRealtimeWsEnvelope;
-      logger.error(
-        `unhandled WebSocket event: ${unexpectedEnvelope.type}, id=${unexpectedEnvelope.id}`,
-      );
+      logger.error(`unhandled WebSocket event: ${String(unexpectedEnvelope.type)}`);
       break;
     }
   }

--- a/frontend/src/public/redux/realtime/watchWsEvents.ts
+++ b/frontend/src/public/redux/realtime/watchWsEvents.ts
@@ -8,6 +8,7 @@ import { getBrowserConfigEnv } from '../../utils/getConfig';
 import { mergePaths } from '../../utils/urls';
 import type { IRealtimeWsEnvelope } from './types';
 import { routeRealtimeEvent } from './utils/routeRealtimeEvent';
+import { logger } from '../../utils/logger';
 
 
 
@@ -22,6 +23,10 @@ export function* watchWsEvents() {
 
   while (true) {
     const envelope: IRealtimeWsEnvelope = yield take(channel);
-    yield call(routeRealtimeEvent, envelope);
+    try {
+      yield call(routeRealtimeEvent, envelope);
+    } catch (error) {
+      logger.error(`failed to route WebSocket event`, error);
+    }
   }
 }

--- a/frontend/src/public/redux/utils/createWebSocketChannel.ts
+++ b/frontend/src/public/redux/utils/createWebSocketChannel.ts
@@ -1,5 +1,6 @@
 import { eventChannel } from 'redux-saga';
 import { mapToCamelCase } from '../../utils/mappers';
+import { logger } from '../../utils/logger';
 import { addConnection } from './webSocketConnections';
 
 export interface WebSocketWithRemoveFlag extends WebSocket {
@@ -54,8 +55,16 @@ export function createWebSocketChannel(url: string) {
           return;
         }
 
-        const data = mapToCamelCase(JSON.parse(message.data));
-        emit(data);
+        try {
+          const data = mapToCamelCase(JSON.parse(message.data));
+          emit(data);
+        } catch (error) {
+          logger.error('Invalid WebSocket message', message.data, error);
+        }
+      };
+
+      ws.onerror = (event) => {
+        logger.error('WebSocket connection error', event);
       };
 
       ws.onclose = () => {

--- a/frontend/src/public/redux/utils/createWebSocketChannel.ts
+++ b/frontend/src/public/redux/utils/createWebSocketChannel.ts
@@ -81,6 +81,7 @@ export function createWebSocketChannel(url: string) {
         clearInterval(heartbeatInterval);
         heartbeatInterval = null;
       }
+      ws.shouldRemove = true;
       ws.close();
     };
   });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes affect realtime updates (tasks, notifications, users) and logout/session transitions; mis-timed cancel/close could briefly drop or duplicate connections, but scope is frontend-only with defensive error handling.
> 
> **Overview**
> Hardens realtime WebSocket handling so bad messages and routing failures are logged instead of breaking the listener, and moves connection start/stop out of `MainLayout` into the auth saga.
> 
> **Error handling:** `createWebSocketChannel` wraps JSON parsing in try/catch, adds `onerror` logging, and sets `shouldRemove` on channel teardown so cleanup does not auto-reconnect. `watchWsEvents` catches errors from `routeRealtimeEvent` per envelope. Unhandled-event logs in `routeRealtimeEvent` are slightly simplified.
> 
> **Lifecycle:** `MainLayout` no longer checks `hasActiveConnections`, closes sockets, or delays before `watchUserWSEventsAction`—it dispatches watch when `billingPlan` is set. The auth saga tracks the forked `watchWsEvents` task, cancels it and calls `closeAllConnections` via `stopWatchWsEvents` (including on logout), restarts before a new fork, and uses `takeLeading` on `WatchUserWSEvents` to avoid overlapping watchers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d971733deab260e628dbcff38f5d1933ba2d53de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Catch and handle WebSocket errors and prevent duplicate watcher tasks
> - Wraps the event routing loop in [watchWsEvents.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/240/files#diff-e4197fdd54e3cf032603e243ca0675fcb88457d3fa007ae361d147fc1b944583) in a try/catch so routing errors are logged rather than crashing the watcher.
> - Invalid WebSocket messages and connection errors in [createWebSocketChannel.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/240/files#diff-fcf8117a324da5145502e637009ea36e772048e3cce477e2e0c3016b6fdc1720) are now caught and logged instead of potentially breaking the channel.
> - Introduces `stopWatchWsEvents` in [auth saga](https://github.com/pneumaticapp/pneumaticworkflow/pull/240/files#diff-fe024bce77c1ac21b6513b94df77f63e8d162d0517ba4cf5d45692ff974a95c8) to cancel the active watcher task and close all connections; called on logout and before starting a new watcher.
> - Switches `watchUserWSEvents` from `takeEvery` to `takeLeading` so concurrent watcher tasks cannot overlap.
> - Unsubscribing from a WebSocket channel now sets `ws.shouldRemove = true` to prevent the `onclose` handler from triggering a reconnect.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d971733.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->