### PR TITLE
47817 frontend [ errors ] remove technical error information from the banner

### DIFF
--- a/frontend/src/public/api/__tests__/commonRequest.test.ts
+++ b/frontend/src/public/api/__tests__/commonRequest.test.ts
@@ -1,4 +1,5 @@
 import { ApiError } from '../commonRequest';
+import { createApiError } from '../utils/createApiError';
 
 describe('ApiError', () => {
   it('creates an instance with message, data, and status', () => {
@@ -57,28 +58,11 @@ describe('ApiError', () => {
   });
 });
 
-/**
- * Tests for the error interceptor logic.
- *
- * The interceptor (commonRequest.ts:94-111) does:
- *   const data = error.response?.data;
- *   const payload = typeof data === 'string' ? { error: data } : data ?? {};
- *   const message = payload.message || payload.error || error.message;
- *   return Promise.reject(new ApiError(message, payload, error.response?.status));
- *
- * We test the logic inline since the actual interceptor is attached to an
- * axios instance that requires extensive mocking of config, env, and auth.
- */
 describe('error interceptor logic (unit)', () => {
-  // Replicate the interceptor's payload extraction logic
   function extractPayload(responseData: any) {
     const data = responseData;
     const payload = typeof data === 'string' ? { error: data } : data ?? {};
     return payload;
-  }
-
-  function extractMessage(payload: any, fallbackMessage: string) {
-    return payload.message || payload.error || fallbackMessage;
   }
 
   it('extracts data from response.data object', () => {
@@ -110,40 +94,15 @@ describe('error interceptor logic (unit)', () => {
     expect(payload).toEqual({});
   });
 
-  it('creates ApiError with message from payload.message', () => {
-    const payload = { code: 'FILE_003', message: 'File size exceeds limit' };
-    const message = extractMessage(payload, 'Axios fallback');
-
-    expect(message).toBe('File size exceeds limit');
-  });
-
-  it('falls back to payload.error when no message', () => {
-    const payload = { error: 'Service unavailable' };
-    const message = extractMessage(payload, 'Axios fallback');
-
-    expect(message).toBe('Service unavailable');
-  });
-
-  it('falls back to error.message when no payload message/error', () => {
-    const payload = {};
-    const message = extractMessage(payload, 'Network Error');
-
-    expect(message).toBe('Network Error');
-  });
-
   it('preserves file service error format through pipeline', () => {
-    // Simulate full interceptor flow for a File Service error
     const responseData = {
       code: 'FILE_003',
       message: 'File size exceeds limit',
       details: { reason: 'Maximum allowed size is 100MB' },
     };
 
-    const payload = extractPayload(responseData);
-    const message = extractMessage(payload, 'fallback');
-    const error = new ApiError(message, payload, 413);
+    const error = createApiError(responseData, 413);
 
-    // Verify the complete error matches what getErrorMessage expects
     expect(error.message).toBe('File size exceeds limit');
     expect(error.status).toBe(413);
     expect((error.data as any).code).toBe('FILE_003');
@@ -151,14 +110,25 @@ describe('error interceptor logic (unit)', () => {
   });
 
   it('preserves code field from file service response (no camelCase)', () => {
-    // Key test: error interceptor does NOT apply mapToCamelCase to errors
-    // so 'code' stays 'code' (not transformed)
     const responseData = { code: 'AUTH_001', message: 'Authentication failed' };
 
     const payload = extractPayload(responseData);
-
-    // 'code' is already camelCase-safe, but verify it's not mangled
     expect(payload.code).toBe('AUTH_001');
     expect(payload.message).toBe('Authentication failed');
   });
+  it('copies payload.message to error.message via Object.assign', () => {
+    const error = createApiError({ message: 'Permission denied', code: 'PERM_001' }, 403);
+
+    expect(error.message).toBe('Permission denied');
+    expect(error.status).toBe(403);
+  });
+
+  it('creates ApiError with empty message for payload without message field (regression #47550)', () => {
+    const error = createApiError({ detail: 'Some technical error from Django' }, 500);
+
+    expect(error.message).toBe('');
+    expect(error.data).toEqual({ detail: 'Some technical error from Django' });
+    expect(error.status).toBe(500);
+  });
 });
+

--- a/frontend/src/public/api/commonRequest.ts
+++ b/frontend/src/public/api/commonRequest.ts
@@ -12,6 +12,7 @@ import { isRequestCanceled } from '../utils/isRequestCanceled';
 import { isExpectedClientError } from '../utils/expectedClientErrors';
 
 import { InterceptorError } from './InterceptorError';
+import { createApiError } from './utils/createApiError';
 
 export { InterceptorError };
 
@@ -129,13 +130,7 @@ axiosInstance.interceptors.response.use(
       logger.error('Error:', error.message);
     }
 
-    const data = error.response?.data;
-    const payload = typeof data === 'string' ? { error: data } : data ?? {};
-    const hasPayloadData = Object.keys(payload).length > 0;
-    const message = payload.message || payload.error
-      || (hasPayloadData ? JSON.stringify({ ...payload, status: error.response?.status }) : null)
-      || error.message || 'Request failed';
-    return Promise.reject(new ApiError(message, payload, error.response?.status));
+    return Promise.reject(createApiError(error.response?.data, error.response?.status));
   },
 );
 

--- a/frontend/src/public/api/utils/createApiError.ts
+++ b/frontend/src/public/api/utils/createApiError.ts
@@ -1,0 +1,6 @@
+import { ApiError } from '../commonRequest';
+
+export function createApiError(responseData: unknown, status?: number): ApiError {
+  const payload = typeof responseData === 'string' ? { error: responseData } : responseData ?? {};
+  return new ApiError('', payload, status);
+}


### PR DESCRIPTION
### 1. Release notes

Fixed a bug where technical data (Django REST JSON objects or Nginx 500 HTML pages) was displayed in the error notification banner instead of a user-friendly message.

### 2. Problem

In task #47550 (June 17, commit `536fccf8`), the technical `message` assembly from payload was removed from the error interceptor — `JSON.stringify(payload)` was deleted and replaced with an empty string.

When merging `origin/master` into branch `41526__create_file_service`, a conflict occurred in `commonRequest.ts`. During conflict resolution, the fix was lost — `JSON.stringify` was reintroduced. PR #53 (June 30) brought the regression into master.

As a result, for backend responses without a `message` field (e.g., Django REST `{ detail: "..." }` or Nginx HTML 500), users saw raw JSON like `{"detail":"Some error","status":500}` or HTML markup in the error toast.

### 3. Context

- Task: #47817
- Cause: regression during merge of branch `41526__create_file_service` into master (PR #53), fix from #47550 was lost
- Location: any page — error toast/notification on any failed API request

### 4. Solution

- The error interceptor no longer attempts to compose error messages on its own.
- The `response.data` → `ApiError` normalization logic has been extracted into a dedicated `createApiError` function that **always** passes an empty string `''` as the `message`.
- If the backend responds with a `message` field in the payload, it is automatically copied to `error.message` via `Object.assign` in the `ApiError` constructor.
- If the payload has no `message` field, `error.message` remains an empty string, and the UI function `getErrorMessage()` displays a localized fallback.

### 5. Implementation details

**Before:**
The interceptor inline-assembled the message via a fallback chain:
```
payload.message || payload.error || JSON.stringify({...payload, status}) || error.message || 'Request failed'
```
For payloads without `message`/`error` (e.g., Django `{detail: "..."}`), `JSON.stringify` was used.

**After:**
- Created `createApiError(responseData, status)` in `api/utils/createApiError.ts`
- The function normalizes `responseData` into a payload and creates `new ApiError('', payload, status)`
- The interceptor calls `createApiError(error.response?.data, error.response?.status)`
- `message` is populated only via `Object.assign` (if the payload contains a `message` field)

### 6. Testing

#### 6.1 Preconditions

- Dev branch `frontend/errors/47817__remove_technical_error_information_from_the_banner`
- Running frontend + backend

#### 6.2 Positive scenarios

| Scenario | Description (steps → expected result) | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| :--- | :--- | :--- | :--- | :--- | :--- |
| **Error with message from backend** | Trigger an API error where backend responds with `{ message: "Permission denied" }` → Toast displays "Permission denied" | [ ] | [ ] | [ ] | [ ] |
| **Error without message (Django detail)** | Trigger an error where backend responds with `{ detail: "Not found" }` → Toast displays localized fallback (no JSON, no technical data) | [ ] | [ ] | [ ] | [ ] |
| **File service error** | Upload a file exceeding the limit → Toast displays "File size exceeds limit" (from payload.message) | [ ] | [ ] | [ ] | [ ] |

#### 6.3 Negative scenarios

| Scenario | Description (steps → expected result) | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| :--- | :--- | :--- | :--- | :--- | :--- |
| **500 with HTML response** | Trigger a 500 from Nginx (HTML page) → Toast does **not** display HTML markup, shows fallback | [ ] | [ ] | [ ] | [ ] |
| **500 with Django REST response** | Trigger a 500 from Django (`{ detail: "..." }`) → Toast does **not** display JSON, shows fallback | [ ] | [ ] | [ ] | [ ] |
| **Network error (no response)** | Disconnect backend → Toast displays a user-friendly network error message | [ ] | [ ] | [ ] | [ ] |

#### 6.4 Verification points

- **UI:** error toast does not contain JSON strings, HTML tags, or raw technical payloads
- **DevTools → Console:** `ApiError` in the console contains the full payload in `.data` (for debugging)

#### 6.6 Not tested

- Locales were not tested (changes do not affect translations)
- Not tested under load

### 7. Unit tests

14 tests in `commonRequest.test.ts`:

- **ApiError** (6 tests): instance creation, payload preservation with code, string/null/empty payload
- **Error interceptor logic** (8 tests):
  - Payload normalization: object, string → `{error}`, null → `{}`, undefined → `{}`
  - Pipeline via `createApiError`: file service payload, code preservation
  - **Message contract:** payload with `message` → copied; payload without `message` → empty string (regression #47550)

### 8. Commits

- `0d21f833` — 47817 fix(errors): prevent technical JSON/HTML from leaking into user-facing error toasts



<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes global API error messaging for all `commonRequest` failures; callers that relied on synthesized messages or `payload.error` may show emptier banners unless `getErrorMessage` maps from `data`.
> 
> **Overview**
> Centralizes axios response error handling in **`createApiError`**, which normalizes `response.data` (string → `{ error }`, otherwise the object or `{}`) and builds **`ApiError`** with an empty constructor message so **`message`** only comes from **`payload.message`** via existing **`Object.assign`** on the class.
> 
> The response interceptor no longer synthesizes **`error.message`** from **`payload.error`**, stringified payloads, axios fallbacks, or **`Request failed`**, so bodies like Django **`detail`** stay on **`error.data`** but are not copied into **`message`** for banners (regression **#47550**). Tests were updated to target **`createApiError`** and assert empty **`message`** when the payload has no **`message`** field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d21f8331802e20b9da3389f499f0b27a7c2dd10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->