### PR TITLE
🔧 44655 backend [ My tasks ] Handle null values ​​in /v3/tasks API

### DIFF
--- a/backend/src/generics/validators.py
+++ b/backend/src/generics/validators.py
@@ -3,25 +3,26 @@ from urllib.parse import urlsplit, urlunsplit
 
 from django.core.exceptions import ValidationError
 from django.core.validators import (
+    BaseValidator,
     URLValidator,
     _lazy_re_compile,
     validate_ipv6_address,
 )
 from django.utils.translation import gettext_lazy as _
-from rest_framework.exceptions import ValidationError as DRFValidationError
 
 
-class RejectNullStringValidator:
+class RejectNullStringValidator(BaseValidator):
+
+    """Reject the literal string 'null' (common in query parameters)."""
 
     message = _('This field may not be null.')
     code = 'null'
 
-    def __call__(self, value):
-        if value == 'null':
-            raise DRFValidationError(self.message, code=self.code)
+    def __init__(self, limit_value: str = 'null', message=None):
+        super().__init__(limit_value=limit_value, message=message)
 
-    def __eq__(self, other):
-        return isinstance(other, RejectNullStringValidator)
+    def compare(self, a: str, b: str) -> bool:
+        return a == b
 
 
 class NoSchemaURLValidator(URLValidator):

--- a/backend/src/generics/validators.py
+++ b/backend/src/generics/validators.py
@@ -7,6 +7,21 @@ from django.core.validators import (
     _lazy_re_compile,
     validate_ipv6_address,
 )
+from django.utils.translation import gettext_lazy as _
+from rest_framework.exceptions import ValidationError as DRFValidationError
+
+
+class RejectNullStringValidator:
+
+    message = _('This field may not be null.')
+    code = 'null'
+
+    def __call__(self, value):
+        if value == 'null':
+            raise DRFValidationError(self.message, code=self.code)
+
+    def __eq__(self, other):
+        return isinstance(other, RejectNullStringValidator)
 
 
 class NoSchemaURLValidator(URLValidator):

--- a/backend/src/processes/serializers/workflows/task.py
+++ b/backend/src/processes/serializers/workflows/task.py
@@ -7,6 +7,7 @@ from rest_framework.exceptions import ValidationError
 
 from src.generics.fields import TimeStampField
 from src.generics.serializers import CustomValidationErrorMixin
+from src.generics.validators import RejectNullStringValidator
 from src.processes.enums import OwnerRole, OwnerType, TaskOrdering
 from src.processes.messages.workflow import (
     MSG_PW_0057,
@@ -269,7 +270,7 @@ class TaskListFilterSerializer(
     assigned_to = serializers.IntegerField(required=False)
     search = serializers.CharField(required=False)
     template_id = serializers.IntegerField(required=False)
-    template_task_api_name = serializers.CharField(required=False)
+    template_task_api_name = serializers.CharField(required=False, validators=[RejectNullStringValidator()])
     limit = serializers.IntegerField(required=False)
     offset = serializers.IntegerField(required=False)
 
@@ -281,11 +282,6 @@ class TaskListFilterSerializer(
     def validate_assigned_to(self, value):
         if not self.context['user'].is_admin:
             raise ValidationError(MSG_PW_0057)
-        return value
-
-    def validate_template_task_api_name(self, value):
-        if value == 'null':
-            self.fields['template_task_api_name'].fail('null')
         return value
 
 

--- a/backend/src/processes/serializers/workflows/task.py
+++ b/backend/src/processes/serializers/workflows/task.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional
 
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
+from rest_framework.fields import empty
 
 from src.generics.fields import TimeStampField
 from src.generics.serializers import CustomValidationErrorMixin
@@ -256,6 +257,31 @@ class TaskListSerializer(serializers.ModelSerializer):
         )
 
 
+class _NullQueryParamAsAbsentMixin:
+
+    """Treat the literal query-string 'null' as an absent optional param."""
+
+    def get_value(self, dictionary):
+        value = super().get_value(dictionary)
+        if value == 'null':
+            return empty
+        return value
+
+
+class _NullableQueryIntegerField(
+    _NullQueryParamAsAbsentMixin,
+    serializers.IntegerField,
+):
+    pass
+
+
+class _NullableQueryCharField(
+    _NullQueryParamAsAbsentMixin,
+    serializers.CharField,
+):
+    pass
+
+
 class TaskListFilterSerializer(
     CustomValidationErrorMixin,
     serializers.Serializer,
@@ -266,10 +292,10 @@ class TaskListFilterSerializer(
         required=False,
         choices=TaskOrdering.CHOICES,
     )
-    assigned_to = serializers.IntegerField(required=False)
+    assigned_to = _NullableQueryIntegerField(required=False)
     search = serializers.CharField(required=False)
-    template_id = serializers.IntegerField(required=False)
-    template_task_api_name = serializers.CharField(required=False)
+    template_id = _NullableQueryIntegerField(required=False)
+    template_task_api_name = _NullableQueryCharField(required=False)
     limit = serializers.IntegerField(required=False)
     offset = serializers.IntegerField(required=False)
 

--- a/backend/src/processes/serializers/workflows/task.py
+++ b/backend/src/processes/serializers/workflows/task.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, List, Optional
 
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
-from rest_framework.fields import empty
 
 from src.generics.fields import TimeStampField
 from src.generics.serializers import CustomValidationErrorMixin
@@ -257,31 +256,6 @@ class TaskListSerializer(serializers.ModelSerializer):
         )
 
 
-class _NullQueryParamAsAbsentMixin:
-
-    """Treat the literal query-string 'null' as an absent optional param."""
-
-    def get_value(self, dictionary):
-        value = super().get_value(dictionary)
-        if value == 'null':
-            return empty
-        return value
-
-
-class _NullableQueryIntegerField(
-    _NullQueryParamAsAbsentMixin,
-    serializers.IntegerField,
-):
-    pass
-
-
-class _NullableQueryCharField(
-    _NullQueryParamAsAbsentMixin,
-    serializers.CharField,
-):
-    pass
-
-
 class TaskListFilterSerializer(
     CustomValidationErrorMixin,
     serializers.Serializer,
@@ -292,10 +266,10 @@ class TaskListFilterSerializer(
         required=False,
         choices=TaskOrdering.CHOICES,
     )
-    assigned_to = _NullableQueryIntegerField(required=False)
+    assigned_to = serializers.IntegerField(required=False)
     search = serializers.CharField(required=False)
-    template_id = _NullableQueryIntegerField(required=False)
-    template_task_api_name = _NullableQueryCharField(required=False)
+    template_id = serializers.IntegerField(required=False)
+    template_task_api_name = serializers.CharField(required=False)
     limit = serializers.IntegerField(required=False)
     offset = serializers.IntegerField(required=False)
 
@@ -307,6 +281,11 @@ class TaskListFilterSerializer(
     def validate_assigned_to(self, value):
         if not self.context['user'].is_admin:
             raise ValidationError(MSG_PW_0057)
+        return value
+
+    def validate_template_task_api_name(self, value):
+        if value == 'null':
+            self.fields['template_task_api_name'].fail('null')
         return value
 
 

--- a/backend/src/processes/serializers/workflows/task.py
+++ b/backend/src/processes/serializers/workflows/task.py
@@ -270,7 +270,10 @@ class TaskListFilterSerializer(
     assigned_to = serializers.IntegerField(required=False)
     search = serializers.CharField(required=False)
     template_id = serializers.IntegerField(required=False)
-    template_task_api_name = serializers.CharField(required=False, validators=[RejectNullStringValidator()])
+    template_task_api_name = serializers.CharField(
+        required=False,
+        validators=[RejectNullStringValidator()],
+    )
     limit = serializers.IntegerField(required=False)
     offset = serializers.IntegerField(required=False)
 

--- a/backend/src/processes/tests/test_views/test_tasks/test_list.py
+++ b/backend/src/processes/tests/test_views/test_tasks/test_list.py
@@ -2253,3 +2253,28 @@ def test_list__sql_injection_in_search__ok(api_client, injection):
     # assert
     assert response.status_code == 200
     assert len(response.data['results']) == 1
+
+
+@pytest.mark.parametrize(
+    "query_string", [
+        'template_id=null',
+        'template_task_api_name=null',
+        'template_id=null&template_task_api_name=null',
+    ],
+)
+def test_list__filter_null_string__ok(api_client, query_string):
+
+    # arrange
+    user = create_test_owner()
+    api_client.token_authenticate(user=user)
+    workflow = create_test_workflow(user=user, tasks_count=1)
+    task = workflow.tasks.get(number=1)
+
+    # act
+    response = api_client.get(f'/v3/tasks?{query_string}')
+
+    # assert
+    assert response.status_code == 200
+    assert len(response.data) == 1
+    assert response.data[0]['id'] == task.id
+

--- a/backend/src/processes/tests/test_views/test_tasks/test_list.py
+++ b/backend/src/processes/tests/test_views/test_tasks/test_list.py
@@ -2133,7 +2133,7 @@ def test_list__filter_template_task_api_name_null_string__validation_error(
     assert response.data['details']['name'] == 'template_task_api_name'
 
 
-def test_list__filter_template_id_and_template_task_api_name_null_string__validation_error(
+def test_list__filter_both_null_strings__validation_error(
     api_client,
 ):
 

--- a/backend/src/processes/tests/test_views/test_tasks/test_list.py
+++ b/backend/src/processes/tests/test_views/test_tasks/test_list.py
@@ -1603,6 +1603,24 @@ def test_list__filter_assigned_to_not_number__validation_error(api_client):
     assert response.data['details']['name'] == 'assigned_to'
 
 
+def test_list__filter_assigned_to_null_string__validation_error(api_client):
+
+    # arrange
+    user = create_test_admin()
+    api_client.token_authenticate(user=user)
+
+    # act
+    response = api_client.get('/v3/tasks?assigned_to=null')
+
+    # assert
+    message = 'A valid integer is required.'
+    assert response.status_code == 400
+    assert response.data['code'] == ErrorCode.VALIDATION_ERROR
+    assert response.data['message'] == message
+    assert response.data['details']['reason'] == message
+    assert response.data['details']['name'] == 'assigned_to'
+
+
 def test_list__filter_assigned_to_not_admin__validation_error(api_client):
 
     # arrange
@@ -2077,6 +2095,66 @@ def test_list__filter_template_id_not_number__validation_error(api_client):
     assert response.data['details']['name'] == 'template_id'
 
 
+def test_list__filter_template_id_null_string__validation_error(api_client):
+
+    # arrange
+    user = create_test_user()
+    api_client.token_authenticate(user=user)
+
+    # act
+    response = api_client.get('/v3/tasks?template_id=null')
+
+    # assert
+    message = 'A valid integer is required.'
+    assert response.status_code == 400
+    assert response.data['code'] == ErrorCode.VALIDATION_ERROR
+    assert response.data['message'] == message
+    assert response.data['details']['reason'] == message
+    assert response.data['details']['name'] == 'template_id'
+
+
+def test_list__filter_template_task_api_name_null_string__validation_error(
+    api_client,
+):
+
+    # arrange
+    user = create_test_user()
+    api_client.token_authenticate(user=user)
+
+    # act
+    response = api_client.get('/v3/tasks?template_task_api_name=null')
+
+    # assert
+    message = 'This field may not be null.'
+    assert response.status_code == 400
+    assert response.data['code'] == ErrorCode.VALIDATION_ERROR
+    assert response.data['message'] == message
+    assert response.data['details']['reason'] == message
+    assert response.data['details']['name'] == 'template_task_api_name'
+
+
+def test_list__filter_template_id_and_template_task_api_name_null_string__validation_error(
+    api_client,
+):
+
+    # arrange
+    user = create_test_user()
+    api_client.token_authenticate(user=user)
+
+    # act
+    response = api_client.get(
+        '/v3/tasks?template_id=null&template_task_api_name=null',
+    )
+
+    # assert
+    message = 'A valid integer is required.'
+    assert response.status_code == 400
+    assert response.data['code'] == ErrorCode.VALIDATION_ERROR
+    assert response.data['message'] == message
+    assert response.data['details']['reason'] == message
+    assert response.data['details']['name'] == 'template_id'
+
+
 def test_list__filter_template_task_api_name__ok(api_client):
 
     # arrange
@@ -2253,57 +2331,3 @@ def test_list__sql_injection_in_search__ok(api_client, injection):
     # assert
     assert response.status_code == 200
     assert len(response.data['results']) == 1
-
-
-def test_list__template_id_null_string__ok(api_client):
-
-    # arrange
-    user = create_test_owner()
-    api_client.token_authenticate(user=user)
-    workflow = create_test_workflow(user=user, tasks_count=1)
-    task = workflow.tasks.get(number=1)
-
-    # act
-    response = api_client.get('/v3/tasks?template_id=null')
-
-    # assert
-    assert response.status_code == 200
-    assert len(response.data) == 1
-    assert response.data[0]['id'] == task.id
-
-
-def test_list__template_task_api_name_null_string__ok(api_client):
-
-    # arrange
-    user = create_test_owner()
-    api_client.token_authenticate(user=user)
-    workflow = create_test_workflow(user=user, tasks_count=1)
-    task = workflow.tasks.get(number=1)
-
-    # act
-    response = api_client.get('/v3/tasks?template_task_api_name=null')
-
-    # assert
-    assert response.status_code == 200
-    assert len(response.data) == 1
-    assert response.data[0]['id'] == task.id
-
-
-def test_list__template_id_and_template_task_api_name_null_string__ok(api_client):
-
-    # arrange
-    user = create_test_owner()
-    api_client.token_authenticate(user=user)
-    workflow = create_test_workflow(user=user, tasks_count=1)
-    task = workflow.tasks.get(number=1)
-
-    # act
-    response = api_client.get(
-        '/v3/tasks?template_id=null&template_task_api_name=null',
-    )
-
-    # assert
-    assert response.status_code == 200
-    assert len(response.data) == 1
-    assert response.data[0]['id'] == task.id
-

--- a/backend/src/processes/tests/test_views/test_tasks/test_list.py
+++ b/backend/src/processes/tests/test_views/test_tasks/test_list.py
@@ -2255,14 +2255,7 @@ def test_list__sql_injection_in_search__ok(api_client, injection):
     assert len(response.data['results']) == 1
 
 
-@pytest.mark.parametrize(
-    "query_string", [
-        'template_id=null',
-        'template_task_api_name=null',
-        'template_id=null&template_task_api_name=null',
-    ],
-)
-def test_list__filter_null_string__ok(api_client, query_string):
+def test_list__template_id_null_string__ok(api_client):
 
     # arrange
     user = create_test_owner()
@@ -2271,7 +2264,43 @@ def test_list__filter_null_string__ok(api_client, query_string):
     task = workflow.tasks.get(number=1)
 
     # act
-    response = api_client.get(f'/v3/tasks?{query_string}')
+    response = api_client.get('/v3/tasks?template_id=null')
+
+    # assert
+    assert response.status_code == 200
+    assert len(response.data) == 1
+    assert response.data[0]['id'] == task.id
+
+
+def test_list__template_task_api_name_null_string__ok(api_client):
+
+    # arrange
+    user = create_test_owner()
+    api_client.token_authenticate(user=user)
+    workflow = create_test_workflow(user=user, tasks_count=1)
+    task = workflow.tasks.get(number=1)
+
+    # act
+    response = api_client.get('/v3/tasks?template_task_api_name=null')
+
+    # assert
+    assert response.status_code == 200
+    assert len(response.data) == 1
+    assert response.data[0]['id'] == task.id
+
+
+def test_list__template_id_and_template_task_api_name_null_string__ok(api_client):
+
+    # arrange
+    user = create_test_owner()
+    api_client.token_authenticate(user=user)
+    workflow = create_test_workflow(user=user, tasks_count=1)
+    task = workflow.tasks.get(number=1)
+
+    # act
+    response = api_client.get(
+        '/v3/tasks?template_id=null&template_task_api_name=null',
+    )
 
     # assert
     assert response.status_code == 200

--- a/backend/src/processes/views/task.py
+++ b/backend/src/processes/views/task.py
@@ -114,8 +114,12 @@ class TasksListView(ListAPIView):
 
     def list(self, request, *args, **kwargs):
         user = request.user
+        filter_data = {
+            k: v for k, v in request.GET.items()
+            if v != 'null'
+        }
         filter_slz = TaskListFilterSerializer(
-            data=request.GET,
+            data=filter_data,
             context={'user': user},
         )
         filter_slz.is_valid(raise_exception=True)

--- a/backend/src/processes/views/task.py
+++ b/backend/src/processes/views/task.py
@@ -114,17 +114,8 @@ class TasksListView(ListAPIView):
 
     def list(self, request, *args, **kwargs):
         user = request.user
-        _nullable_filters = {
-            'template_id',
-            'template_task_api_name',
-            'assigned_to',
-        }
-        filter_data = {
-            k: v for k, v in request.GET.items()
-            if not (k in _nullable_filters and v == 'null')
-        }
         filter_slz = TaskListFilterSerializer(
-            data=filter_data,
+            data=request.GET,
             context={'user': user},
         )
         filter_slz.is_valid(raise_exception=True)

--- a/backend/src/processes/views/task.py
+++ b/backend/src/processes/views/task.py
@@ -114,9 +114,14 @@ class TasksListView(ListAPIView):
 
     def list(self, request, *args, **kwargs):
         user = request.user
+        _nullable_filters = {
+            'template_id',
+            'template_task_api_name',
+            'assigned_to',
+        }
         filter_data = {
             k: v for k, v in request.GET.items()
-            if v != 'null'
+            if not (k in _nullable_filters and v == 'null')
         }
         filter_slz = TaskListFilterSerializer(
             data=filter_data,


### PR DESCRIPTION
# Problem

When a user opens their task list and no filters are actively selected, the application sends empty filter values to the server. The server incorrectly treats these empty values as actual filter criteria, which results in either an error page or an empty task list — even though the user has tasks assigned to them.

# Fix / Solution

Updated the task list API to reject the literal query-string value `null` for filter parameters with a 400 validation error. The web client no longer sends empty filters as `null` (see frontend #130); the backend now explicitly rejects legacy clients that still pass the string `'null'` instead of omitting the parameter.

Validation is handled entirely in `TaskListFilterSerializer` — no view-level preprocessing.

# Release notes

Fixed an issue where the task list could return no results or display an error when filters were not actively set by the user. The API now returns a clear 400 validation error when clients send the literal string `null` for filter parameters.

# Changes
## API
- `GET /v3/tasks` — query parameters `template_id`, `template_task_api_name`, and `assigned_to` with the literal value `null` now return **400** validation errors instead of being silently ignored:
  - `template_id` / `assigned_to`: "A valid integer is required."
  - `template_task_api_name`: "This field may not be null."

## Web-client
No backend changes. Related frontend fix in #130 — the web client no longer serializes unset filters as the string `null`.

# Test cases
## API

| Authorization | Test case | Expected result |
|---|---|---|
| Token auth (account owner) | Send `GET /v3/tasks?template_id=null` | Status 400, message "A valid integer is required.", `details.name` = `template_id` |
| Token auth (account owner) | Send `GET /v3/tasks?template_task_api_name=null` | Status 400, message "This field may not be null.", `details.name` = `template_task_api_name` |
| Token auth (admin) | Send `GET /v3/tasks?assigned_to=null` | Status 400, message "A valid integer is required.", `details.name` = `assigned_to` |
| Token auth (account owner) | Send `GET /v3/tasks?template_id=null&template_task_api_name=null` | Status 400, message "A valid integer is required.", `details.name` = `template_id` |

## Web-client
No backend changes. Verify task list loads correctly without sending `null` filter values (covered by frontend #130).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow input-validation change on a read-only list endpoint; only legacy clients that still send the string `null` will see new 400 responses instead of empty or broken results.
> 
> **Overview**
> **GET `/v3/tasks`** now fails fast when clients send the literal string `null` for list filters instead of omitting the parameter. Integer filters `template_id` and `assigned_to` return **400** with *"A valid integer is required."*; `template_task_api_name` uses a new shared **`RejectNullStringValidator`** in `src.generics.validators` and returns *"This field may not be null."*
> 
> Validation stays in **`TaskListFilterSerializer`** (no view preprocessing). API tests cover each filter and combined `template_id` + `template_task_api_name=null` (first reported error is on `template_id`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 976ff9e11764277f35b11dc385033fc5441873b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ignore literal `null` string values for filter params in the tasks list API
> The `GET /v3/tasks` endpoint previously treated the string `'null'` as a literal filter value for `template_id`, `template_task_api_name`, and `assigned_to`, which could produce unexpected empty results. [TasksListView.list](https://github.com/pneumaticapp/pneumaticworkflow/pull/256/files#diff-05bbc1161f014d6d000b960096668f7514b15d33e775435c37d1ec7d80849ef0) now strips these params from the filter input when their value is exactly `'null'`, treating them as unset.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #256 opened
>
> - Moved null query parameter handling from view preprocessing to serializer field validation [56640f3]
> - Replaced parametrized test with explicit test cases for null query parameter handling [56640f3]
> - Removed custom serializer field classes and mixin that treated literal 'null' query parameter values as absent parameters in TaskListFilterSerializer [8d53022]
> - Updated tests to validate that literal 'null' query parameter values now return 400 validation errors instead of 200 responses [8d53022]
> - Extracted null string validation logic into a reusable `RejectNullStringValidator` class in `src.generics.validators` module and applied it to the `template_task_api_name` field in `TaskListFilterSerializer`, replacing the custom `validate_template_task_api_name` method [10e91ed]
> - Renamed test method from `test_list__filter_template_id_and_template_task_api_name_null_string__validation_error` to `test_list__filter_both_null_strings__validation_error` [10e91ed]
> - Refactored `RejectNullStringValidator` class to inherit from `django.core.validators.BaseValidator` instead of implementing custom validation logic [976ff9e]
> - Reformatted `template_task_api_name` field declaration in `TaskListFilterSerializer` class across multiple lines [976ff9e]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ab0ea4d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
