### PR TITLE
47610 frontend [ tasks ] Update workflow names after rename

### DIFF
--- a/frontend/src/public/redux/workflows/saga.ts
+++ b/frontend/src/public/redux/workflows/saga.ts
@@ -100,6 +100,7 @@ import {
   getLastLoadedTemplateIdForTable,
 } from '../selectors/workflows';
 import { getCurrentTask } from '../selectors/task';
+import { syncRenamedWorkflowToTasks } from './utils/syncRenamedWorkflowToTasks';
 import { getEditKickoff, mapFilesToRequest } from '../../utils/workflows';
 import { getErrorMessage } from '../../utils/getErrorMessage';
 import { getWorkflows } from '../../api/getWorkflows';
@@ -474,36 +475,11 @@ function* editWorkflowInWork({ payload }: PayloadAction<TEditWorkflowPayload>) {
       );
     }
     if (name) {
-      if (task) {
-        const hasMainWorkflowMatch = payload.workflowId === task.workflow.id;
-        const hasSubWorkflowMatch = task.subWorkflows?.some((subWorkflow) => subWorkflow.id === payload.workflowId);
-
-        if (hasMainWorkflowMatch || hasSubWorkflowMatch) {
-          yield put(setCurrentTask({
-            ...task,
-            ...(hasMainWorkflowMatch && {
-              workflow: { ...task.workflow, name: formattedEditedWorkflow.name },
-            }),
-            ...(hasSubWorkflowMatch && {
-              subWorkflows: task.subWorkflows.map((subWorkflow) =>
-                subWorkflow.id === payload.workflowId
-                  ? { ...subWorkflow, name: formattedEditedWorkflow.name }
-                  : subWorkflow,
-              ),
-            }),
-          }));
-        }
-      }
-
-      yield all(
-        formattedWorkflow.tasks.map((localTask: IWorkflowTaskClient) =>
-          put(
-            patchTaskInList({
-              taskId: localTask.id,
-              task: { workflowName: formattedEditedWorkflow.name },
-            }),
-          ),
-        ),
+      yield syncRenamedWorkflowToTasks(
+        task,
+        payload.workflowId,
+        formattedEditedWorkflow.name,
+        formattedWorkflow.tasks,
       );
     }
     // yield put(loadWorkflowsList(0));

--- a/frontend/src/public/redux/workflows/saga.ts
+++ b/frontend/src/public/redux/workflows/saga.ts
@@ -473,6 +473,39 @@ function* editWorkflowInWork({ payload }: PayloadAction<TEditWorkflowPayload>) {
         ),
       );
     }
+    if (name) {
+      if (task) {
+        const hasMainWorkflowMatch = payload.workflowId === task.workflow.id;
+        const hasSubWorkflowMatch = task.subWorkflows?.some((subWorkflow) => subWorkflow.id === payload.workflowId);
+
+        if (hasMainWorkflowMatch || hasSubWorkflowMatch) {
+          yield put(setCurrentTask({
+            ...task,
+            ...(hasMainWorkflowMatch && {
+              workflow: { ...task.workflow, name: formattedEditedWorkflow.name },
+            }),
+            ...(hasSubWorkflowMatch && {
+              subWorkflows: task.subWorkflows.map((subWorkflow) =>
+                subWorkflow.id === payload.workflowId
+                  ? { ...subWorkflow, name: formattedEditedWorkflow.name }
+                  : subWorkflow,
+              ),
+            }),
+          }));
+        }
+      }
+
+      yield all(
+        formattedWorkflow.tasks.map((localTask: IWorkflowTaskClient) =>
+          put(
+            patchTaskInList({
+              taskId: localTask.id,
+              task: { workflowName: formattedEditedWorkflow.name },
+            }),
+          ),
+        ),
+      );
+    }
     // yield put(loadWorkflowsList(0));
     yield updateDetailedWorkflow(payload.workflowId);
 

--- a/frontend/src/public/redux/workflows/utils/syncRenamedWorkflowToTasks.ts
+++ b/frontend/src/public/redux/workflows/utils/syncRenamedWorkflowToTasks.ts
@@ -1,0 +1,55 @@
+import { all, put } from 'redux-saga/effects';
+
+import { setCurrentTask } from '../../actions';
+import { patchTaskInList } from '../../tasks/slice';
+import { ITask } from '../../../types/tasks';
+import { IWorkflowTaskClient } from '../../../types/workflow';
+
+export function getTaskWithRenamedWorkflow(
+  task: ITask,
+  workflowId: number,
+  workflowName: string,
+): ITask | null {
+  const isMainWorkflow = workflowId === task.workflow.id;
+  const isSubWorkflow = task.subWorkflows?.some((subWorkflow) => subWorkflow.id === workflowId);
+
+  if (!isMainWorkflow && !isSubWorkflow) {
+    return null;
+  }
+
+  return {
+    ...task,
+    ...(isMainWorkflow && {
+      workflow: { ...task.workflow, name: workflowName },
+    }),
+    ...(isSubWorkflow && {
+      subWorkflows: task.subWorkflows.map((subWorkflow) =>
+        subWorkflow.id === workflowId ? { ...subWorkflow, name: workflowName } : subWorkflow,
+      ),
+    }),
+  };
+}
+
+export function* syncRenamedWorkflowToTasks(
+  task: ITask | null,
+  workflowId: number,
+  workflowName: string,
+  workflowTasks: IWorkflowTaskClient[],
+) {
+  if (task) {
+    const updatedTask = getTaskWithRenamedWorkflow(task, workflowId, workflowName);
+
+    if (updatedTask) {
+      yield put(setCurrentTask(updatedTask));
+    }
+  }
+
+  yield all(
+    workflowTasks.map((workflowTask) =>
+      put(patchTaskInList({
+        taskId: workflowTask.id,
+        task: { workflowName },
+      })),
+    ),
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized Redux updates after an existing edit flow; no API or auth changes.
> 
> **Overview**
> After a successful **workflow rename**, task-related Redux state now stays in sync instead of showing the old name in the task list and open task detail.
> 
> `editWorkflowInWork` calls a new saga helper when `name` is in the edit payload. It updates **`setCurrentTask`** if the open task’s main workflow or a matching **sub-workflow** was renamed, and **`patchTaskInList`** for every task on that workflow with the new **`workflowName`** (for list/preview UI).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 601c5941277cb6264bcbd97a71b9930fa48253fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update task workflow names when a workflow is renamed
> - Adds `syncRenamedWorkflowToTasks` in [syncRenamedWorkflowToTasks.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/242/files#diff-95106c32ffcf4e0ec22f0b42dd9a9460f9a8ef18f0ef4746a7ff49ca9200abf6), a saga util that updates `workflowName` on the current task and patches all tasks in the workflow list when a workflow is renamed.
> - The `editWorkflowInWork` saga in [saga.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/242/files#diff-33f0f5384094add22dcaa819b1d9d7b784f406bc8781f39b2b67f57bd0938da8) calls this util when a new name is provided, passing the current task, workflow ID, and formatted name.
> - A pure helper `getTaskWithRenamedWorkflow` checks if a task is linked to the renamed workflow (as main workflow or sub-workflow) and returns an updated copy, or null if unrelated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 601c594.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->