### PR TITLE
🔧 47820 frontend [ tests ] Fix tests

### DIFF
--- a/frontend/src/public/components/EditableField/__tests__/EditableField.test.tsx
+++ b/frontend/src/public/components/EditableField/__tests__/EditableField.test.tsx
@@ -42,14 +42,15 @@ describe('EditableField', () => {
   it('on click to edit, sets the caret in the desired position', () => {
     const focus = jest.fn();
     const current = {textContent: 'test', focus};
-    jest.spyOn(React, 'createRef').mockReturnValueOnce({current});
     const range = {collapse: jest.fn(), selectNodeContents: jest.fn()};
     const selection = {addRange: jest.fn(), removeAllRanges: jest.fn()};
     window.getSelection = jest.fn().mockReturnValueOnce(selection as unknown as Selection);
     document.createRange = jest.fn().mockReturnValueOnce(range as unknown as Range);
     const wrapper = shallow(<EditableField {...mockProps} hiddenIcon />);
+    const instance = wrapper.instance() as EditableField;
+    instance.fieldRef = {current} as unknown as React.RefObject<HTMLSpanElement>;
 
-    wrapper.find('span > span').simulate('click')
+    wrapper.find('span > span').simulate('click');
 
     expect(focus).toHaveBeenCalled();
     expect(range.selectNodeContents).toHaveBeenCalledWith(current);
@@ -60,11 +61,12 @@ describe('EditableField', () => {
   it('on click to edit, places the caret in the correct position', () => {
     const focus = jest.fn();
     const current = {textContent: 'test', focus};
-    jest.spyOn(React, 'createRef').mockReturnValueOnce({current});
     const range = {collapse: jest.fn(), selectNodeContents: jest.fn()};
     window.getSelection = jest.fn().mockReturnValueOnce(undefined as unknown as Selection);
     document.createRange = jest.fn().mockReturnValueOnce(range as unknown as Range);
     const wrapper = shallow(<EditableField {...mockProps} hiddenIcon />);
+    const instance = wrapper.instance() as EditableField;
+    instance.fieldRef = {current} as unknown as React.RefObject<HTMLSpanElement>;
 
     wrapper.find('span > span').simulate('click');
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only changes to ref mocking; no runtime behavior or production paths affected.
> 
> **Overview**
> Fixes **EditableField** caret-placement tests by **replacing** `jest.spyOn(React, 'createRef')` with **direct assignment** of `instance.fieldRef` to a mock ref whose `current` exposes `focus` and `textContent`, matching how `handleCaret` reads `this.fieldRef`.
> 
> Adds a missing semicolon after one `simulate('click')` call. **No production code changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4445de77c6609a3d4bc47526ed78adb9f81abb62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `EditableField` tests by assigning `fieldRef` directly on the component instance
> Replaces `React.createRef` spying with direct assignment of a mock `fieldRef` on the shallow-rendered component instance in two caret-position tests in [EditableField.test.tsx](https://github.com/pneumaticapp/pneumaticworkflow/pull/250/files#diff-f2fe10214c0df90f380f1126bcf751023883d8ecb0bd3ad7fcde6950d1aa3f1f). Also adds a missing semicolon after a `simulate('click')` call.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4445de7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->