### PR TITLE
44521 backend [ Highlights ] Use new group performer events

### DIFF
--- a/backend/src/processes/queries.py
+++ b/backend/src/processes/queries.py
@@ -1865,6 +1865,8 @@ class HighlightsQuery(SqlQueryObject):
         WorkflowEventType.NOT_URGENT,
         WorkflowEventType.TASK_PERFORMER_CREATED,
         WorkflowEventType.TASK_PERFORMER_DELETED,
+        WorkflowEventType.TASK_PERFORMER_GROUP_CREATED,
+        WorkflowEventType.TASK_PERFORMER_GROUP_DELETED,
         WorkflowEventType.FORCE_DELAY,
         WorkflowEventType.FORCE_RESUME,
         WorkflowEventType.DUE_DATE_CHANGED,

--- a/backend/src/processes/queries.py
+++ b/backend/src/processes/queries.py
@@ -1940,6 +1940,7 @@ class HighlightsQuery(SqlQueryObject):
           we.created,
           we.user_id,
           we.target_user_id,
+          we.target_group_id,
           we.workflow_id
         FROM processes_workflowevent we
         LEFT JOIN processes_workflow workflow ON

--- a/backend/src/reports/serializers.py
+++ b/backend/src/reports/serializers.py
@@ -110,6 +110,7 @@ class EventHighlightsSerializer(serializers.ModelSerializer):
             'created_tsp',
             'user_id',
             'target_user_id',
+            'target_group_id',
             'workflow',
         )
 

--- a/backend/src/reports/tests/test_views/test_highlights.py
+++ b/backend/src/reports/tests/test_views/test_highlights.py
@@ -1551,3 +1551,65 @@ def test_complete_task_event__kickoff_field_with_dataset__ok(api_client):
     assert field_data['id'] == field.id
     assert field_data['type'] == FieldType.DROPDOWN
     assert field_data['value'] == dataset_item.value
+
+
+def test_highlights__performer_group_created__ok(api_client):
+
+    # arrange
+    account = create_test_account()
+    user = create_test_owner(account=account)
+    group = create_test_group(account=account, users=[user])
+    workflow = create_test_workflow(user, tasks_count=1)
+    task = workflow.tasks.get(number=1)
+    event = create_test_event(
+        workflow=workflow,
+        task=task,
+        type_event=WorkflowEventType.TASK_PERFORMER_GROUP_CREATED,
+        user=user,
+    )
+    event.target_group_id = group.id
+    event.save(update_fields=['target_group_id'])
+
+    api_client.token_authenticate(user)
+
+    # act
+    response = api_client.get('/reports/highlights')
+
+    # assert
+    assert response.status_code == 200
+    assert len(response.data) == 1
+    event_data = response.data[0]
+    assert event_data['id'] == event.id
+    assert event_data['type'] == WorkflowEventType.TASK_PERFORMER_GROUP_CREATED
+    assert event_data['target_group_id'] == group.id
+
+
+def test_highlights__performer_group_deleted__ok(api_client):
+
+    # arrange
+    account = create_test_account()
+    user = create_test_owner(account=account)
+    group = create_test_group(account=account, users=[user])
+    workflow = create_test_workflow(user, tasks_count=1)
+    task = workflow.tasks.get(number=1)
+    event = create_test_event(
+        workflow=workflow,
+        task=task,
+        type_event=WorkflowEventType.TASK_PERFORMER_GROUP_DELETED,
+        user=user,
+    )
+    event.target_group_id = group.id
+    event.save(update_fields=['target_group_id'])
+
+    api_client.token_authenticate(user)
+
+    # act
+    response = api_client.get('/reports/highlights')
+
+    # assert
+    assert response.status_code == 200
+    assert len(response.data) == 1
+    event_data = response.data[0]
+    assert event_data['id'] == event.id
+    assert event_data['type'] == WorkflowEventType.TASK_PERFORMER_GROUP_DELETED
+    assert event_data['target_group_id'] == group.id

--- a/frontend/src/public/components/Highlights/FeedItem.tsx
+++ b/frontend/src/public/components/Highlights/FeedItem.tsx
@@ -157,6 +157,8 @@ export const ALLOWED_EVENT_TYPES = [
   EWorkflowLogEvent.WorkflowIsNotUrgent,
   EWorkflowLogEvent.AddedPerformer,
   EWorkflowLogEvent.RemovedPerformer,
+  EWorkflowLogEvent.AddedPerformerGroup,
+  EWorkflowLogEvent.RemovedPerformerGroup,
   EWorkflowLogEvent.WorkflowSnoozedManually,
   EWorkflowLogEvent.WorkflowResumed,
   EWorkflowLogEvent.DueDateChanged,

--- a/frontend/src/public/components/Highlights/FeedItemHeader.tsx
+++ b/frontend/src/public/components/Highlights/FeedItemHeader.tsx
@@ -5,12 +5,13 @@ import { useIntl } from 'react-intl';
 import { RichText } from '../RichText';
 import { Attachments } from '../Attachments';
 import { EWorkflowLogEvent } from '../../types/workflow';
-import { EExtraFieldType, IExtraField } from '../../types/template';
+import { EExtraFieldType, ETemplateOwnerType, IExtraField } from '../../types/template';
 import { IHighlightsItem } from '../../types/highlights';
 import { isArrayWithItems } from '../../utils/helpers';
 import { EKickoffOutputsViewModes, KickoffOutputs } from '../KickoffOutputs';
 import { UserData } from '../UserData';
 import { getUserFullName } from '../../utils/users';
+import UserDataWithGroup from '../UserDataWithGroup';
 import { getSnoozedUntilDate } from '../../utils/dateTime';
 
 import { Ellipsis } from './Ellipsis';
@@ -28,6 +29,7 @@ export function FeedItemHeader({
   task,
   delay,
   targetUserId,
+  targetGroupId,
 }: IFeedItemHeaderProps) {
   const { messages, formatMessage } = useIntl();
   const commentTextRef = useRef<HTMLSpanElement>(null);
@@ -188,6 +190,36 @@ export function FeedItemHeader({
     );
   };
 
+  const renderAddedPerformerGroup = () => {
+    if (!targetGroupId) {
+      return null;
+    }
+
+    return (
+      <div className={styles['changed-performer']}>
+        {formatMessage({ id: 'task.log-added-performer-group' })}
+        <UserDataWithGroup type={ETemplateOwnerType.UserGroup} idItem={targetGroupId}>
+          {(group) => <span className={styles['username']}>{group.firstName}</span>}
+        </UserDataWithGroup>
+      </div>
+    );
+  };
+
+  const renderRemovedPerformerGroup = () => {
+    if (!targetGroupId) {
+      return null;
+    }
+
+    return (
+      <div className={styles['changed-performer']}>
+        {formatMessage({ id: 'task.log-removed-performer-group' })}
+        <UserDataWithGroup type={ETemplateOwnerType.UserGroup} idItem={targetGroupId}>
+          {(group) => <span className={styles['username']}>{group.firstName}</span>}
+        </UserDataWithGroup>
+      </div>
+    );
+  };
+
   const EVENT_CONTENT_MAP: { [key in EWorkflowLogEvent]?: JSX.Element | null } = {
     [EWorkflowLogEvent.TaskComplete]: renderOutputsContents(),
     [EWorkflowLogEvent.TaskComment]: renderTaskCommentContent(),
@@ -198,6 +230,8 @@ export function FeedItemHeader({
     [EWorkflowLogEvent.TaskRevert]: renderTaskCommentContent(),
     [EWorkflowLogEvent.AddedPerformer]: renderAddedPerformer(),
     [EWorkflowLogEvent.RemovedPerformer]: renderRemovedPerformer(),
+    [EWorkflowLogEvent.AddedPerformerGroup]: renderAddedPerformerGroup(),
+    [EWorkflowLogEvent.RemovedPerformerGroup]: renderRemovedPerformerGroup(),
     [EWorkflowLogEvent.WorkflowSnoozedManually]: (
       <>{formatMessage({ id: 'workflows.event-snoozed-until' }, { date: getSnoozedUntilDate(delay || null) })}</>
     ),

--- a/frontend/src/public/components/Highlights/__tests__/FeedItem.test.tsx
+++ b/frontend/src/public/components/Highlights/__tests__/FeedItem.test.tsx
@@ -1,0 +1,125 @@
+// <reference types="jest" />
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { FeedItem, ALLOWED_EVENT_TYPES } from '../FeedItem';
+import { EWorkflowLogEvent, EWorkflowStatus } from '../../../types/workflow';
+import { IHighlightsItem } from '../../../types/highlights';
+
+jest.mock('../FeedItemHeader', () => ({
+  FeedItemHeader: () => <div data-testid="feed-header" />,
+}));
+
+jest.mock('../FeedItemIcon', () => ({
+  FeedItemIcon: () => <div data-testid="feed-icon" />,
+}));
+
+jest.mock('../../UserData', () => ({
+  UserData: ({ children }: { children: (user: any) => React.ReactNode }) =>
+    children({ id: 1, firstName: 'John', lastName: 'Doe' }),
+}));
+
+jest.mock('../../UI', () => ({
+  Dropdown: () => null,
+  Loader: () => null,
+}));
+
+jest.mock('../../icons', () => ({
+  EditIcon: () => null,
+  MoreIcon: () => null,
+}));
+
+jest.mock('../../../utils/users', () => ({
+  getUserFullName: (u: any) => `${u.firstName} ${u.lastName}`,
+  EXTERNAL_USER: { firstName: 'External', lastName: 'User' },
+}));
+
+jest.mock('react-router-dom', () => ({
+  Link: ({ children, to }: any) => <a href={to}>{children}</a>,
+}));
+
+jest.mock('../../UI/DateFormat', () => ({
+  DateFormat: ({ date }: { date: string }) => <span>{date}</span>,
+}));
+
+const makeHighlightsItem = (
+  type: EWorkflowLogEvent,
+  overrides: Partial<IHighlightsItem> = {},
+): IHighlightsItem => ({
+  id: 1,
+  type,
+  task: {
+    id: 10,
+    name: 'Test Task',
+    number: 1,
+    process: 100,
+    delay: null,
+    output: [],
+    dueDate: null,
+  },
+  text: '',
+  attachments: [],
+  created: '2024-01-01T00:00:00Z',
+  user: { id: 1 },
+  workflow: {
+    id: 100,
+    name: 'Test Workflow',
+    currentTask: 1,
+    tasksCount: 3,
+    template: { id: 1, name: 'Template', count: 0 },
+    isLegacyTemplate: false,
+    legacyTemplateName: '',
+    status: EWorkflowStatus.Running,
+    kickoff: null,
+    isExternal: false,
+  },
+  userId: 1,
+  targetUserId: null,
+  targetGroupId: null,
+  delay: null,
+  ...overrides,
+});
+
+describe('FeedItem', () => {
+  const baseProps = {
+    applyUserFilter: jest.fn(() => jest.fn()),
+    applyTemplatesFilter: jest.fn(() => jest.fn()),
+    isProcessLogPopupLoading: false,
+    openProcessLogPopup: jest.fn(),
+    redirectToTemplate: jest.fn(() => jest.fn()),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('ALLOWED_EVENT_TYPES', () => {
+    it('includes AddedPerformerGroup', () => {
+      expect(ALLOWED_EVENT_TYPES).toContain(EWorkflowLogEvent.AddedPerformerGroup);
+    });
+
+    it('includes RemovedPerformerGroup', () => {
+      expect(ALLOWED_EVENT_TYPES).toContain(EWorkflowLogEvent.RemovedPerformerGroup);
+    });
+  });
+
+  describe('render', () => {
+    it('renders AddedPerformerGroup event', () => {
+      const item = makeHighlightsItem(EWorkflowLogEvent.AddedPerformerGroup, { targetGroupId: 5 });
+
+      render(React.createElement(FeedItem, { ...baseProps, ...item, item }));
+
+      expect(screen.getByTestId('feed-header')).toBeInTheDocument();
+      expect(screen.getByTestId('feed-icon')).toBeInTheDocument();
+    });
+
+    it('renders RemovedPerformerGroup event', () => {
+      const item = makeHighlightsItem(EWorkflowLogEvent.RemovedPerformerGroup, { targetGroupId: 5 });
+
+      render(React.createElement(FeedItem, { ...baseProps, ...item, item }));
+
+      expect(screen.getByTestId('feed-header')).toBeInTheDocument();
+      expect(screen.getByTestId('feed-icon')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/public/components/Highlights/__tests__/FeedItemHeader.test.tsx
+++ b/frontend/src/public/components/Highlights/__tests__/FeedItemHeader.test.tsx
@@ -1,0 +1,150 @@
+// <reference types="jest" />
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import { useSelector } from 'react-redux';
+
+import { FeedItemHeader } from '../FeedItemHeader';
+import { EWorkflowLogEvent, EWorkflowStatus } from '../../../types/workflow';
+import { IHighlightsItem } from '../../../types/highlights';
+import { intlMock } from '../../../__stubs__/intlMock';
+
+jest.mock('../../RichText', () => ({
+  RichText: ({ text }: { text: string }) => <span>{text}</span>,
+}));
+
+jest.mock('../../Attachments', () => ({
+  Attachments: () => null,
+}));
+
+jest.mock('../../KickoffOutputs', () => ({
+  KickoffOutputs: () => null,
+  EKickoffOutputsViewModes: { Short: 'short' },
+}));
+
+jest.mock('../../UserData', () => ({
+  UserData: ({ children }: { children: (user: any) => React.ReactNode }) =>
+    children({ id: 1, firstName: 'John', lastName: 'Doe' }),
+}));
+
+jest.mock('../../UI', () => ({
+  Tooltip: ({ children }: any) => children,
+  DateFormat: ({ date }: { date: string }) => <span>{date}</span>,
+}));
+
+jest.mock('../../UI/DateFormat', () => ({
+  DateFormat: ({ date }: { date: string }) => <span>{date}</span>,
+}));
+
+jest.mock('../../../utils/users', () => ({
+  getUserFullName: (u: any, opts?: any) =>
+    opts?.withAtSign ? `@${u.firstName} ${u.lastName}` : `${u.firstName} ${u.lastName}`,
+}));
+
+jest.mock('../../../utils/dateTime', () => ({
+  getSnoozedUntilDate: () => '2024-01-01',
+}));
+
+jest.mock('../Ellipsis', () => ({
+  Ellipsis: () => null,
+}));
+
+jest.mock('../utils/TruncatedContent', () => ({
+  TruncatedContent: ({ children }: any) => children,
+}));
+
+const GROUP_NAME = 'Engineering Team';
+
+const makeHighlightsItem = (
+  type: EWorkflowLogEvent,
+  overrides: Partial<IHighlightsItem> = {},
+): IHighlightsItem => ({
+  id: 1,
+  type,
+  task: {
+    id: 10,
+    name: 'Test Task',
+    number: 1,
+    process: 100,
+    delay: null,
+    output: [],
+    dueDate: null,
+  },
+  text: '',
+  attachments: [],
+  created: '2024-01-01T00:00:00Z',
+  user: { id: 1 },
+  workflow: {
+    id: 100,
+    name: 'Test Workflow',
+    currentTask: 1,
+    tasksCount: 3,
+    template: { id: 1, name: 'Template', count: 0 },
+    isLegacyTemplate: false,
+    legacyTemplateName: '',
+    status: EWorkflowStatus.Running,
+    kickoff: null,
+    isExternal: false,
+  },
+  userId: 1,
+  targetUserId: null,
+  targetGroupId: null,
+  delay: null,
+  ...overrides,
+});
+
+describe('FeedItemHeader', () => {
+  const t = (id: string) => intlMock.formatMessage({ id });
+  const ADDED_GROUP_LABEL = t('task.log-added-performer-group');
+  const REMOVED_GROUP_LABEL = t('task.log-removed-performer-group');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useSelector as jest.Mock).mockImplementation((cb: any) =>
+      cb({
+        authUser: { isSuperuser: false, account: {} },
+        groups: {
+          list: [{ id: 5, name: GROUP_NAME }],
+        },
+        accounts: { isCreateUserModalOpen: false },
+      }),
+    );
+  });
+
+  describe('AddedPerformerGroup', () => {
+    it('renders group name with added label', () => {
+      const item = makeHighlightsItem(EWorkflowLogEvent.AddedPerformerGroup, { targetGroupId: 5 });
+
+      render(React.createElement(FeedItemHeader, item));
+
+      expect(screen.getByText(ADDED_GROUP_LABEL.trim())).toBeInTheDocument();
+      expect(screen.getByText(GROUP_NAME)).toBeInTheDocument();
+    });
+
+    it('returns null when targetGroupId is missing', () => {
+      const item = makeHighlightsItem(EWorkflowLogEvent.AddedPerformerGroup, { targetGroupId: null });
+
+      const { container } = render(React.createElement(FeedItemHeader, item));
+
+      expect(container.innerHTML).toBe('');
+    });
+  });
+
+  describe('RemovedPerformerGroup', () => {
+    it('renders group name with removed label', () => {
+      const item = makeHighlightsItem(EWorkflowLogEvent.RemovedPerformerGroup, { targetGroupId: 5 });
+
+      render(React.createElement(FeedItemHeader, item));
+
+      expect(screen.getByText(REMOVED_GROUP_LABEL.trim())).toBeInTheDocument();
+      expect(screen.getByText(GROUP_NAME)).toBeInTheDocument();
+    });
+
+    it('returns null when targetGroupId is missing', () => {
+      const item = makeHighlightsItem(EWorkflowLogEvent.RemovedPerformerGroup, { targetGroupId: null });
+
+      const { container } = render(React.createElement(FeedItemHeader, item));
+
+      expect(container.innerHTML).toBe('');
+    });
+  });
+});

--- a/frontend/src/public/types/highlights.ts
+++ b/frontend/src/public/types/highlights.ts
@@ -32,6 +32,7 @@ export interface IHighlightsItem {
   };
   userId: number | null;
   targetUserId: number | null;
+  targetGroupId: number | null;
   delay: IHighlightsDelay | null;
 }
 


### PR DESCRIPTION
## 1. Description

The Highlights feed (`GET /reports/highlights`) did not display events for adding/removing **groups** from task performers (event types 20 and 21). Users could not see in the feed when a group was assigned to or removed from a task.

**Where it manifested:** Highlights page (activity feed), missing cards for group performer events.

## 2. Context

Events `TASK_PERFORMER_GROUP_CREATED` (20) and `TASK_PERFORMER_GROUP_DELETED` (21) already existed in the `WorkflowEvent` model, but were not included in the Highlights API query filter and were not handled on the frontend. This PR completes the integration: backend query → API serialization → frontend rendering.

## 3. Solution

- Add event types 20, 21 to the `HighlightsQuery.event_types` filter
- Extend `EventHighlightsSerializer` with the `target_group_id` field
- On the frontend: add types to `ALLOWED_EVENT_TYPES`, implement render functions using the existing `UserDataWithGroup` component for group name resolution from the Redux store

## 4. Implementation Details

**Backend:**
- `src/processes/queries.py` — added `TASK_PERFORMER_GROUP_CREATED`, `TASK_PERFORMER_GROUP_DELETED` to `HighlightsQuery.event_types`
- `src/reports/serializers.py` — added `target_group_id` to `EventHighlightsSerializer.Meta.fields`
- `src/reports/tests/test_views/test_highlights.py` — 2 new tests verifying `target_group_id` in API response

**Frontend:**
- `types/highlights.ts` — added `targetGroupId: number | null` to `IHighlightsItem`
- `FeedItem.tsx` — `AddedPerformerGroup` and `RemovedPerformerGroup` added to `ALLOWED_EVENT_TYPES`
- `FeedItemHeader.tsx` — implemented `renderAddedPerformerGroup` and `renderRemovedPerformerGroup` with `UserDataWithGroup`, registered in `EVENT_CONTENT_MAP`
- `__tests__/FeedItem.test.tsx` — 4 tests (ALLOWED_EVENT_TYPES inclusion + render)
- `__tests__/FeedItemHeader.test.tsx` — 4 tests (render with group, null targetGroupId for both types)

## 5. What to Test

### 5.1 Preconditions
- Account with at least one user group
- A running workflow with a task

### 5.2 Positive Scenarios

1. **Add group to performers:**
   - Open a task → add a group to performers
   - Navigate to Highlights
   - **Expected:** a card appears with add icon, "Add group" label, and the group name

2. **Remove group from performers:**
   - Open a task → remove a group from performers
   - Navigate to Highlights
   - **Expected:** a card appears with remove icon, "Delete group" label, and the group name

3. **Mixed display:**
   - Add a group, then add a user, then remove the group
   - **Expected:** all three events appear in the feed in chronological order

### 5.3 Negative Scenarios

1. **Deleted group:** group was deleted from the system after the event → feed should render without crash (UserDataWithGroup returns fallback)
2. **Empty feed:** account has no group events → feed displays without group cards, other events unaffected
3. **Filtering:** TaskStart and other non-allowed events still don't appear in the feed

### 5.4 Verification Points

- **UI:** card contains correct icon, label text, group name
- **API:** `GET /reports/highlights` returns events with `type: 20` / `type: 21` and correct `target_group_id`

### 5.5 API Checks

- **Endpoint:** `GET /reports/highlights`
- **New field in response:** `target_group_id` (integer | null) on each event object
- For event types 20/21: `target_group_id` should contain the group ID
- For other event types: `null`

### 5.6 What Was NOT Tested

- Locales (en/ru) — not in task scope
- Mobile devices — not tested
- Production — verified on dev only

## 6. Affected Areas

| Component | What to verify |
|---|---|
| Highlights feed (all) | All existing event types render correctly |
| `FeedItemHeader` — all `EVENT_CONTENT_MAP` branches | Comments, complete, revert, performer events — not broken |

## 7. Refactoring

No refactoring was performed.

## 8. Commits

- `eb622439` — 44521 feat(highlights): add performer group events to highlights feed

## 9. Release Notes

Added performer group add/remove events to the Highlights feed. Users can now see when a group is assigned to or removed from a task in their activity feed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive highlights integration and UI rendering; no auth or performer mutation logic changed.
> 
> **Overview**
> The Highlights feed now surfaces **group** task performer add/remove activity, mirroring existing user performer events.
> 
> **Backend:** `HighlightsQuery` includes `TASK_PERFORMER_GROUP_CREATED` and `TASK_PERFORMER_GROUP_DELETED`, selects `target_group_id`, and `EventHighlightsSerializer` exposes it on `GET /reports/highlights`. API tests cover types 20/21 with the expected group id.
> 
> **Frontend:** `AddedPerformerGroup` and `RemovedPerformerGroup` are allowed feed types; `IHighlightsItem` carries `targetGroupId`. `FeedItemHeader` renders localized labels and resolves the group name via `UserDataWithGroup`, with unit tests for allow-list and header behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93938d5805dd297c26ad5f4b48909bc04b49264b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add group performer events to Highlights feed
> - Adds `TASK_PERFORMER_GROUP_CREATED` and `TASK_PERFORMER_GROUP_DELETED` to the `HighlightsQuery` event types so these events appear in `/reports/highlights` results.
> - Adds `target_group_id` to `EventHighlightsSerializer` and the `IHighlightsItem` TypeScript interface so the group ID is available on the frontend.
> - Renders `AddedPerformerGroup` and `RemovedPerformerGroup` feed items in `FeedItemHeader`, showing a localized label and group name when `targetGroupId` is present; returns null when it is missing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 93938d5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->