### PR TITLE
47594 frontend [ process ] Make markdown output support for template description

### DIFF
--- a/frontend/src/public/components/RichEditor/components/LexicalEditorContent/LexicalEditorContent.css
+++ b/frontend/src/public/components/RichEditor/components/LexicalEditorContent/LexicalEditorContent.css
@@ -86,6 +86,43 @@
   min-height: 2rem;
 }
 
+:global(.lexical-rich-editor-heading-h1),
+:global(.lexical-rich-editor-heading-h2),
+:global(.lexical-rich-editor-heading-h3),
+:global(.lexical-rich-editor-heading-h4),
+:global(.lexical-rich-editor-heading-h5),
+:global(.lexical-rich-editor-heading-h6) {
+  margin: 0;
+  padding: 0;
+  font-weight: 800;
+  line-height: 1.3;
+  color: var(--pneumatic-color-black100);
+}
+
+:global(.lexical-rich-editor-heading-h1) {
+  font-size: 2.4rem;
+}
+
+:global(.lexical-rich-editor-heading-h2) {
+  font-size: 2rem;
+}
+
+:global(.lexical-rich-editor-heading-h3) {
+  font-size: 1.8rem;
+}
+
+:global(.lexical-rich-editor-heading-h4) {
+  font-size: 1.6rem;
+}
+
+:global(.lexical-rich-editor-heading-h5) {
+  font-size: 1.5rem;
+}
+
+:global(.lexical-rich-editor-heading-h6) {
+  font-size: 1.4rem;
+}
+
 :global(.lexical-rich-editor-link) {
   color: var(--pneumatic-color-link-dark);
   transition: color 0.1s ease-in-out;

--- a/frontend/src/public/components/RichEditor/components/LexicalEditorContent/LexicalEditorContent.tsx
+++ b/frontend/src/public/components/RichEditor/components/LexicalEditorContent/LexicalEditorContent.tsx
@@ -8,7 +8,7 @@ import { LexicalErrorBoundary } from '@lexical/react/LexicalErrorBoundary';
 import { LinkPlugin } from '@lexical/react/LexicalLinkPlugin';
 import { ListPlugin } from '@lexical/react/LexicalListPlugin';
 import { MarkdownShortcutPlugin } from '@lexical/react/LexicalMarkdownShortcutPlugin';
-import { ELEMENT_TRANSFORMERS } from '@lexical/markdown';
+import { ELEMENT_TRANSFORMERS, TEXT_FORMAT_TRANSFORMERS } from '@lexical/markdown';
 
 import {
   InsertAttachmentPlugin,
@@ -30,6 +30,8 @@ import { Loader } from '../../../UI/Loader';
 import type { ILexicalEditorContentProps } from '../../types';
 
 import styles from './LexicalEditorContent.css';
+
+const MARKDOWN_SHORTCUT_TRANSFORMERS = [...ELEMENT_TRANSFORMERS, ...TEXT_FORMAT_TRANSFORMERS];
 
 
 
@@ -109,7 +111,7 @@ export function LexicalEditorContent({
         <SubmitOnKeyPlugin onSubmit={onSubmit} />
       ) : null}
       <OnChangePlugin ignoreSelectionChange onChange={onChange} />
-      {showRichTextPlugins && <MarkdownShortcutPlugin transformers={ELEMENT_TRANSFORMERS} />}
+      {showRichTextPlugins && <MarkdownShortcutPlugin transformers={MARKDOWN_SHORTCUT_TRANSFORMERS} />}
       {plainText && <DisableRichTextFormattingPlugin />}
       {plainText && <PlainTextPastePlugin templateVariables={templateVariables} />}
 

--- a/frontend/src/public/components/RichText/RichText.css
+++ b/frontend/src/public/components/RichText/RichText.css
@@ -1,18 +1,70 @@
 /* stylelint-disable selector-max-compound-selectors */
-.container * {
-  margin: 0;
-  max-width: 100%;
-  font-size: inherit;
-  line-height: inherit;
-  white-space: pre-wrap;
-}
-
 .container {
   overflow-wrap: anywhere;
 
+  * + * {
+    /* stylelint-disable-next-line declaration-no-important */
+    margin-top: 2rem !important;
+  }
+
+  li + li {
+    /* stylelint-disable-next-line declaration-no-important */
+    margin-top: 0.8rem !important;
+  }
+
+  p,
+  li,
+  blockquote,
+  pre,
+  code {
+    margin: 0;
+    max-width: 100%;
+    white-space: pre-wrap;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    margin: 0.8rem 0 0.4rem;
+    font-weight: 800;
+    line-height: 1.3;
+    color: inherit;
+  }
+
+  h1 {
+    font-size: 2.4rem;
+  }
+
+  h2 {
+    font-size: 2rem;
+  }
+
+  h3 {
+    font-size: 1.8rem;
+  }
+
+  h4 {
+    font-size: 1.6rem;
+  }
+
+  h5 {
+    font-size: 1.5rem;
+  }
+
+  h6 {
+    font-size: 1.4rem;
+  }
+
+  strong {
+    font-weight: 800;
+  }
+
   hr {
-    margin: 16px 0;
-    max-width: 370px;
+    margin: 1.6rem 0;
+    max-width: 37rem;
   }
 
   a {
@@ -26,8 +78,8 @@
 
   ul,
   ol {
-    padding-left: 32px;
-    list-style-position: inside;
+    padding-left: 3.2rem;
+    list-style-position: outside;
 
     li::marker {
       font-weight: bold;
@@ -65,7 +117,7 @@
   img {
     display: block;
     width: auto;
-    max-height: 500px;
+    max-height: 50rem;
     cursor: pointer;
   }
 }
@@ -83,30 +135,36 @@
 
 .loading-image {
   width: 100%;
-  min-height: 64px;
+  min-height: 6.4rem;
   pointer-events: none;
-  background-color: #f6f6f6;
-  background-image: linear-gradient(90deg, #f6f6f6, white, #f6f6f6);
+  background-color: var(--pneumatic-color-beige);
+  background-image:
+    linear-gradient(
+      90deg,
+      var(--pneumatic-color-beige),
+      var(--pneumatic-color-white),
+      var(--pneumatic-color-beige)
+    );
   background-repeat: no-repeat;
-  background-size: 200px 100%;
-  border-radius: 4px;
+  background-size: 20rem 100%;
+  border-radius: 0.4rem;
   animation: loading-animation 1.8s ease-in-out infinite;
 }
 
 @keyframes loading-animation {
   0% {
-    background-position: -200px 0;
+    background-position: -20rem 0;
   }
   100% {
-    background-position: calc(200px + 100%) 0;
+    background-position: calc(20rem + 100%) 0;
   }
 }
 
 .checklist {
-  margin: 16px 32px;
+  margin: 1.6rem 3.2rem;
 
   @media (--mobile) {
-    margin: 16px 0;
+    margin: 1.6rem 0;
   }
 }
 
@@ -116,10 +174,10 @@
 
 .checkbox-wrapper {
   display: flex;
-  min-height: 20px;
+  min-height: 2rem;
 
   &:not(:last-child) {
-    margin-bottom: 8px;
+    margin-bottom: 0.8rem;
   }
 }
 
@@ -132,11 +190,11 @@
 }
 
 .checkbox-content {
-  margin-left: 28px;
+  margin-left: 2.8rem;
 }
 
 .progressbar-container {
-  margin-bottom: 6px;
+  margin-bottom: 0.6rem;
 }
 
 .progressbar {
@@ -145,18 +203,56 @@
 }
 
 .progressbar-hint {
-  margin-left: 8px;
+  margin-left: 0.8rem;
 }
 
 .progressbar-hint-icon {
   display: flex;
 }
 
+.container_collapsed {
+  /* stylelint-disable-next-line value-no-vendor-prefix */
+  display: -webkit-box;
+  overflow: hidden;
+  /* stylelint-disable-next-line property-no-vendor-prefix */
+  -webkit-box-orient: vertical;
+}
+
+.wrapper {
+  width: 100%;
+}
+
+.wrapper_collapsed {
+  position: relative;
+}
+
+.more-link {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  padding-left: 1rem;
+  line-height: inherit;
+  white-space: nowrap;
+  cursor: pointer;
+  /* stylelint-disable-next-line declaration-no-important */
+  color: var(--pneumatic-color-link) !important;
+  background:
+    linear-gradient(
+      90deg,
+      transparent 0%,
+      var(--rich-text-more-fade-color, var(--pneumatic-color-white)) 0.75rem
+    );
+}
+
+.more-link__delimiter {
+  color: var(--pneumatic-warning-color);
+}
+
 .checkbox-fake-placeholder {
   position: absolute;
-  width: 20px;
-  height: 20px;
+  width: 2rem;
+  height: 2rem;
   background-color: transparent;
   border: 1px solid var(--pneumatic-color-black16);
-  border-radius: 4px;
+  border-radius: 0.4rem;
 }

--- a/frontend/src/public/components/RichText/RichText.tsx
+++ b/frontend/src/public/components/RichText/RichText.tsx
@@ -1,36 +1,13 @@
 import * as React from 'react';
-import ReactDOMServer from 'react-dom/server';
-import * as xssFilters from 'xss-filters';
-import { useDispatch } from 'react-redux';
+import classnames from 'classnames';
 import { useIntl } from 'react-intl';
-import { Remarkable } from 'remarkable';
-import { LinkCloseToken } from 'remarkable/lib';
-import { linkify } from './linkify';
 
-import {
-  mentionsRegex,
-  youtubeVideoRegexp,
-  loomVideoRegexp,
-  wistiaVideoRegexp,
-  variableRegex,
-} from '../../constants/defaultValues';
-import { isArrayWithItems } from '../../utils/helpers';
 import { TTaskVariable } from '../TemplateEdit/types';
-import { getLocalizedSystemVariable } from '../TemplateEdit/TaskForm/utils/getTaskVariables';
-import { truncateString } from '../../utils/truncateString';
-import { openFullscreenImage } from '../../redux/general/actions';
-import { DocumentAttachment } from '../Attachments/DocumentAttachment';
-import {
-  linksRemarkablePlugin,
-  checklistsRemarkablePlugin,
-  TCustomLinkToken,
-} from '../RichEditor/utils/converters/customMarkdownPlugins';
-
-import { ECustomEditorEntities } from '../RichEditor/utils/types';
-import { createChecklistRenderer } from '../TaskCard/checklist/createChecklistRenderer';
-import { createCheckPlaceholderId } from '../TaskCard/checklist/createCheckPlaceholderId';
-import { prepareChecklistsForRendering } from '../../utils/checklists/prepareChecklistsForRendering';
-import { createProgressbarPlaceholderId } from '../TaskCard/checklist/createProgressbarPlaceholderId';
+import { useRichTextLineClamp } from './useRichTextLineClamp';
+import { useRichTextContainer } from './useRichTextContainer';
+import { prepareRichTextHtml } from './utils/prepareRichTextHtml';
+import { createRichTextRemarkable } from './utils/createRichTextRemarkable';
+import { RichTextMoreLink } from './RichTextMoreLink';
 import styles from './RichText.css';
 import badgeStyles from '../../utils/badge/Badge.css';
 
@@ -42,9 +19,9 @@ export interface IRichTextProps {
   renderExtensions?: React.ReactNode[];
   interactiveChecklists?: boolean;
   hideIcon?: boolean;
+  maxLines?: number;
+  className?: string;
 }
-
-const MAX_VARIABLE_LENGTH = 20;
 
 export function RichText({
   text,
@@ -54,239 +31,102 @@ export function RichText({
   renderExtensions,
   interactiveChecklists,
   hideIcon,
-}: IRichTextProps) {
-  if (!text) {
-    return null;
-  }
-
+  maxLines,
+  className,
+}: IRichTextProps): React.ReactElement | null {
   const [isRendered, setIsRendered] = React.useState(false);
+  const [isExpanded, setIsExpanded] = React.useState(false);
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const { formatMessage } = useIntl();
+
+  const safeText = text ?? '';
+  const isTruncated = useRichTextLineClamp(containerRef, maxLines, isExpanded, safeText);
+
+  React.useEffect(() => {
+    setIsExpanded(false);
+  }, [text]);
 
   React.useLayoutEffect(() => {
     setIsRendered(true);
   }, []);
 
-  const md = new Remarkable({
-    html: true,
-    breaks: true,
-  })
-    .use(checklistsRemarkablePlugin)
-    .use(linkify)
-    .use(attachmnetRenderer(embedVideos, hideIcon))
-    .use(
-      createChecklistRenderer({
-        renderCheck: (listApiName, itemApiName) => {
-          if (interactiveChecklists) {
-            return `<div id="${createCheckPlaceholderId(listApiName, itemApiName)}"></div>`;
-          }
+  const remarkable = React.useMemo(
+    () => createRichTextRemarkable({
+      embedVideos,
+      hideIcon,
+      interactiveChecklists,
+      checkboxPlaceholderClassName: styles['checkbox-fake-placeholder'],
+      videoClassName: styles['video'],
+    }),
+    [embedVideos, hideIcon, interactiveChecklists],
+  );
 
-          return `<div class="${styles['checkbox-fake-placeholder']}"></div>`;
-        },
-        renderProgressbar: (listApiName) => {
-          if (!interactiveChecklists) {
-            return '';
-          }
+  const htmlString = React.useMemo(
+    () => prepareRichTextHtml(safeText, {
+      variables,
+      formatMessage,
+      mentionClassName: styles['mention'],
+      badgeClassName: badgeStyles['badge'],
+      specificityBadgeClassName: badgeStyles['specifity'],
+    }),
+    [safeText, variables, formatMessage],
+  );
 
-          return `<div id="${createProgressbarPlaceholderId(listApiName)}"></div>`;
-        },
-        interactiveChecklist: interactiveChecklists,
-      }),
-    );
+  const renderedHtml = React.useMemo(
+    () => (isMarkdownMode ? remarkable.render(htmlString) : htmlString),
+    [isMarkdownMode, remarkable, htmlString],
+  );
 
-  const dispatch = useDispatch();
-  const { formatMessage } = useIntl();
-  const conatainerRef = React.useRef<HTMLDivElement>(null);
+  useRichTextContainer(containerRef, renderedHtml);
 
-  const handleClick = React.useCallback((event: MouseEvent) => {
-    const target = event.target as Element;
-    const url = target.getAttribute('src');
-    if (target.tagName === 'IMG' && url) {
-      event.stopImmediatePropagation();
-      dispatch(openFullscreenImage({ url }));
-    }
+  const handleExpand = React.useCallback((
+    event: React.MouseEvent<HTMLAnchorElement> | React.KeyboardEvent<HTMLAnchorElement>,
+  ) => {
+    event.preventDefault();
+    setIsExpanded(true);
   }, []);
 
-  const showImagePlaceholders = (container: HTMLDivElement) => {
-    const images = container.getElementsByTagName('img');
-    for (let i = 0; i < images.length; i += 1) {
-      images[i].classList.add(styles['loading-image']);
-      images[i].onload = () => {
-        images[i].classList.remove(styles['loading-image']);
-      };
-    }
-  };
-
-  React.useEffect(() => {
-    if (conatainerRef.current) {
-      showImagePlaceholders(conatainerRef.current);
-      conatainerRef.current.addEventListener('click', handleClick);
-    }
-
-    return () => {
-      if (conatainerRef.current) {
-        conatainerRef.current.removeEventListener('click', handleClick);
-      }
-    };
-  }, []);
-
-  const REPLACE_RULES: {
-    regExp: RegExp;
-    // tslint:disable-next-line: no-any
-    replaceLogic: any;
-  }[] = [
-    {
-      // This is a hacky way to correctly render new lines in markdown
-      regExp: /\n/g,
-      replaceLogic: (match: string, offset: number, str: string) => {
-        const nextSymbol = str[offset + 1];
-
-        return nextSymbol === '\n' ? '\n&nbsp;\n' : match;
-      },
-    },
-    {
-      regExp: mentionsRegex,
-      replaceLogic: `<span class='${styles['mention']}'>@$1</span>`,
-    },
-    {
-      regExp: variableRegex,
-      replaceLogic: (match: string, variableApiName: string) => {
-        if (!isArrayWithItems(variables)) {
-          return match;
-        }
-
-        const variable = variables.find((item) => variableApiName === item.apiName);
-        if (!variable) {
-          return match;
-        }
-
-        const { title } = getLocalizedSystemVariable({
-          apiName: variableApiName,
-          title: variable.title,
-          formatMessage,
-        });
-
-        return `<span class="${badgeStyles['badge']} ${badgeStyles['specifity']}">${truncateString(
-          title,
-          MAX_VARIABLE_LENGTH,
-        )}</span>`;
-      },
-    },
-  ];
-
-  const sanitizedText = xssFilters.inHTMLData(prepareChecklistsForRendering(text));
-
-  const htmlString = REPLACE_RULES.reduce((acc, { regExp, replaceLogic }) => {
-    const replaceRegex = new RegExp(regExp, 'gi');
-
-    return acc.replace(replaceRegex, replaceLogic);
-  }, sanitizedText);
-
-  /* eslint-disable react/no-danger */
-  if (!isMarkdownMode) {
-    return <div dangerouslySetInnerHTML={{ __html: htmlString }} />;
+  if (!text) {
+    return null;
   }
 
-  return (
+  const isCollapsed = Boolean(maxLines) && !isExpanded;
+  const collapsedStyle = isCollapsed && maxLines
+    ? ({
+      WebkitLineClamp: maxLines,
+      lineClamp: maxLines,
+    } as React.CSSProperties)
+    : undefined;
+
+  const content = (
     <>
-      {isRendered && renderExtensions}
+      {isMarkdownMode && isRendered && renderExtensions}
+      {/* eslint-disable-next-line react/no-danger */}
       <div
-        ref={conatainerRef}
-        className={styles['container']}
-        dangerouslySetInnerHTML={{ __html: md.render(htmlString) }}
+        ref={containerRef}
+        className={classnames(styles['container'], isCollapsed && styles['container_collapsed'])}
+        style={collapsedStyle}
+        dangerouslySetInnerHTML={{ __html: renderedHtml }}
       />
     </>
   );
-  /* eslint-enable react/no-danger */
+
+  const needsWrapper = Boolean(maxLines) || Boolean(className);
+
+  if (!needsWrapper) {
+    return content;
+  }
+
+  return (
+    <div
+      className={classnames(
+        maxLines && styles['wrapper'],
+        className,
+        maxLines && isCollapsed && styles['wrapper_collapsed'],
+      )}
+    >
+      {content}
+      {isCollapsed && isTruncated && <RichTextMoreLink onExpand={handleExpand} />}
+    </div>
+  );
 }
-
-const attachmnetRenderer = (embedVideoLinks: boolean, hideIcon?: boolean) => {
-  const renderLink = (url: string, name: string) => {
-    const defaultLinkHtml = `<a href="${url}" target="_blank">${name}<a/>`;
-    if (!embedVideoLinks) {
-      return defaultLinkHtml;
-    }
-
-    const renderRules = [
-      {
-        regExp: loomVideoRegexp,
-        replaceLogic: (match: string, group1: string) => {
-          return '<div><iframe'
-            + ` class="${styles['video']}"`
-            + ' frameBorder="0"'
-            + ` src="https://www.useloom.com/embed/${group1}"`
-            + ' webkitallowfullscreen mozallowfullscreen allowfullscreen'
-            + '></iframe></div>';
-        },
-      },
-      {
-        regExp: youtubeVideoRegexp,
-        replaceLogic: (match: string, group1: string) => {
-          return '<div><iframe'
-            + ` class="${styles['video']}"`
-            + ' frameBorder="0"'
-            + ` src="//www.youtube.com/embed/${group1}"`
-            + ' webkitallowfullscreen mozallowfullscreen allowfullscreen'
-            + '></iframe></div>';
-        },
-      },
-      {
-        regExp: wistiaVideoRegexp,
-        replaceLogic: (match: string, videoId: string) => {
-          const videoUrl = `https://fast.wistia.com/embed/medias/${videoId}`;
-
-          return '<div><iframe'
-            + ` class="${styles['video']}"`
-            + ' allowtransparency="true" frameborder="0" scrolling="no"'
-            + ` src="${videoUrl}"`
-            + ' webkitallowfullscreen mozallowfullscreen allowfullscreen'
-            + '></iframe></div>';
-        },
-      },
-    ];
-
-    const renderVideoLogic = renderRules.find(({ regExp }) => regExp.test(url));
-    if (renderVideoLogic) {
-      return url.replace(renderVideoLogic.regExp, renderVideoLogic.replaceLogic);
-    }
-
-    return defaultLinkHtml;
-  };
-
-  return (md: Remarkable) => {
-    md.inline.ruler.disable(['links']);
-    md.use(linksRemarkablePlugin, {});
-
-    // @ts-ignore
-    md.renderer.rules.link_open = (tokens: TCustomLinkToken[], idx: number) => {
-      const { url, name, entityType, isLinkified } = tokens[idx];
-
-      if (isLinkified || !entityType) {
-        return renderLink(url, name);
-      }
-
-      const renderMap: { [key in ECustomEditorEntities]: string } = {
-        [ECustomEditorEntities.Link]: `<a href="${url}" target="_blank">`,
-        [ECustomEditorEntities.Image]: `<img src=${url} />`,
-        // eslint-disable-next-line jsx-a11y/media-has-caption
-        [ECustomEditorEntities.Video]: ReactDOMServer.renderToStaticMarkup(<video src={url} preload="auto" controls />),
-        [ECustomEditorEntities.File]: ReactDOMServer.renderToStaticMarkup(
-          <DocumentAttachment name={name} url={url} isEdit={false} hideIcon={hideIcon} />,
-        ),
-        [ECustomEditorEntities.Variable]: '',
-        [ECustomEditorEntities.Mention]: '',
-      };
-
-      return renderMap[entityType];
-    };
-
-    // @ts-ignore
-    md.renderer.rules.link_close = (tokens: LinkCloseToken[], idx: number) => {
-      // @ts-ignore
-      const { entityType } = tokens[idx];
-      if (entityType === 'LINK') {
-        return '</a>';
-      }
-
-      return '';
-    };
-  };
-};

--- a/frontend/src/public/components/RichText/RichTextMoreLink.tsx
+++ b/frontend/src/public/components/RichText/RichTextMoreLink.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { useIntl } from 'react-intl';
+
+import { ELLIPSIS_CHAR } from '../../constants/defaultValues';
+import styles from './RichText.css';
+
+interface IRichTextMoreLinkProps {
+  onExpand: (event: React.MouseEvent<HTMLAnchorElement> | React.KeyboardEvent<HTMLAnchorElement>) => void;
+}
+
+export const RichTextMoreLink = ({ onExpand }: IRichTextMoreLinkProps) => {
+  const { formatMessage } = useIntl();
+
+  const handleKeyDown = React.useCallback((event: React.KeyboardEvent<HTMLAnchorElement>) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      onExpand(event);
+    }
+  }, [onExpand]);
+
+  return (
+    // eslint-disable-next-line jsx-a11y/anchor-is-valid
+    <a
+      href="#"
+      role="button"
+      tabIndex={0}
+      onClick={onExpand}
+      onKeyDown={handleKeyDown}
+      className={styles['more-link']}
+    >
+      <span className={styles['more-link__delimiter']}>{ELLIPSIS_CHAR}</span>
+      {formatMessage({ id: 'templates.description-more' })}
+    </a>
+  );
+};

--- a/frontend/src/public/components/RichText/__tests__/RichText.test.tsx
+++ b/frontend/src/public/components/RichText/__tests__/RichText.test.tsx
@@ -28,6 +28,22 @@ import {
 describe('RichText', () => {
   const LOCALIZED_WF_STARTER_TITLE = intlMock.formatMessage({ id: 'kickoff.system-varibale-workflow-starter' });
 
+  it('renders multiple paragraphs without empty nbsp blocks', () => {
+    const props: IRichTextProps = {
+      text: 'Paragraph 1\n\nParagraph 2\n\n## Heading\n\nText below',
+      isMarkdownMode: true,
+    };
+
+    const { container } = render(<RichText {...props} />);
+
+    expect(container.querySelectorAll('p')).toHaveLength(3);
+    expect(container.innerHTML).not.toContain('&nbsp;');
+    expect(container.textContent).toContain('Paragraph 1');
+    expect(container.textContent).toContain('Paragraph 2');
+    expect(container.textContent).toContain('Heading');
+    expect(container.textContent).toContain('Text below');
+  });
+
   it('renders correct html for mentions and links', () => {
     const props: IRichTextProps = {
       text: 'Hello, [Jyoti Puri|3], look here: link: http://pneumatic.app/',

--- a/frontend/src/public/components/RichText/__tests__/__snapshots__/RichText.test.tsx.snap
+++ b/frontend/src/public/components/RichText/__tests__/__snapshots__/RichText.test.tsx.snap
@@ -2,9 +2,11 @@
 
 exports[`RichText RichText and loom link in text flag return text with loom iframe 1`] = `
 <div
-  class="container"
+  class="rich-editor-content container"
 >
-  <p>
+  <p
+    class="lexical-rich-editor-paragraph"
+  >
     test1 
   </p>
   <div>
@@ -25,9 +27,11 @@ exports[`RichText RichText and loom link in text flag return text with loom ifra
 
 exports[`RichText RichText and youtube and loom link in text flag return text with youtube and loom iframe 1`] = `
 <div
-  class="container"
+  class="rich-editor-content container"
 >
-  <p>
+  <p
+    class="lexical-rich-editor-paragraph"
+  >
     test1 
   </p>
   <div>
@@ -59,9 +63,11 @@ exports[`RichText RichText and youtube and loom link in text flag return text wi
 
 exports[`RichText RichText and youtube in text flag return text with youtube iframe 1`] = `
 <div
-  class="container"
+  class="rich-editor-content container"
 >
-  <p>
+  <p
+    class="lexical-rich-editor-paragraph"
+  >
     test1 
   </p>
   <div>
@@ -82,17 +88,20 @@ exports[`RichText RichText and youtube in text flag return text with youtube ifr
 
 exports[`RichText renders correct html for mentions and links 1`] = `
 <div
-  class="container"
+  class="rich-editor-content container"
 >
-  <p>
+  <p
+    class="lexical-rich-editor-paragraph"
+  >
     Hello, 
     <span
-      class="mention"
+      class="lexical-rich-editor-mention"
     >
       @Jyoti Puri
     </span>
     , look here: link: 
     <a
+      class="lexical-rich-editor-link"
       href="http://pneumatic.app/"
       target="_blank"
     >
@@ -109,9 +118,11 @@ exports[`RichText renders correct html for mentions and links 1`] = `
 
 exports[`RichText renders correct html for plain text 1`] = `
 <div
-  class="container"
+  class="rich-editor-content container"
 >
-  <p>
+  <p
+    class="lexical-rich-editor-paragraph"
+  >
     Some plain text
   </p>
   

--- a/frontend/src/public/components/RichText/useRichTextContainer.ts
+++ b/frontend/src/public/components/RichText/useRichTextContainer.ts
@@ -27,9 +27,10 @@ export const useRichTextContainer = (
 
     const images = container.getElementsByTagName('img');
     for (let i = 0; i < images.length; i += 1) {
-      images[i].classList.add(styles['loading-image']);
-      images[i].onload = () => {
-        images[i].classList.remove(styles['loading-image']);
+      const image = images[i];
+      image.classList.add(styles['loading-image']);
+      image.onload = () => {
+        image.classList.remove(styles['loading-image']);
       };
     }
 

--- a/frontend/src/public/components/RichText/useRichTextContainer.ts
+++ b/frontend/src/public/components/RichText/useRichTextContainer.ts
@@ -28,10 +28,18 @@ export const useRichTextContainer = (
     const images = container.getElementsByTagName('img');
     for (let i = 0; i < images.length; i += 1) {
       const image = images[i];
-      image.classList.add(styles['loading-image']);
-      image.onload = () => {
+
+      if (image.complete && image.naturalWidth > 0) {
         image.classList.remove(styles['loading-image']);
-      };
+      } else {
+        image.classList.add(styles['loading-image']);
+        image.onload = () => {
+          image.classList.remove(styles['loading-image']);
+        };
+        image.onerror = () => {
+          image.classList.remove(styles['loading-image']);
+        };
+      }
     }
 
     container.addEventListener('click', handleClick);

--- a/frontend/src/public/components/RichText/useRichTextContainer.ts
+++ b/frontend/src/public/components/RichText/useRichTextContainer.ts
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import { useDispatch } from 'react-redux';
+
+import { openFullscreenImage } from '../../redux/general/actions';
+import styles from './RichText.css';
+
+export const useRichTextContainer = (
+  containerRef: React.RefObject<HTMLDivElement | null>,
+  html: string,
+) => {
+  const dispatch = useDispatch();
+
+  const handleClick = React.useCallback((event: MouseEvent) => {
+    const target = event.target as Element;
+    const url = target.getAttribute('src');
+    if (target.tagName === 'IMG' && url) {
+      event.stopImmediatePropagation();
+      dispatch(openFullscreenImage({ url }));
+    }
+  }, [dispatch]);
+
+  React.useEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return undefined;
+    }
+
+    const images = container.getElementsByTagName('img');
+    for (let i = 0; i < images.length; i += 1) {
+      images[i].classList.add(styles['loading-image']);
+      images[i].onload = () => {
+        images[i].classList.remove(styles['loading-image']);
+      };
+    }
+
+    container.addEventListener('click', handleClick);
+
+    return () => {
+      container.removeEventListener('click', handleClick);
+    };
+  }, [containerRef, handleClick, html]);
+};

--- a/frontend/src/public/components/RichText/useRichTextLineClamp.ts
+++ b/frontend/src/public/components/RichText/useRichTextLineClamp.ts
@@ -15,15 +15,15 @@ export function useRichTextLineClamp(
       return undefined;
     }
 
+    const element = elementRef.current;
+
+    if (!element) {
+      setIsTruncated(false);
+
+      return undefined;
+    }
+
     const measureTruncation = () => {
-      const element = elementRef.current;
-
-      if (!element) {
-        setIsTruncated(false);
-
-        return;
-      }
-
       setIsTruncated(element.scrollHeight > element.clientHeight + 1);
     };
 
@@ -31,7 +31,21 @@ export function useRichTextLineClamp(
 
     const frameId = requestAnimationFrame(measureTruncation);
 
-    return () => cancelAnimationFrame(frameId);
+    const images = element.getElementsByTagName('img');
+    for (let i = 0; i < images.length; i += 1) {
+      const image = images[i];
+      if (!image.complete) {
+        image.addEventListener('load', measureTruncation);
+      }
+    }
+
+    return () => {
+      cancelAnimationFrame(frameId);
+      const imgs = element.getElementsByTagName('img');
+      for (let i = 0; i < imgs.length; i += 1) {
+        imgs[i].removeEventListener('load', measureTruncation);
+      }
+    };
   }, [elementRef, maxLines, isExpanded, text]);
 
   return isTruncated;

--- a/frontend/src/public/components/RichText/useRichTextLineClamp.ts
+++ b/frontend/src/public/components/RichText/useRichTextLineClamp.ts
@@ -1,0 +1,38 @@
+import { useLayoutEffect, useState, type RefObject } from 'react';
+
+export function useRichTextLineClamp(
+  elementRef: RefObject<HTMLDivElement | null>,
+  maxLines: number | undefined,
+  isExpanded: boolean,
+  text: string,
+): boolean {
+  const [isTruncated, setIsTruncated] = useState(false);
+
+  useLayoutEffect(() => {
+    if (!maxLines || isExpanded) {
+      setIsTruncated(false);
+
+      return undefined;
+    }
+
+    const measureTruncation = () => {
+      const element = elementRef.current;
+
+      if (!element) {
+        setIsTruncated(false);
+
+        return;
+      }
+
+      setIsTruncated(element.scrollHeight > element.clientHeight + 1);
+    };
+
+    measureTruncation();
+
+    const frameId = requestAnimationFrame(measureTruncation);
+
+    return () => cancelAnimationFrame(frameId);
+  }, [elementRef, maxLines, isExpanded, text]);
+
+  return isTruncated;
+}

--- a/frontend/src/public/components/RichText/utils/attachmentRenderer.tsx
+++ b/frontend/src/public/components/RichText/utils/attachmentRenderer.tsx
@@ -25,7 +25,7 @@ export const createAttachmentRenderer = (
   hideIcon?: boolean,
 ) => {
   const renderLink = (url: string, name: string) => {
-    const defaultLinkHtml = `<a href="${url}" target="_blank">${name}<a/>`;
+    const defaultLinkHtml = `<a href="${url}" target="_blank">${name}</a>`;
     if (!embedVideoLinks) {
       return defaultLinkHtml;
     }

--- a/frontend/src/public/components/RichText/utils/attachmentRenderer.tsx
+++ b/frontend/src/public/components/RichText/utils/attachmentRenderer.tsx
@@ -1,0 +1,117 @@
+import * as React from 'react';
+import ReactDOMServer from 'react-dom/server';
+import { Remarkable } from 'remarkable';
+import { LinkCloseToken } from 'remarkable/lib';
+
+import {
+  youtubeVideoRegexp,
+  loomVideoRegexp,
+  wistiaVideoRegexp,
+} from '../../../constants/defaultValues';
+import { DocumentAttachment } from '../../Attachments/DocumentAttachment';
+import {
+  linksRemarkablePlugin,
+  TCustomLinkToken,
+} from '../../RichEditor/utils/converters/customMarkdownPlugins';
+import { ECustomEditorEntities } from '../../RichEditor/utils/types';
+
+interface IAttachmentRendererStyles {
+  video: string;
+}
+
+export const createAttachmentRenderer = (
+  embedVideoLinks: boolean,
+  styles: IAttachmentRendererStyles,
+  hideIcon?: boolean,
+) => {
+  const renderLink = (url: string, name: string) => {
+    const defaultLinkHtml = `<a href="${url}" target="_blank">${name}<a/>`;
+    if (!embedVideoLinks) {
+      return defaultLinkHtml;
+    }
+
+    const renderRules = [
+      {
+        regExp: loomVideoRegexp,
+        replaceLogic: (_match: string, group1: string) => {
+          return '<div><iframe'
+            + ` class="${styles.video}"`
+            + ' frameBorder="0"'
+            + ` src="https://www.useloom.com/embed/${group1}"`
+            + ' webkitallowfullscreen mozallowfullscreen allowfullscreen'
+            + '></iframe></div>';
+        },
+      },
+      {
+        regExp: youtubeVideoRegexp,
+        replaceLogic: (_match: string, group1: string) => {
+          return '<div><iframe'
+            + ` class="${styles.video}"`
+            + ' frameBorder="0"'
+            + ` src="//www.youtube.com/embed/${group1}"`
+            + ' webkitallowfullscreen mozallowfullscreen allowfullscreen'
+            + '></iframe></div>';
+        },
+      },
+      {
+        regExp: wistiaVideoRegexp,
+        replaceLogic: (_match: string, videoId: string) => {
+          const videoUrl = `https://fast.wistia.com/embed/medias/${videoId}`;
+
+          return '<div><iframe'
+            + ` class="${styles.video}"`
+            + ' allowtransparency="true" frameborder="0" scrolling="no"'
+            + ` src="${videoUrl}"`
+            + ' webkitallowfullscreen mozallowfullscreen allowfullscreen'
+            + '></iframe></div>';
+        },
+      },
+    ];
+
+    const renderVideoLogic = renderRules.find(({ regExp }) => regExp.test(url));
+    if (renderVideoLogic) {
+      return url.replace(renderVideoLogic.regExp, renderVideoLogic.replaceLogic);
+    }
+
+    return defaultLinkHtml;
+  };
+
+  return (md: Remarkable) => {
+    md.inline.ruler.disable(['links']);
+    md.use(linksRemarkablePlugin, {});
+
+    // @ts-expect-error remarkable token type extended by custom plugin
+    md.renderer.rules.link_open = (tokens: TCustomLinkToken[], idx: number) => {
+      const { url, name, entityType, isLinkified } = tokens[idx];
+
+      if (isLinkified || !entityType) {
+        return renderLink(url, name);
+      }
+
+      const renderMap: Record<ECustomEditorEntities, string> = {
+        [ECustomEditorEntities.Link]: `<a href="${url}" target="_blank">`,
+        [ECustomEditorEntities.Image]: `<img src=${url} />`,
+        [ECustomEditorEntities.Video]: ReactDOMServer.renderToStaticMarkup(
+          // eslint-disable-next-line jsx-a11y/media-has-caption
+          <video src={url} preload="auto" controls />,
+        ),
+        [ECustomEditorEntities.File]: ReactDOMServer.renderToStaticMarkup(
+          <DocumentAttachment name={name} url={url} isEdit={false} hideIcon={hideIcon} />,
+        ),
+        [ECustomEditorEntities.Variable]: '',
+        [ECustomEditorEntities.Mention]: '',
+      };
+
+      return renderMap[entityType];
+    };
+
+    md.renderer.rules.link_close = (tokens: LinkCloseToken[], idx: number) => {
+      const { entityType } = tokens[idx] as LinkCloseToken & { entityType?: string };
+      if (entityType === 'LINK') {
+        return '</a>';
+      }
+
+      return '';
+    };
+  };
+};

--- a/frontend/src/public/components/RichText/utils/createRichTextRemarkable.ts
+++ b/frontend/src/public/components/RichText/utils/createRichTextRemarkable.ts
@@ -1,0 +1,51 @@
+import { Remarkable } from 'remarkable';
+
+import { checklistsRemarkablePlugin } from '../../RichEditor/utils/converters/customMarkdownPlugins';
+import { createChecklistRenderer } from '../../TaskCard/checklist/createChecklistRenderer';
+import { createCheckPlaceholderId } from '../../TaskCard/checklist/createCheckPlaceholderId';
+import { createProgressbarPlaceholderId } from '../../TaskCard/checklist/createProgressbarPlaceholderId';
+import { linkify } from '../linkify';
+import { createAttachmentRenderer } from './attachmentRenderer';
+
+interface ICreateRichTextRemarkableOptions {
+  embedVideos: boolean;
+  hideIcon?: boolean;
+  interactiveChecklists?: boolean;
+  checkboxPlaceholderClassName: string;
+  videoClassName: string;
+}
+
+export const createRichTextRemarkable = ({
+  embedVideos,
+  hideIcon,
+  interactiveChecklists,
+  checkboxPlaceholderClassName,
+  videoClassName,
+}: ICreateRichTextRemarkableOptions): Remarkable => {
+  return new Remarkable({
+    html: true,
+    breaks: true,
+  })
+    .use(checklistsRemarkablePlugin)
+    .use(linkify)
+    .use(createAttachmentRenderer(embedVideos, { video: videoClassName }, hideIcon))
+    .use(
+      createChecklistRenderer({
+        renderCheck: (listApiName, itemApiName) => {
+          if (interactiveChecklists) {
+            return `<div id="${createCheckPlaceholderId(listApiName, itemApiName)}"></div>`;
+          }
+
+          return `<div class="${checkboxPlaceholderClassName}"></div>`;
+        },
+        renderProgressbar: (listApiName) => {
+          if (!interactiveChecklists) {
+            return '';
+          }
+
+          return `<div id="${createProgressbarPlaceholderId(listApiName)}"></div>`;
+        },
+        interactiveChecklist: interactiveChecklists,
+      }),
+    );
+};

--- a/frontend/src/public/components/RichText/utils/prepareRichTextHtml.ts
+++ b/frontend/src/public/components/RichText/utils/prepareRichTextHtml.ts
@@ -1,0 +1,80 @@
+import * as xssFilters from 'xss-filters';
+import { IntlShape } from 'react-intl';
+
+import {
+  mentionsRegex,
+  variableRegex,
+} from '../../../constants/defaultValues';
+import { isArrayWithItems } from '../../../utils/helpers';
+import { truncateString } from '../../../utils/truncateString';
+import { prepareChecklistsForRendering } from '../../../utils/checklists/prepareChecklistsForRendering';
+import { TTaskVariable } from '../../TemplateEdit/types';
+import { getLocalizedSystemVariable } from '../../TemplateEdit/TaskForm/utils/getTaskVariables';
+
+const MAX_VARIABLE_LENGTH = 20;
+
+interface IPrepareRichTextHtmlOptions {
+  variables?: TTaskVariable[];
+  formatMessage: IntlShape['formatMessage'];
+  mentionClassName: string;
+  badgeClassName: string;
+  specificityBadgeClassName: string;
+}
+
+type TReplaceRule =
+  | { regExp: RegExp; replaceLogic: string }
+  | { regExp: RegExp; replaceLogic: (substring: string, ...args: unknown[]) => string };
+
+export function prepareRichTextHtml(
+  text: string,
+  {
+    variables,
+    formatMessage,
+    mentionClassName,
+    badgeClassName,
+    specificityBadgeClassName,
+  }: IPrepareRichTextHtmlOptions,
+): string {
+  const replaceRules: TReplaceRule[] = [
+    {
+      regExp: mentionsRegex,
+      replaceLogic: `<span class='${mentionClassName}'>@$1</span>`,
+    },
+    {
+      regExp: variableRegex,
+      replaceLogic: (match: string, variableApiName: string) => {
+        if (!isArrayWithItems(variables)) {
+          return match;
+        }
+
+        const variable = variables.find((item) => variableApiName === item.apiName);
+        if (!variable) {
+          return match;
+        }
+
+        const { title } = getLocalizedSystemVariable({
+          apiName: variableApiName,
+          title: variable.title,
+          formatMessage,
+        });
+
+        return `<span class="${badgeClassName} ${specificityBadgeClassName}">${truncateString(
+          title,
+          MAX_VARIABLE_LENGTH,
+        )}</span>`;
+      },
+    },
+  ];
+
+  const sanitizedText = xssFilters.inHTMLData(prepareChecklistsForRendering(text));
+
+  return replaceRules.reduce((acc, { regExp, replaceLogic }) => {
+    const replaceRegex = new RegExp(regExp, 'gi');
+
+    if (typeof replaceLogic === 'string') {
+      return acc.replace(replaceRegex, replaceLogic);
+    }
+
+    return acc.replace(replaceRegex, replaceLogic);
+  }, sanitizedText);
+}

--- a/frontend/src/public/components/SelectTemplateModal/SelectTemplateModal.css
+++ b/frontend/src/public/components/SelectTemplateModal/SelectTemplateModal.css
@@ -54,20 +54,13 @@
 }
 
 .item__body {
-  font-size: 13px;
-  line-height: 16px;
+  font-size: 1.3rem;
+  line-height: 1.6rem;
   color: var(--pneumatic-color-black48);
+}
 
-  @supports (-webkit-line-clamp: 2) {
-    /* stylelint-disable-next-line property-no-vendor-prefix, value-no-vendor-prefix */
-    display: -webkit-box;
-    overflow: hidden;
-    white-space: initial;
-    text-overflow: ellipsis;
-    -webkit-line-clamp: 2;
-    /* stylelint-disable-next-line property-no-vendor-prefix */
-    -webkit-box-orient: vertical;
-  }
+.item__body > div {
+  @mixin text-overflow 2;
 }
 
 .link {

--- a/frontend/src/public/components/SelectTemplateModal/SelectTemplateModalItem.tsx
+++ b/frontend/src/public/components/SelectTemplateModal/SelectTemplateModalItem.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { ITemplateListItem } from '../../types/template';
+import { RichText } from '../RichText';
 import { SideModalCard } from '../UI/SideModalCard';
 
 import styles from './SelectTemplateModal.css';
@@ -14,7 +15,11 @@ export function StartProcessModalItem({ name, description, selectWorkflow }: ISt
     <SideModalCard className={styles['item-container']} onClick={selectWorkflow}>
       <SideModalCard.Title className={styles['item__title']}>{name}</SideModalCard.Title>
 
-      {description && <SideModalCard.Body className={styles['item__body']}>{description}</SideModalCard.Body>}
+      {description && (
+        <SideModalCard.Body className={styles['item__body']}>
+          <RichText text={description} embedVideos={false} />
+        </SideModalCard.Body>
+      )}
     </SideModalCard>
   );
 }

--- a/frontend/src/public/components/Templates/TemplateSystemCard/TemplateSystemCard.tsx
+++ b/frontend/src/public/components/Templates/TemplateSystemCard/TemplateSystemCard.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 import { ISystemTemplate } from '../../../types/template';
 import { sanitizeText } from '../../../utils/strings';
 import { ERoutes } from '../../../constants/routes';
+import { RichText } from '../../RichText';
 
 import styles from '../Templates.css';
 
@@ -23,7 +24,9 @@ export const TemplateSystemCard = ({ id, name, color, description, icon }: ITemp
         <div className={styles['card__header']}>
           <div className={styles['card__title']}>{sanitizeText(name)}</div>
         </div>
-        <p className={styles['card__description']}>{description}</p>
+        {description && <div className={styles['card__description']}>
+          <RichText text={description} embedVideos={false} />
+        </div>}
         {icon && (
           <div className={styles['card__footer']}>
             <div className={styles['card__icon']}>

--- a/frontend/src/public/components/Templates/Templates.css
+++ b/frontend/src/public/components/Templates/Templates.css
@@ -317,19 +317,9 @@
   width: 100%;
   font-size: 1.3rem;
   line-height: 1.6rem;
-  white-space: pre-wrap;
   text-overflow: ellipsis;
   word-break: break-word;
   color: var(--pneumatic-warning-color);
-}
-
-.description_more {
-  cursor: pointer;
-  color: var(--pneumatic-color-link) !important;
-
-  .more_delimeter {
-    color: var(--pneumatic-warning-color);
-  }
 }
 
 .popup-buttons {

--- a/frontend/src/public/components/UI/SideModalCard/SideModalCard.css
+++ b/frontend/src/public/components/UI/SideModalCard/SideModalCard.css
@@ -1,37 +1,33 @@
 .card-container {
-  padding: 16px;
+  padding: 1.6rem;
   display: flex;
   overflow: hidden;
-  background: #fdf7ee;
-  border: none;
-  border-radius: 16px;
-  transition: 0.1s ease-in-out background;
   flex-flow: column;
-}
+  background: var(--pneumatic-color-beige);
+  border: none;
+  border-radius: 1.6rem;
+  transition: background 0.1s ease-in-out;
 
-.card-container:hover {
-  background: white;
+  &:hover {
+    background: var(--pneumatic-color-white);
 
-  .card__title {
-    color: currencolor;
+    .card__title {
+      color: currentColor;
+    }
   }
 }
 
 .card__title {
-  overflow: hidden;
-  font-family: 'Abhaya Libre', 'Times New Roman', Arial;
-  font-size: 20px;
+  @mixin h6;
+
   font-weight: 800;
-  line-height: 24px;
-  text-overflow: ellipsis;
   word-break: break-word;
-  color: #262522;
+  color: var(--pneumatic-color-black100);
 }
 
 .card__footer {
+  @mixin text-small;
+
   margin-top: auto;
-  font-family: Nunito, sans-serif;
-  font-size: 13px;
-  line-height: 16px;
-  color: #979795;
+  color: var(--pneumatic-color-black48);
 }

--- a/frontend/src/public/components/WorkflowEditPopup/WorkflowEditPopup.tsx
+++ b/frontend/src/public/components/WorkflowEditPopup/WorkflowEditPopup.tsx
@@ -1,12 +1,10 @@
 import * as React from 'react';
-import { useState, useCallback, FormEvent, MouseEvent } from 'react';
+import { useState, FormEvent, MouseEvent } from 'react';
 import classnames from 'classnames';
-import Truncate from 'react-truncate';
 import { Form, Modal, ModalBody, ModalHeader } from 'reactstrap';
 import { useIntl } from 'react-intl';
 import Switch from 'rc-switch';
 
-import { ELLIPSIS_CHAR } from '../../constants/defaultValues';
 import { ERoutes } from '../../constants/routes';
 
 import { history } from '../../utils/history';
@@ -69,32 +67,12 @@ function WorkflowEditPopupComponent({
 
   const { formatMessage } = useIntl();
 
-  const descriptionLinesCount = 5;
-
   const [workflowName, changeWorkflowName] = useState(
     workflow.wfNameTemplate || `${reactElementToText(<DateFormat />)} — ${workflow.name}`,
   );
   const [kickoffState, setKickoffState] = useState(getInitialKickoff(workflow.kickoff));
 
   const [isUrgent, setIsUrgent] = useState(false);
-
-  const [textExpaned, setTextExpanded] = useState(false);
-  const expandText = useCallback(() => setTextExpanded(!textExpaned), [textExpaned]);
-
-  const ellispis = (
-    // eslint-disable-next-line jsx-a11y/anchor-is-valid
-    <a
-      href="#"
-      role="button"
-      tabIndex={0}
-      onClick={(e) => { e.preventDefault(); expandText(); }}
-      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') expandText(); }}
-      className={styles['description_more']}
-    >
-      <span className={styles['more_delimeter']}>{ELLIPSIS_CHAR}</span>
-      <IntlMessages id="templates.description-more" />
-    </a>
-  );
 
   const handleEditField = (apiName: string) => (changedProps: Partial<IExtraField>) => {
     setKickoffState((prevKickoff) => {
@@ -146,20 +124,12 @@ function WorkflowEditPopupComponent({
           <div className={styles['popup-title__name']}>{workflow.name}</div>
         </div>
         {workflow.description && (
-          <div className={styles['popup-description']}>
-            <Truncate lines={!textExpaned && descriptionLinesCount} ellipsis={ellispis} trimWhitespace>
-              {/* eslint-disable react/no-array-index-key */}
-              {workflow.description.split('\n').map((el, i, arr) => {
-                const line = <span key={i}>{el}</span>;
-                if (i === arr.length - 1) {
-                  return line;
-                }
-
-                return [line, <br key={`${i}br`} />];
-              })}
-              {/* eslint-enable react/no-array-index-key */}
-            </Truncate>
-          </div>
+          <RichText
+            text={workflow.description}
+            embedVideos={false}
+            maxLines={5}
+            className={styles['popup-description']}
+          />
         )}
         <div className={styles['workflow-modal-info']}>
           <div className={styles['workflow-modal-info__stats']}>

--- a/frontend/src/public/components/WorkflowEditPopup/__tests__/WorkflowEditPopup.test.tsx
+++ b/frontend/src/public/components/WorkflowEditPopup/__tests__/WorkflowEditPopup.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 import { enMessages } from '../../../lang/locales/en_US';
 
@@ -97,6 +97,21 @@ describe('WorkflowEditPopup', () => {
       renderWithIntl(<WorkflowEditPopup {...baseProps} workflow={workflow} />);
 
       expect(screen.getAllByTestId('extra-field')).toHaveLength(2);
+    });
+  });
+
+  describe('Template description', () => {
+    it('renders markdown in template description', async () => {
+      const workflow = {
+        ...baseWorkflow,
+        description: '**Bold description**',
+      };
+
+      renderWithIntl(<WorkflowEditPopup {...baseProps} workflow={workflow} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Bold description')).toBeInTheDocument();
+      });
     });
   });
 });

--- a/frontend/src/public/components/Workflows/WorkflowModal/WorkflowModal.tsx
+++ b/frontend/src/public/components/Workflows/WorkflowModal/WorkflowModal.tsx
@@ -30,6 +30,7 @@ import { getWorkflowProgressColor } from '../utils/getWorkflowProgressColor';
 import { getEditedFields } from '../../TemplateEdit/ExtraFields/utils/getEditedFields';
 import { UserData } from '../../UserData';
 import { DateFormat } from '../../UI/DateFormat';
+import { RichText } from '../../RichText';
 
 import styles from './WorkflowModal.css';
 import {
@@ -425,7 +426,11 @@ export class WorkflowModal extends React.Component<IWorkflowModalProps> {
     const workflowDescription = workflow?.description;
 
     if (workflowDescription) {
-      return <div className={styles['popup-description']}>{workflowDescription}</div>;
+      return (
+        <div className={styles['popup-description']}>
+          <RichText text={workflowDescription} embedVideos={false} />
+        </div>
+      );
     }
 
     return null;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches shared RichText rendering and XSS/sanitization paths used across modals; behavior changes are mostly display-only but wide surface area for markdown/HTML regressions.
> 
> **Overview**
> Template and workflow descriptions now render through **`RichText`** (markdown, mentions, variables) instead of plain text in system template cards, the start-process modal, **`WorkflowEditPopup`**, and **`WorkflowModal`**, with **`embedVideos={false}`** in those surfaces.
> 
> **`RichText`** gains optional **`maxLines`** plus a **`RichTextMoreLink`** expand control; the run-workflow popup uses **5 lines** and drops **`react-truncate`** / manual “more” markup. Rendering logic is split into **`prepareRichTextHtml`**, **`createRichTextRemarkable`**, **`useRichTextContainer`**, and **`useRichTextLineClamp`**, and paragraph spacing no longer relies on the old `&nbsp;` newline hack (covered by a new test).
> 
> **`RichText.css`** and Lexical editor CSS add shared **h1–h6** typography and spacing tweaks (rem units, list markers). **`MarkdownShortcutPlugin`** now includes **`TEXT_FORMAT_TRANSFORMERS`** so bold/italic shortcuts work in the editor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 734bd843d24fdca9daf0cf1f290de21e6fbe1219. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add markdown rendering support to template and workflow descriptions
> - Replaces plain text description rendering in `WorkflowEditPopup`, `WorkflowModal`, `SelectTemplateModal`, and `TemplateSystemCard` with the `RichText` component, enabling markdown output.
> - Refactors `RichText` to support line clamping via a new `maxLines` prop, showing a 'More' link (via `RichTextMoreLink`) when content exceeds the limit, replacing the previous `react-truncate` approach.
> - Extracts markdown processing into `createRichTextRemarkable`, `prepareRichTextHtml`, and `createAttachmentRenderer` utilities for a centralized, consistent pipeline.
> - Adds `useRichTextLineClamp` and `useRichTextContainer` hooks to handle truncation detection and image loading/fullscreen behavior.
> - Behavioral Change: paragraph rendering no longer injects non-breaking space blocks between blank lines; `MarkdownShortcutPlugin` in the Lexical editor now also recognizes text-format shortcuts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 734bd84.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->