### PR TITLE
⚙️ 47721 backend [ accounts ] New API endpoint: get all account users 

### DIFF
--- a/backend/src/accounts/filters.py
+++ b/backend/src/accounts/filters.py
@@ -94,6 +94,7 @@ class UsersListFilterSet(FilterSet):
     groups = ListFilter(
         field_name='user_groups',
         lookup_expr='in',
+        distinct=True,
     )
 
 

--- a/backend/src/accounts/serializers/api_key.py
+++ b/backend/src/accounts/serializers/api_key.py
@@ -1,4 +1,5 @@
 from django.contrib.auth import get_user_model
+from django.core.exceptions import ObjectDoesNotExist
 from rest_framework import serializers
 
 from src.accounts.models import (
@@ -16,3 +17,27 @@ class APIKeyListSerializer(serializers.ModelSerializer):
             'name',
             'key',
         )
+
+
+class UserAPIKeySerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = UserModel
+        fields = (
+            'first_name',
+            'last_name',
+            'email',
+            'is_admin',
+            'is_account_owner',
+            'api_key',
+            'type',
+            'status',
+        )
+
+    api_key = serializers.SerializerMethodField()
+
+    def get_api_key(self, obj) -> str:
+        try:
+            return obj.apikey.key
+        except ObjectDoesNotExist:
+            return None

--- a/backend/src/accounts/tests/views/test_users/test_api_key.py
+++ b/backend/src/accounts/tests/views/test_users/test_api_key.py
@@ -1,0 +1,528 @@
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+
+from src.accounts.enums import (
+    BillingPlanType,
+    UserStatus,
+    UserType,
+)
+from src.accounts.messages import (
+    MSG_A_0035,
+    MSG_A_0036,
+    MSG_A_0041,
+)
+from src.accounts.models import APIKey
+from src.authentication.tokens import PneumaticToken
+from src.generics.messages import MSG_GE_0001
+from src.processes.tests.fixtures import (
+    create_invited_user,
+    create_test_account,
+    create_test_admin,
+    create_test_group,
+    create_test_guest,
+    create_test_not_admin,
+    create_test_owner,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+def test_api_key__ok(api_client):
+
+    # arrange
+    account = create_test_account()
+    owner = create_test_owner(account=account)
+    api_key = APIKey.objects.create(
+        user=owner,
+        name=owner.get_full_name(),
+        account_id=owner.account_id,
+        key=PneumaticToken.create(owner, for_api_key=True),
+    )
+    api_client.token_authenticate(owner)
+
+    # act
+    response = api_client.get('/accounts/users/api-key')
+
+    # assert
+    assert response.status_code == 200
+    assert len(response.data) == 1
+    data = response.data[0]
+    assert data['first_name'] == owner.first_name
+    assert data['last_name'] == owner.last_name
+    assert data['email'] == owner.email
+    assert data['is_admin'] == owner.is_admin
+    assert data['is_account_owner'] == owner.is_account_owner
+    assert data['api_key'] == api_key.key
+    assert data['type'] == owner.type
+    assert data['status'] == owner.status
+
+
+def test_api_key__pagination__ok(api_client):
+
+    """ Pagination parameters limit=2 offset=1 are ignored """
+
+    # arrange
+    account = create_test_account()
+    owner = create_test_owner(account=account)
+    create_test_admin(account=account)
+    create_test_not_admin(account=account)
+    api_client.token_authenticate(owner)
+
+    # act
+    response = api_client.get(
+        path='/accounts/users/api-key',
+        data={'limit': 2, 'offset': 1},
+    )
+
+    # assert
+    assert response.status_code == 200
+    assert len(response.data) == 3
+
+
+def test_api_key__user_without_api_key__ok(api_client):
+
+    """ User without APIKey — api_key field is null """
+
+    # arrange
+    account = create_test_account()
+    owner = create_test_owner(account=account)
+    api_client.token_authenticate(owner)
+
+    # act
+    response = api_client.get('/accounts/users/api-key')
+
+    # assert
+    assert response.status_code == 200
+    assert len(response.data) == 1
+    assert response.data[0]['email'] == owner.email
+    assert response.data[0]['api_key'] is None
+
+
+def test_api_key__account_scope__ok(api_client):
+
+    """ Only users from the requester's account are returned """
+
+    # arrange
+    account_1 = create_test_account(name='Account 1')
+    owner_1 = create_test_owner(account=account_1)
+    account_2 = create_test_account(name='Account 2')
+    create_test_owner(
+        account=account_2,
+        email='owner2@test.test',
+    )
+    create_test_not_admin(
+        account=account_2,
+        email='user2@test.test',
+    )
+    api_client.token_authenticate(owner_1)
+
+    # act
+    response = api_client.get('/accounts/users/api-key')
+
+    # assert
+    assert response.status_code == 200
+    assert len(response.data) == 1
+    assert response.data[0]['email'] == owner_1.email
+
+
+def test_api_key__invited_users_included__ok(api_client):
+
+    """ Users with a pending UserInvite are included in results """
+
+    # arrange
+    account = create_test_account()
+    owner = create_test_owner(account=account)
+    invited_user = create_invited_user(
+        user=owner,
+        email='invited@test.test',
+    )
+    api_client.token_authenticate(owner)
+
+    # act
+    response = api_client.get('/accounts/users/api-key')
+
+    # assert
+    assert response.status_code == 200
+    assert len(response.data) == 2
+    # default ordering: last_name asc; '' < 'Doe'
+    assert response.data[0]['email'] == invited_user.email
+    assert response.data[1]['email'] == owner.email
+
+
+def test_api_key__filter_type_user__ok(api_client):
+
+    """ Filter type=user returns only regular users """
+
+    # arrange
+    account = create_test_account()
+    owner = create_test_owner(account=account)
+    create_test_guest(account=account)
+    api_client.token_authenticate(owner)
+
+    # act
+    response = api_client.get(
+        path='/accounts/users/api-key',
+        data={'type': UserType.USER},
+    )
+
+    # assert
+    assert response.status_code == 200
+    assert len(response.data) == 1
+    assert response.data[0]['type'] == UserType.USER
+    assert response.data[0]['email'] == owner.email
+
+
+def test_api_key__filter_type_guest__ok(api_client):
+
+    """ Filter type=guest returns only guest users """
+
+    # arrange
+    account = create_test_account()
+    owner = create_test_owner(account=account)
+    guest = create_test_guest(account=account)
+    api_client.token_authenticate(owner)
+
+    # act
+    response = api_client.get(
+        path='/accounts/users/api-key',
+        data={'type': UserType.GUEST},
+    )
+
+    # assert
+    assert response.status_code == 200
+    assert len(response.data) == 1
+    assert response.data[0]['type'] == UserType.GUEST
+    assert response.data[0]['email'] == guest.email
+
+
+def test_api_key__filter_status_active__ok(api_client):
+
+    """ Filter status=active returns only active users """
+
+    # arrange
+    account = create_test_account()
+    owner = create_test_owner(account=account)
+    create_test_not_admin(
+        account=account,
+        email='inactive@test.test',
+        status=UserStatus.INACTIVE,
+    )
+    create_invited_user(user=owner, email='invited@test.test')
+    api_client.token_authenticate(owner)
+
+    # act
+    response = api_client.get(
+        path='/accounts/users/api-key',
+        data={'status': UserStatus.ACTIVE},
+    )
+
+    # assert
+    assert response.status_code == 200
+    assert len(response.data) == 1
+    assert response.data[0]['status'] == UserStatus.ACTIVE
+    assert response.data[0]['email'] == owner.email
+
+
+def test_api_key__filter_status_invited__ok(api_client):
+
+    """ Filter status=invited returns only invited users """
+
+    # arrange
+    account = create_test_account()
+    owner = create_test_owner(account=account)
+    invited_user = create_invited_user(
+        user=owner,
+        email='invited@test.test',
+    )
+    api_client.token_authenticate(owner)
+
+    # act
+    response = api_client.get(
+        path='/accounts/users/api-key',
+        data={'status': UserStatus.INVITED},
+    )
+
+    # assert
+    assert response.status_code == 200
+    assert len(response.data) == 1
+    assert response.data[0]['status'] == UserStatus.INVITED
+    assert response.data[0]['email'] == invited_user.email
+
+
+def test_api_key__filter_status_inactive__ok(api_client):
+
+    """ Filter status=inactive returns only inactive users """
+
+    # arrange
+    account = create_test_account()
+    owner = create_test_owner(account=account)
+    inactive_user = create_test_not_admin(
+        account=account,
+        email='inactive@test.test',
+        status=UserStatus.INACTIVE,
+    )
+    api_client.token_authenticate(owner)
+
+    # act
+    response = api_client.get(
+        path='/accounts/users/api-key',
+        data={'status': UserStatus.INACTIVE},
+    )
+
+    # assert
+    assert response.status_code == 200
+    assert len(response.data) == 1
+    assert response.data[0]['status'] == UserStatus.INACTIVE
+    assert response.data[0]['email'] == inactive_user.email
+
+
+def test_api_key__filter_groups__ok(api_client):
+
+    """ Filter groups returns only users belonging to the group """
+
+    # arrange
+    account = create_test_account()
+    owner = create_test_owner(account=account)
+    user_in_group = create_test_not_admin(
+        account=account,
+        email='ingroup@test.test',
+    )
+    create_test_not_admin(
+        account=account,
+        email='outside@test.test',
+    )
+    group = create_test_group(
+        account=account,
+        users=[user_in_group],
+    )
+    api_client.token_authenticate(owner)
+
+    # act
+    response = api_client.get(
+        path=f'/accounts/users/api-key?groups={group.id}',
+    )
+
+    # assert
+    assert response.status_code == 200
+    assert len(response.data) == 1
+    assert response.data[0]['email'] == user_in_group.email
+
+
+def test_api_key__ordering_first_name__ok(api_client):
+
+    """ ordering=first_name sorts results ascending by first name """
+
+    # arrange
+    account = create_test_account()
+    owner = create_test_owner(
+        account=account,
+        first_name='Beta',
+    )
+    user_1 = create_test_not_admin(
+        account=account,
+        email='alpha@test.test',
+        first_name='Alpha',
+    )
+    api_client.token_authenticate(owner)
+
+    # act
+    response = api_client.get(
+        path='/accounts/users/api-key',
+        data={'ordering': 'first_name'},
+    )
+
+    # assert
+    assert response.status_code == 200
+    assert response.data[0]['email'] == user_1.email
+    assert response.data[1]['email'] == owner.email
+
+
+def test_api_key__ordering_last_name_desc__ok(api_client):
+
+    """ ordering=-last_name sorts results descending by last name """
+
+    # arrange
+    account = create_test_account()
+    owner = create_test_owner(
+        account=account,
+        last_name='Alpha',
+    )
+    user_1 = create_test_not_admin(
+        account=account,
+        email='beta@test.test',
+        last_name='Beta',
+    )
+    api_client.token_authenticate(owner)
+
+    # act
+    response = api_client.get(
+        path='/accounts/users/api-key',
+        data={'ordering': '-last_name'},
+    )
+
+    # assert
+    assert response.status_code == 200
+    assert response.data[0]['email'] == user_1.email
+    assert response.data[1]['email'] == owner.email
+
+
+def test_api_key__ordering_status__ok(api_client):
+
+    """ ordering=status sorts results ascending by status value """
+
+    # arrange
+    account = create_test_account()
+    owner = create_test_owner(account=account)
+    invited_user = create_invited_user(
+        user=owner,
+        email='invited@test.test',
+    )
+    api_client.token_authenticate(owner)
+
+    # act
+    response = api_client.get(
+        path='/accounts/users/api-key',
+        data={'ordering': 'status'},
+    )
+
+    # assert
+    assert response.status_code == 200
+    # 'active' < 'invited' lexicographically
+    assert response.data[0]['email'] == owner.email
+    assert response.data[1]['email'] == invited_user.email
+
+
+def test_api_key__unauthenticated__permission_denied(api_client):
+
+    """ Permission: unauthenticated request is rejected """
+
+    # arrange
+    account = create_test_account()
+    create_test_owner(account=account)
+
+    # act
+    response = api_client.get('/accounts/users/api-key')
+
+    # assert
+    assert response.status_code == 401
+
+
+def test_api_key__non_owner__permission_denied(api_client):
+
+    """ Permission: non-owner user is rejected """
+
+    # arrange
+    account = create_test_account()
+    create_test_owner(account=account)
+    admin = create_test_admin(account=account)
+    api_client.token_authenticate(admin)
+
+    # act
+    response = api_client.get('/accounts/users/api-key')
+
+    # assert
+    assert response.status_code == 403
+    assert response.data['detail'] == MSG_A_0036
+
+
+def test_api_key__expired_subscription__permission_denied(api_client):
+
+    """ Permission: expired subscription is rejected """
+
+    # arrange
+    account = create_test_account(
+        plan=BillingPlanType.UNLIMITED,
+        plan_expiration=timezone.now() - timedelta(days=1),
+    )
+    owner = create_test_owner(account=account)
+    api_client.token_authenticate(owner)
+
+    # act
+    response = api_client.get('/accounts/users/api-key')
+
+    # assert
+    assert response.status_code == 403
+    assert response.data['detail'] == MSG_A_0035
+
+
+def test_api_key__no_billing_plan__permission_denied(api_client):
+
+    """ Permission: account without billing plan is rejected """
+
+    # arrange
+    account = create_test_account(plan=None)
+    owner = create_test_owner(account=account)
+    api_client.token_authenticate(owner)
+
+    # act
+    response = api_client.get('/accounts/users/api-key')
+
+    # assert
+    assert response.status_code == 403
+    assert response.data['detail'] == MSG_A_0041
+
+
+def test_api_key__filter_type_invalid__validation_error(api_client):
+
+    """ Filter type with invalid value returns 400 """
+
+    # arrange
+    account = create_test_account()
+    owner = create_test_owner(account=account)
+    invalid_type = 'invalid_type'
+    api_client.token_authenticate(owner)
+
+    # act
+    response = api_client.get(
+        path=f'/accounts/users/api-key?type={invalid_type}',
+    )
+
+    # assert
+    assert response.status_code == 400
+    assert response.data[0] == MSG_GE_0001(invalid_type)
+
+
+def test_api_key__filter_status_invalid__validation_error(api_client):
+
+    """ Filter status with invalid value returns 400 """
+
+    # arrange
+    account = create_test_account()
+    owner = create_test_owner(account=account)
+    invalid_status = 'invalid_status'
+    api_client.token_authenticate(owner)
+
+    # act
+    response = api_client.get(
+        path=f'/accounts/users/api-key?status={invalid_status}',
+    )
+
+    # assert
+    assert response.status_code == 400
+    assert response.data[0] == MSG_GE_0001(invalid_status)
+
+
+def test_api_key__ordering_invalid__validation_error(api_client):
+
+    """ Filter ordering with invalid field name returns 400 """
+
+    # arrange
+    account = create_test_account()
+    owner = create_test_owner(account=account)
+    invalid_ordering = 'invalid_field'
+    expected_message = (
+        f'Select a valid choice. {invalid_ordering}'
+        f' is not one of the available choices.'
+    )
+    api_client.token_authenticate(owner)
+
+    # act
+    response = api_client.get(
+        path=f'/accounts/users/api-key?ordering={invalid_ordering}',
+    )
+
+    # assert
+    assert response.status_code == 400
+    assert str(response.data['ordering'][0]) == expected_message

--- a/backend/src/accounts/views/users.py
+++ b/backend/src/accounts/views/users.py
@@ -21,6 +21,7 @@ from src.accounts.permissions import (
 )
 from src.accounts.queries import CountTemplatesByUserQuery
 from src.accounts.messages import MSG_A_0052
+from src.accounts.serializers.api_key import UserAPIKeySerializer
 from src.accounts.serializers.user import (
     UserPrivilegesSerializer,
     UserSerializer,
@@ -76,10 +77,12 @@ class UsersViewSet(
         'reassign': ReassignSerializer,
         'privileges': UserPrivilegesSerializer,
         'activate_vacation': VacationActivateSerializer,
+        'api_key': UserAPIKeySerializer,
     }
     action_filterset_classes = {
         'list': UsersListFilterSet,
         'privileges': UsersListFilterSet,
+        'api_key': UsersListFilterSet,
     }
 
     def get_permissions(self):
@@ -90,7 +93,7 @@ class UsersViewSet(
                 IsAuthenticated(),
                 BillingPlanPermission(),
             )
-        if self.action == 'privileges':
+        if self.action in {'privileges', 'api_key'}:
             return (
                 AccountOwnerPermission(),
                 ExpiredSubscriptionPermission(),
@@ -136,7 +139,8 @@ class UsersViewSet(
                 'vacations',
                 'vacations__substitute_group__users',
             )
-
+        elif self.action == 'api_key':
+            queryset = queryset.select_related('apikey')
         return super().prefetch_queryset(
             queryset=queryset,
             extra_fields=extra_fields,
@@ -147,7 +151,7 @@ class UsersViewSet(
         user = self.request.user
         if self.action == 'transfer':
             queryset = UserModel.objects.all()
-        elif self.action in {'list', 'privileges'}:
+        elif self.action in {'list', 'privileges', 'api_key'}:
             queryset = (
                 UserModel.include_inactive
                 .all_account_users(account_id)
@@ -389,6 +393,16 @@ class UsersViewSet(
         return self.response_ok(
             data={'count': count},
         )
+
+    @action(
+        detail=False,
+        methods=('get',),
+        url_path='api-key',
+    )
+    def api_key(self, request, *args, **kwargs):
+        queryset = self.filter_queryset(self.get_queryset())
+        serializer = self.get_serializer(queryset, many=True)
+        return self.response_ok(data=serializer.data)
 
     @action(
         detail=False,


### PR DESCRIPTION
# Problem

Account owners had no way to see which users in their account have an API key created. To find out, they had to check each user individually, which is time-consuming for accounts with many users.

# Fix / Solution

Added a new read-only endpoint `GET /accounts/users/api-key` to `UsersViewSet` that returns the full list of account users together with each user's API key value. Access is restricted to the account owner only. Filtering by user type, status, and group is supported, with the same ordering options available as on the standard users list. A dedicated serializer (`UserAPIKeySerializer`) was added to expose the `api_key` field alongside core user identity fields.

# Release notes

Account owners can now retrieve a single list of all account users that includes each user's API key token. The list supports filtering by type, status, and group, as well as ordering. Users who have not generated an API key appear in the list with `api_key: null`.

# Changes

## API

- **GET /accounts/users/api-key** — new endpoint. Returns a flat array of account users with their API keys. Accessible to account owner only. Supports query parameters: `type`, `status`, `groups`, `ordering`.

# Test cases

## API

### GET /accounts/users/api-key

| Authorization | Test case | Expected result |
|---|---|---|
| Account owner (active plan) | Request without any query parameters. Account has one user with an API key created. | `200`. Response is a JSON array. Item contains: `first_name`, `last_name`, `email`, `is_admin`, `is_account_owner`, `api_key` (token string), `type`, `status`. |
| Account owner (active plan) | User exists but has never created an API key. | `200`. The item is present in the list with `api_key: null`. |
| Account owner (active plan) | Account has users in another account. | `200`. Response contains only users belonging to the requester's account. |
| Account owner (active plan) | Account has a user with status `invited` (pending invite). | `200`. Invited user appears in the response list. |
| Account owner (active plan) | Pass `type=user`. Account also has guest users. | `200`. Only users with `type=user` are returned. |
| Account owner (active plan) | Pass `type=guest`. Account also has regular users. | `200`. Only users with `type=guest` are returned. |
| Account owner (active plan) | Pass `status=active`. Account also has inactive and invited users. | `200`. Only active users are returned. |
| Account owner (active plan) | Pass `status=inactive`. Account also has active users. | `200`. Only deactivated users are returned. |
| Account owner (active plan) | Pass `status=invited`. Account also has active users. | `200`. Only invited users are returned. |
| Account owner (active plan) | Pass `groups=<id>`. Account has users in and outside the group. | `200`. Only users belonging to the specified group are returned. |
| Account owner (active plan) | Pass `ordering=first_name`. Two users with different first names. | `200`. Users ordered ascending by `first_name`. |
| Account owner (active plan) | Pass `ordering=-last_name`. Two users with different last names. | `200`. Users ordered descending by `last_name`. |
| Account owner (active plan) | Pass `ordering=status`. Account has active and invited users. | `200`. Users ordered ascending by `status` value. |
| Account owner (active plan) | Pass `limit=2&offset=1`. Account has 3 users. | `200`. Pagination parameters are ignored; all 3 users are returned (endpoint returns a plain array, not a paginated response). |
| Not authenticated | Request without an authentication token. | `401`. |
| Authenticated as non-owner (admin) | Request with a valid token of an admin who is not the account owner. | `403`. |
| Account owner with expired subscription | Request with a valid owner token, but the account subscription has expired. | `403`. |
| Account owner with no billing plan | Request with a valid owner token, but the account has no active billing plan. | `403`. |
| Account owner (active plan) | Pass `type=invalid_value` (not a valid choice). | `400`. Response body contains a validation error message for the `type` field. |
| Account owner (active plan) | Pass `status=invalid_value` (not a valid choice). | `400`. Response body contains a validation error message for the `status` field. |
| Account owner (active plan) | Pass `ordering=invalid_field` (field not in allowed list). | `400`. Response body: `{"ordering": ["Select a valid choice. invalid_field is not one of the available choices."]}`. |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> The endpoint returns live API key secrets to callers; risk is mitigated by owner-only permissions and billing/subscription checks, but any auth or scope bug would be critical.
> 
> **Overview**
> Adds **`GET /accounts/users/api-key`** on `UsersViewSet` so account owners can list all users in their account with each user’s **API key token** (or `null` if none), in one unpaginated response.
> 
> The new **`UserAPIKeySerializer`** returns identity/role fields plus `api_key`, with **`select_related('apikey')`** on the queryset to avoid N+1 queries. Access matches **`privileges`**: account owner only, active billing plan, and non-expired subscription. **`UsersListFilterSet`** is reused for `type`, `status`, `groups`, and `ordering`; **`distinct=True`** on the `groups` filter avoids duplicate rows when filtering by group membership.
> 
> A large test suite covers happy paths, filters, ordering, auth/permission failures, and invalid query params.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08eb42e815badee36b9f95c0c26c34a35ead8939. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `api-key` endpoint to `UsersViewSet` returning all account users with their API keys
> - Adds a new non-paginated `GET /api-key` action to [`UsersViewSet`](https://github.com/pneumaticapp/pneumaticworkflow/pull/245/files#diff-0507b72ba0bf7d6451f7828b602d95d1b70888fb89656efcfaf00039948083ff) that returns all account users (including inactive/invited) with their associated API key values.
> - Introduces [`UserAPIKeySerializer`](https://github.com/pneumaticapp/pneumaticworkflow/pull/245/files#diff-a2641fc7e0d0d7fa78bcbbb9f708414b367b9bea62027bc4c97ba756aa348ef6) exposing user fields plus an `api_key` field derived from the related `APIKey` object, returning `null` when none exists.
> - Restricts the endpoint to account owners via `AccountOwnerPermission`, `ExpiredSubscriptionPermission`, and `BillingPlanPermission`.
> - Fixes duplicate rows in [`UsersListFilterSet`](https://github.com/pneumaticapp/pneumaticworkflow/pull/245/files#diff-a6b7d73701e74440da954cfdf031f336b3c44ad5f009fc4e446d098685272d86) when filtering by groups by adding `distinct=True` to the groups filter.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 08eb42e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->