### PR TITLE
47673 fix(tests): update RichText snapshots

### DIFF
--- a/frontend/src/public/components/RichText/__tests__/__snapshots__/RichText.test.tsx.snap
+++ b/frontend/src/public/components/RichText/__tests__/__snapshots__/RichText.test.tsx.snap
@@ -2,11 +2,9 @@
 
 exports[`RichText RichText and loom link in text flag return text with loom iframe 1`] = `
 <div
-  class="rich-editor-content container"
+  class="container"
 >
-  <p
-    class="lexical-rich-editor-paragraph"
-  >
+  <p>
     test1 
   </p>
   <div>
@@ -27,11 +25,9 @@ exports[`RichText RichText and loom link in text flag return text with loom ifra
 
 exports[`RichText RichText and youtube and loom link in text flag return text with youtube and loom iframe 1`] = `
 <div
-  class="rich-editor-content container"
+  class="container"
 >
-  <p
-    class="lexical-rich-editor-paragraph"
-  >
+  <p>
     test1 
   </p>
   <div>
@@ -63,11 +59,9 @@ exports[`RichText RichText and youtube and loom link in text flag return text wi
 
 exports[`RichText RichText and youtube in text flag return text with youtube iframe 1`] = `
 <div
-  class="rich-editor-content container"
+  class="container"
 >
-  <p
-    class="lexical-rich-editor-paragraph"
-  >
+  <p>
     test1 
   </p>
   <div>
@@ -88,41 +82,33 @@ exports[`RichText RichText and youtube in text flag return text with youtube ifr
 
 exports[`RichText renders correct html for mentions and links 1`] = `
 <div
-  class="rich-editor-content container"
+  class="container"
 >
-  <p
-    class="lexical-rich-editor-paragraph"
-  >
+  <p>
     Hello, 
     <span
-      class="lexical-rich-editor-mention"
+      class="mention"
     >
       @Jyoti Puri
     </span>
     , look here: link: 
     <a
-      class="lexical-rich-editor-link"
       href="http://pneumatic.app/"
       target="_blank"
     >
       http://pneumatic.app/
     </a>
-    <a />
   </p>
-  <a>
-    
+  
 
-  </a>
 </div>
 `;
 
 exports[`RichText renders correct html for plain text 1`] = `
 <div
-  class="rich-editor-content container"
+  class="container"
 >
-  <p
-    class="lexical-rich-editor-paragraph"
-  >
+  <p>
     Some plain text
   </p>
   


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only snapshot updates with no production code in this diff.
> 
> **Overview**
> Updates **RichText** Jest snapshots so they match the component’s current read-only HTML output.
> 
> Expected markup no longer uses Lexical-oriented wrappers and classes (`rich-editor-content`, `lexical-rich-editor-paragraph`, `lexical-rich-editor-mention`, `lexical-rich-editor-link`). Snapshots now use a plain `container` wrapper, unclassed `<p>` tags, `mention` on spans, and links without the Lexical link class. The mentions/links case also drops extra empty `<a>` nodes that were previously emitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3ac87c1f7939226bc50fcfb3e352315d641038e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update RichText component test snapshots
> Updates the snapshot file for `RichText` component tests to match the current rendered output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f3ac87c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->