### PR TITLE
47800 backend [ attachment ] fix import FileAttachment

### DIFF
--- a/backend/src/processes/views/task.py
+++ b/backend/src/processes/views/task.py
@@ -270,7 +270,6 @@ class TaskViewSet(
             queryset = queryset.prefetch_related(
                 'checklists__selections',
                 'output__storage_attachments',
-                'output__attachments',
                 Prefetch(
                     'output__selections',
                     queryset=FieldSelection.objects.order_by('id'),
@@ -528,7 +527,6 @@ class TaskViewSet(
                             queryset=DatasetItem.objects.order_by('order'),
                             to_attr='dataset_values',
                         ),
-                        'attachments',
                     ),
                 ),
             ).get(pk=task.pk),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small queryset change on read paths; reduces risk of touching the deprecated attachment model without changing API serializers in this diff.
> 
> **Overview**
> Stops prefetching the deprecated **`output__attachments`** relation on task **retrieve**, and drops the nested **`attachments`** prefetch on the **complete** response reload.
> 
> Task output file data continues to load via **`output__storage_attachments`** (and existing selection/dataset prefetches), matching the move away from legacy **`FileAttachment`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5ddd8e7cd514f179ff81aee1237c0208cf4b432. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix attachment prefetch in `TaskViewSet.prefetch_queryset` retrieve action
> Removes `output__attachments` and nested `attachments` from `prefetch_related` in the `retrieve` action of [`task.py`](https://github.com/pneumaticapp/pneumaticworkflow/pull/247/files#diff-05bbc1161f014d6d000b960096668f7514b15d33e775435c37d1ec7d80849ef0). Risk: accessing these relations in `retrieve` will now trigger additional queries instead of using preloaded data.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d5ddd8e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->