### PR TITLE
47616 frontend [ tasks ] Insert urgent tasks after urgent block

### DIFF
--- a/frontend/src/public/redux/tasks/utils/__tests__/getTaskListWithNewTask.test.ts
+++ b/frontend/src/public/redux/tasks/utils/__tests__/getTaskListWithNewTask.test.ts
@@ -72,7 +72,7 @@ describe('getTaskListWithNewTask', () => {
     expect(resultTaskList.count).toEqual(4);
   });
 
-  it('inserts urgent task in the top of list if sorting is "Oldest first"', () => {
+  it('inserts urgent task before non-urgent tasks if sorting is "Oldest first"', () => {
     const initialTaskList: ITaskList = {
       items: [createMockTask({ id: 1 }), createMockTask({ id: 2 }), createMockTask({ id: 3 })],
       count: 3,
@@ -86,6 +86,28 @@ describe('getTaskListWithNewTask', () => {
     expect(resultTaskList.items.findIndex((task) => task.id === NEW_TASK_ID)).toEqual(0);
     expect(resultTaskList.offset).toEqual(4);
     expect(resultTaskList.count).toEqual(4);
+  });
+
+  it('inserts urgent task at the end of urgent block if sorting is "Oldest first" and all loaded tasks are urgent', () => {
+    const initialTaskList: ITaskList = {
+      items: [
+        createMockTask({ id: 1, isUrgent: true }),
+        createMockTask({ id: 2, isUrgent: true }),
+        createMockTask({ id: 3, isUrgent: true }),
+        createMockTask({ id: 4, isUrgent: true }),
+      ],
+      count: 4,
+      offset: 4,
+    };
+
+    const NEW_TASK_ID = 5;
+    const newTask = createMockTask({ id: NEW_TASK_ID, isUrgent: true });
+    const resultTaskList = getTaskListWithNewTask(initialTaskList, newTask, ETaskListSorting.DateAsc);
+
+    expect(resultTaskList.items.findIndex((task) => task.id === NEW_TASK_ID)).toEqual(4);
+    expect(resultTaskList.items.map((task) => task.id)).toEqual([1, 2, 3, 4, 5]);
+    expect(resultTaskList.offset).toEqual(5);
+    expect(resultTaskList.count).toEqual(5);
   });
 
   it('does not insert task if sorting is "Oldest first" and list is not fully loaded', () => {

--- a/frontend/src/public/redux/tasks/utils/getTaskListWithNewTask.ts
+++ b/frontend/src/public/redux/tasks/utils/getTaskListWithNewTask.ts
@@ -18,6 +18,7 @@ export function getTaskListWithNewTask(
   const firstNotUrgentIndex = tasksItems.findIndex(task => {
     return !task.isUrgent;
   });
+  const urgentItemsEndIndex = firstNotUrgentIndex === -1 ? tasksItems.length : firstNotUrgentIndex;
   const tasksItemsLength = tasksItems.length;
 
   const insertTaskMap:
@@ -62,8 +63,8 @@ export function getTaskListWithNewTask(
   };
 
   if (newTask.isUrgent) {
-    const newTaskList = insertTaskMap[sorting](tasksItems.slice(0, firstNotUrgentIndex));
-    const items = [...newTaskList, ...tasksItems.slice(firstNotUrgentIndex)];
+    const newTaskList = insertTaskMap[sorting](tasksItems.slice(0, urgentItemsEndIndex));
+    const items = [...newTaskList, ...tasksItems.slice(urgentItemsEndIndex)];
     const offset = items.length - tasksItems.length;
 
     return {
@@ -72,8 +73,8 @@ export function getTaskListWithNewTask(
       offset: tasksOffset + offset,
     };
   }
-  const newTaskList = insertTaskMap[sorting](tasksItems.slice(firstNotUrgentIndex));
-  const items = [...tasksItems.slice(0, firstNotUrgentIndex), ...newTaskList];
+  const newTaskList = insertTaskMap[sorting](tasksItems.slice(urgentItemsEndIndex));
+  const items = [...tasksItems.slice(0, urgentItemsEndIndex), ...newTaskList];
   const offset = items.length - tasksItems.length;
 
   return {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized Redux list-insertion logic with added unit tests; no auth, API, or data-persistence changes.
> 
> **Overview**
> Fixes **urgent task insertion** in `getTaskListWithNewTask` when the loaded list has **no non-urgent tasks**. The helper now derives `urgentItemsEndIndex` from `firstNotUrgentIndex`, using the full list length when every item is urgent, instead of slicing with `-1` (which dropped the last urgent item and mis-placed new urgent tasks).
> 
> For **Oldest first** (`DateAsc`), a new urgent task is still inserted ahead of non-urgent work when any exists; when the visible list is all urgent, it is appended **after** the existing urgent block. Tests rename the mixed-list case and add coverage for the all-urgent **DateAsc** scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 573785a46bd718b383d3b2d7424f573d1a5353f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix urgent task insertion when all loaded tasks are urgent in task list
> When all loaded tasks are urgent, `getTaskListWithNewTask` previously used `slice(0, -1)`, which dropped the last item in the list. The fix introduces `urgentItemsEndIndex` in [getTaskListWithNewTask.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/243/files#diff-0b15f8488f891af13d5bcfc5793ed9016080e0c9d43fdfc965bd65f32a1d126c) that falls back to `tasksItems.length` when no non-urgent item exists, ensuring the full urgent block is used as the slice boundary. A new test covering this case is added in [getTaskListWithNewTask.test.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/243/files#diff-2484f7f6694ad6dfa7826546c7d3cff21c467bf030f3c1cdf404dfea4f25f70c).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 573785a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->