### PR TITLE
47991 frontend [ errors ] Show "Permission denied" banner for 403 response status

### DIFF
--- a/frontend/src/public/utils/__tests__/getErrorMessage.test.ts
+++ b/frontend/src/public/utils/__tests__/getErrorMessage.test.ts
@@ -25,10 +25,14 @@ function createApiError(
 describe('normalizeToCustomError', () => {
   // --- Shape 1: ApiError (payload in .data) ---
   it('unwraps ApiError with code in .data', () => {
-    const apiError = createApiError('File not found', {
-      code: 'FILE_001',
-      message: 'File not found',
-    }, 404);
+    const apiError = createApiError(
+      'File not found',
+      {
+        code: 'FILE_001',
+        message: 'File not found',
+      },
+      404,
+    );
 
     const result = normalizeToCustomError(apiError);
 
@@ -36,16 +40,19 @@ describe('normalizeToCustomError', () => {
       code: 'FILE_001',
       message: 'File not found',
       details: undefined,
-      detail: undefined,
     });
   });
 
   it('unwraps ApiError with details in .data', () => {
-    const apiError = createApiError('File size exceeds limit', {
-      code: 'FILE_003',
-      message: 'File size exceeds limit',
-      details: { reason: 'Maximum allowed size is 100MB' },
-    }, 413);
+    const apiError = createApiError(
+      'File size exceeds limit',
+      {
+        code: 'FILE_003',
+        message: 'File size exceeds limit',
+        details: { reason: 'Maximum allowed size is 100MB' },
+      },
+      413,
+    );
 
     const result = normalizeToCustomError(apiError);
 
@@ -53,14 +60,17 @@ describe('normalizeToCustomError', () => {
       code: 'FILE_003',
       message: 'File size exceeds limit',
       details: { reason: 'Maximum allowed size is 100MB' },
-      detail: undefined,
     });
   });
 
   it('uses Error.message when .data has no message', () => {
-    const apiError = createApiError('Axios level error', {
-      code: 'INFRA_005',
-    }, 500);
+    const apiError = createApiError(
+      'Axios level error',
+      {
+        code: 'INFRA_005',
+      },
+      500,
+    );
 
     const result = normalizeToCustomError(apiError);
 
@@ -69,27 +79,44 @@ describe('normalizeToCustomError', () => {
   });
 
   it('unwraps ApiError with detail field in .data', () => {
-    const apiError = createApiError('Not found', {
-      code: 'not_found',
-      message: 'Not found',
-      detail: 'Not found.',
-    }, 404);
+    const apiError = createApiError(
+      'Not found',
+      {
+        code: 'not_found',
+        message: 'Not found',
+        detail: 'Not found.',
+      },
+      404,
+    );
 
     const result = normalizeToCustomError(apiError);
 
     expect(result?.detail).toBe('Not found.');
   });
 
-  it('skips .data when it has no code field', () => {
-    const apiError = createApiError('Server Error', {
-      error: 'Internal Server Error',
-    }, 500);
+  it('skips .data when payload has no code, message, or detail keys (e.g. { error: "..." })', () => {
+    const apiError = createApiError(
+      'Server Error',
+      {
+        error: 'Internal Server Error',
+      },
+      500,
+    );
 
-    // Falls through to Shape 3 (Error with message)
     const result = normalizeToCustomError(apiError);
 
     expect(result?.code).toBe('');
     expect(result?.message).toBe('Server Error');
+  });
+
+  it('uses err.detail when data has message key but detail only on error', () => {
+    const apiError = createApiError('', { message: 'Validation failed' }, 400);
+    Object.assign(apiError, { detail: 'Field is required' });
+
+    const result = normalizeToCustomError(apiError);
+
+    expect(result?.message).toBe('Validation failed');
+    expect(result?.detail).toBe('Field is required');
   });
 
   // --- Shape 2: ICustomError (code + message at top level) ---
@@ -104,6 +131,18 @@ describe('normalizeToCustomError', () => {
     expect(result).toBe(error); // same reference, not a copy
   });
 
+  it('returns object as-is when code and detail are present without message', () => {
+    const error = {
+      code: 'token_not_valid',
+      detail: 'Given token not valid',
+    };
+
+    const result = normalizeToCustomError(error);
+
+    expect(result).toBe(error);
+    expect(result?.detail).toBe('Given token not valid');
+  });
+
   // --- Shape 3: Error ---
   it('extracts message from plain Error', () => {
     const error = new Error('Network Error');
@@ -111,6 +150,20 @@ describe('normalizeToCustomError', () => {
     const result = normalizeToCustomError(error);
 
     expect(result).toEqual({ code: '', message: 'Network Error' });
+  });
+
+  it('includes err.detail on Error when .data gate does not match', () => {
+    const error = Object.assign(new Error(''), {
+      detail: 'You do not have permission to perform this action.',
+    });
+
+    const result = normalizeToCustomError(error);
+
+    expect(result).toEqual({
+      code: '',
+      message: '',
+      detail: 'You do not have permission to perform this action.',
+    });
   });
 
   // --- Edge cases ---
@@ -172,6 +225,18 @@ describe('getErrorMessage', () => {
     expect(getErrorMessage(error)).toBe('The actual detail string');
   });
 
+  it('returns detail from ApiError.data when Error.message is empty (DRF without code)', () => {
+    const apiError = createApiError(
+      '',
+      {
+        detail: 'You do not have permission to perform this action.',
+      },
+      403,
+    );
+
+    expect(getErrorMessage(apiError)).toBe('You do not have permission to perform this action.');
+  });
+
   it('returns UNKNOWN_ERROR when message is empty and code not in mapper', () => {
     const error: ICustomError = {
       code: 'unmapped_code',
@@ -228,46 +293,66 @@ describe('getErrorMessage', () => {
 
   // --- File Service error codes through ApiError (REAL production shape) ---
   it('maps FILE_003 from ApiError.data to file-service.size-exceeded', () => {
-    const apiError = createApiError('File size exceeds limit', {
-      code: 'FILE_003',
-      message: 'File size exceeds limit',
-    }, 413);
+    const apiError = createApiError(
+      'File size exceeds limit',
+      {
+        code: 'FILE_003',
+        message: 'File size exceeds limit',
+      },
+      413,
+    );
 
     expect(getErrorMessage(apiError)).toBe('file-service.size-exceeded');
   });
 
   it('maps AUTH_001 from ApiError.data to file-service.auth-failed', () => {
-    const apiError = createApiError('Authentication failed', {
-      code: 'AUTH_001',
-      message: 'Authentication failed',
-    }, 401);
+    const apiError = createApiError(
+      'Authentication failed',
+      {
+        code: 'AUTH_001',
+        message: 'Authentication failed',
+      },
+      401,
+    );
 
     expect(getErrorMessage(apiError)).toBe('file-service.auth-failed');
   });
 
   it('maps PERM_001 from ApiError.data to file-service.permission-denied', () => {
-    const apiError = createApiError('Permission denied', {
-      code: 'PERM_001',
-      message: 'Permission denied',
-    }, 403);
+    const apiError = createApiError(
+      'Permission denied',
+      {
+        code: 'PERM_001',
+        message: 'Permission denied',
+      },
+      403,
+    );
 
     expect(getErrorMessage(apiError)).toBe('file-service.permission-denied');
   });
 
   it('maps backend code from ApiError.data', () => {
-    const apiError = createApiError('wrong task message', {
-      code: 'error__processes__wrong_task',
-      message: 'wrong task message',
-    }, 400);
+    const apiError = createApiError(
+      'wrong task message',
+      {
+        code: 'error__processes__wrong_task',
+        message: 'wrong task message',
+      },
+      400,
+    );
 
     expect(getErrorMessage(apiError)).toBe('task.not-found');
   });
 
   it('falls back to ApiError.data.message for unmapped codes', () => {
-    const apiError = createApiError('DB error', {
-      code: 'DB_001',
-      message: 'Database connection error',
-    }, 503);
+    const apiError = createApiError(
+      'DB error',
+      {
+        code: 'DB_001',
+        message: 'Database connection error',
+      },
+      503,
+    );
 
     expect(getErrorMessage(apiError)).toBe('Database connection error');
   });
@@ -336,11 +421,15 @@ describe('getErrorMessage', () => {
   });
 
   it('handles ApiError.data with details (File Service full payload)', () => {
-    const apiError = createApiError('File size exceeds limit', {
-      code: 'unmapped_storage_code',
-      message: 'Upload failed',
-      details: { reason: 'Maximum allowed size is 100MB' },
-    }, 503);
+    const apiError = createApiError(
+      'File size exceeds limit',
+      {
+        code: 'unmapped_storage_code',
+        message: 'Upload failed',
+        details: { reason: 'Maximum allowed size is 100MB' },
+      },
+      503,
+    );
 
     expect(getErrorMessage(apiError)).toBe('Upload failed\nMaximum allowed size is 100MB');
   });
@@ -384,10 +473,14 @@ describe('isPaidFeatureError', () => {
   });
 
   it('returns true for paid feature error via ApiError.data', () => {
-    const apiError = createApiError('Paid feature', {
-      code: 'error__conditions__paid_feature',
-      message: 'Paid feature',
-    }, 403);
+    const apiError = createApiError(
+      'Paid feature',
+      {
+        code: 'error__conditions__paid_feature',
+        message: 'Paid feature',
+      },
+      403,
+    );
 
     expect(isPaidFeatureError(apiError)).toBe(true);
   });
@@ -401,10 +494,14 @@ describe('isPaidFeatureError', () => {
   });
 
   it('returns false for non-paid feature ApiError', () => {
-    const apiError = createApiError('File not found', {
-      code: 'FILE_001',
-      message: 'File not found',
-    }, 404);
+    const apiError = createApiError(
+      'File not found',
+      {
+        code: 'FILE_001',
+        message: 'File not found',
+      },
+      404,
+    );
 
     expect(isPaidFeatureError(apiError)).toBe(false);
   });

--- a/frontend/src/public/utils/getErrorMessage.ts
+++ b/frontend/src/public/utils/getErrorMessage.ts
@@ -41,13 +41,14 @@ const errorMapper: { [key: string]: string } = {
  * Handles three error shapes that exist in the codebase:
  *
  * 1. ApiError (from axios interceptor) — payload sits in `.data`:
- *    { message: "...", data: { code: "FILE_003", message: "..." }, status: 413 }
+ *    File Service: { data: { code: "FILE_003", message: "..." }, status: 413 }
+ *    Django/DRF:   { data: { detail: "..." }, status: 4xx } — often no code
  *
  * 2. Plain ICustomError (from auth saga resolved promises):
  *    { code: "error__processes__wrong_task", message: "Wrong task" }
  *
  * 3. Native Error (from throws, network errors):
- *    { message: "Network Error" }
+ *    { message: "Network Error" } — detail may sit on error from Object.assign
  *
  * Uses duck typing — no coupling to ApiError class.
  */
@@ -58,32 +59,39 @@ export function normalizeToCustomError(error: unknown): ICustomError | undefined
 
   const err = error as Record<string, unknown>;
 
-  // Shape 1: ApiError — response payload stored in .data
-  // Check .data first because ApiError extends Error (has .message) but NOT .code
+  const isErrorMessage = typeof err.message === 'string';
+  const isErrorDetail = typeof err.detail === 'string';
+  const isErrorCode = typeof err.code === 'string';
+
+  const errorMessage = isErrorMessage ? (err.message as string) : '';
+  const errorDetail = isErrorDetail ? (err.detail as string) : '';
+
   if (err.data && typeof err.data === 'object') {
     const data = err.data as Record<string, unknown>;
-    if (typeof data.code === 'string') {
+
+    if ('code' in data || 'message' in data || 'detail' in data) {
+      const code = typeof data.code === 'string' ? (data.code as string) : '';
+      const message = (typeof data.message === 'string' && data.message) || errorMessage;
+      const detail = (typeof data.detail === 'string' && data.detail) || errorDetail;
+
       return {
-        code: data.code,
-        message: (typeof data.message === 'string' ? data.message : undefined)
-          || (typeof err.message === 'string' ? err.message : '')
-          || '',
+        code,
+        message,
         details: data.details as ICustomError['details'],
-        detail: typeof data.detail === 'string' ? data.detail : undefined,
+        ...(detail ? { detail } : {}),
       };
     }
   }
 
-  // Shape 2: ICustomError — code and message at top level
-  if (typeof err.code === 'string' && typeof err.message === 'string') {
+  if (isErrorCode && (isErrorMessage || isErrorDetail)) {
     return error as ICustomError;
   }
 
-  // Shape 3: Error — only message available
-  if (typeof err.message === 'string') {
+  if (isErrorMessage || isErrorDetail) {
     return {
       code: '',
-      message: err.message,
+      message: errorMessage,
+      ...(errorDetail ? { detail: errorDetail } : {}),
     };
   }
 
@@ -112,8 +120,8 @@ export const getErrorMessage = (error?: unknown) => {
   const messageLower = message?.trim()?.toLowerCase() || '';
   const shouldAppendDetails = Boolean(reasonLower && reasonLower !== messageLower);
 
-  const errorDetails = details?.reason && shouldAppendDetails
-    && (details.name ? `${details.name}: ${details.reason}` : details.reason);
+  const errorDetails =
+    details?.reason && shouldAppendDetails && (details.name ? `${details.name}: ${details.reason}` : details.reason);
   const errorMessage = [message, errorDetails].filter(Boolean).join('\n');
 
   return errorMessage || UNKNOWN_ERROR;


### PR DESCRIPTION
## 1. Release notes

Fixed access-denied error messages: when the server returns 403 with text such as «Permission denied…», the banner shows that message instead of the generic «Something Went Wrong».

---

## 2. Problem description

**Where it appeared:** error banner (notification) when the Django REST Framework backend returns 403 with body `{ "detail": "..." }` and no `code` field — e.g. editing a template without owner rights.

**What was wrong:** regression after commit `9e9569c1d181924965e08e9bc9bcfa20f3c23eef` (`41526 fix(error-handling): unify File Service error mapping across frontend and backend`): File Service error unification (`normalizeToCustomError` + ApiError) made Shape 1 gate check only for `code` in `.data`. DRF responses with a single `detail` field (no `code`) were no longer recognized — text was lost and `getErrorMessage` returned fallback `UNKNOWN_ERROR` («Something Went Wrong»).

**How to reproduce:**
1. Log in as an account admin (not the template owner).
2. Open another user's template for editing: `/templates/edit/{id}/`.
3. Wait for the 403 response.

**Expected:** banner with text from `detail` (e.g. «Permission denied. You are not a template owner.»).  
**Actual before fix:** banner «Something Went Wrong».

---

## 3. Context

- **Task:** 47991 — show a meaningful message on 403 instead of generic fallback.
- **Regression source:** commit `9e9569c1d181924965e08e9bc9bcfa20f3c23eef` — `41526 fix(error-handling): unify File Service error mapping across frontend and backend`. Added `normalizeToCustomError` with gate only on `data.code` (File Service format); DRF `{ detail }` responses did not pass this gate. Not related to task 47817 (removing technical details from banner text) — that changed user-facing message content, not the `detail` field in API JSON.
- **Affected utility:** `frontend/src/public/utils/getErrorMessage.ts` — used in sagas (templates, tasks, workflows, auth, etc.) and UI components for `NotificationManager`.

---

## 4. Solution

- Extended ApiError normalization: responses with `detail` in `.data` (without `code`) are correctly unwrapped for the banner.
- Errors shaped as `{ code, detail }` without `message` are no longer dropped.
- `detail` on Error object (after `Object.assign` in `createApiError`) is included when building the message.
- `getErrorMessage` logic and File Service / backend code mapping **unchanged** — fix is only in `normalizeToCustomError`.

---

## 5. Implementation details

| Before | After |
|--------|-------|
| Shape 1 (ApiError `.data`): gate only when `typeof data.code === 'string'` | Gate when any of `code`, `message`, `detail` keys exist in `.data` |
| DRF `{ detail: "..." }` without `code` was ignored | `detail` is extracted; when `message` is empty, text comes from `detail` |
| Shape 2: required `code` **and** `message` | `code` and (`message` **or** `detail`) is enough |
| Shape 3: only `message` on Error | `detail` on Error is also used when `message` is empty |
| `detail` always present as `undefined` on object | `detail` key added only when value is truthy (spread) |

The **`details`** field (plural, File Service) **was not changed** — FILE_* tests from commit `9e9569c1` behave the same.

---

## 6. What to test

### 6.1 Preconditions

- Dev environment with frontend and backend running.
- Account with at least two users: **account owner** and **admin** (not owner of the specific template).
- A template created by the owner.
- Testing on **dev branch** with this PR.

### 6.2 Positive scenarios

| Scenario | Description (steps and expected result) | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| :--- | :--- | :--- | :--- | :--- | :--- |
| **403 when editing another user's template** | 1. Log in as admin (not template owner). 2. Open `/templates/edit/{id}/` for someone else's template. 3. Wait for error. **Expected:** banner with «Permission denied. You are not a template owner.» (or actual `detail` from backend), **not** «Something Went Wrong». | ✅ | [ ] | [ ] | [ ] |
| **File Service error with code** | 1. Log in as any user. 2. Trigger file upload error (size limit / 413). **Expected:** banner with mapped translated text (e.g. size exceeded), same as before fix. | [ ] | [ ] | [ ] | [ ] |
| **Backend code in mapper** | 1. Trigger error with known code (e.g. wrong task). **Expected:** text from `errorMapper`, not generic fallback. | [ ] | [ ] | [ ] | [ ] |

### 6.3 Negative scenarios and edge cases

| Scenario | Description (steps and expected result) | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| :--- | :--- | :--- | :--- | :--- | :--- |
| **Unknown error without detail/message** | 1. Simulate/get response without `detail`, `message`, and without mapper code. **Expected:** «Something Went Wrong» — fallback preserved. | [ ] | [ ] | [ ] | [ ] |
| **Network failure** | 1. Disconnect network / block request. **Expected:** network error message or «Failed to fetch» / mapper, not empty banner. | [ ] | [ ] | [ ] | [ ] |
| **401 / expired token** | 1. Action with invalid token. **Expected:** meaningful message (redirect/login or auth error text), no regression on 403 scenario. | [ ] | [ ] | [ ] | [ ] |
| **Successful action without error** | 1. Owner opens own template, saves changes. **Expected:** no false error banner. | [ ] | [ ] | [ ] | [ ] |

### 6.4 Verification points

- **UI:** banner text (`NotificationManager` / toast) is readable, no «Something Went Wrong» where backend returned `detail`.
- **Network (DevTools):** on 403, response body contains `{ "detail": "..." }`; status 403.
- **Regression:** File Service errors (FILE_*, AUTH_*, PERM_*) and paid-feature modals work as before.

### 6.6 What was NOT tested

- Locales (en/ru/de/fr/es) — not checked; backend `detail` is shown as-is.
- Safari Desktop / Mobile, Chrome Mobile — not checked (manual test only on Chrome Desktop).
- Production environment — dev only.
- Load / concurrent testing — not performed.

---

## 7. Testing impacted areas

`getErrorMessage` is used in many sagas and components. Minimum regression checks:

| Scenario | Description (steps and expected result) | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| :--- | :--- | :--- | :--- | :--- | :--- |
| **Workflows grid** | Error loading workflows list. **Expected:** meaningful banner text, not empty. | [ ] | [ ] | [ ] | [ ] |
| **Team / Users** | Error on user action (invite, vacation). **Expected:** API error text in warning banner. | [ ] | [ ] | [ ] | [ ] |
| **File upload** | File service error on attachment upload. **Expected:** File Service mapper text. | [ ] | [ ] | [ ] | [ ] |
| **Run workflow modal** | Error starting workflow. **Expected:** error text in modal/banner, no generic fallback where `detail` exists. | [ ] | [ ] | [ ] | [ ] |

---

## 8. Unit tests

File: `frontend/src/public/utils/__tests__/getErrorMessage.test.ts` — **53 tests**, all passing.

Added / updated coverage:
- Shape 1 gate: `.data` without `code`/`message`/`detail` (e.g. `{ error: "..." }`) — falls back to `Error.message`.
- DRF: `detail` in `.data` with empty `Error.message` → text in `getErrorMessage`.
- Shape 2: `{ code, detail }` without `message`.
- Shape 3: `detail` on Error after `Object.assign`.
- `err.detail` when `message` is in `.data`.
- Phase 1.5: with old (buggy) code, **4 tests fail** for the correct reason (assertion mismatch on `detail` / UNKNOWN_ERROR).

---

## 9. Commits with changes

| Hash | Message |
|------|---------|
| `b9724173` | `47991 fix(errors): show DRF detail in banner instead of UNKNOWN_ERROR` |



<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Scoped changes to shared error parsing with expanded unit tests; behavior shifts only for payloads that previously missed normalization (e.g. detail-only DRF responses).
> 
> **Overview**
> **`normalizeToCustomError`** now treats axios **`.data`** payloads that include **`code`**, **`message`**, or **`detail`** (not only when **`code`** is a string), so Django/DRF responses like `{ detail: "..." }` without a code are normalized instead of falling through to a generic unknown error.
> 
> Top-level **`ICustomError`** objects with **`code`** plus **`detail`** but no **`message`** are returned as-is. Plain **`Error`** objects can carry **`detail`** (e.g. from **`Object.assign`**) when **`.data`** does not match. **`detail`** is only added on the normalized object when it is non-empty.
> 
> Together with existing **`getErrorMessage`** behavior (prefer **`detail`** when mappers do not apply), **403** permission strings such as *"You do not have permission to perform this action."* surface correctly for banners/UI. Tests cover DRF **`detail`-only** **`ApiError`**, **`code`+`detail`**, and **`Error`** with **`detail`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9724173496606c501ba3d218bcd62504eef75f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show "Permission denied" banner for 403 responses by broadening error normalization
> - Updates `normalizeToCustomError` in [`getErrorMessage.ts`](https://github.com/pneumaticapp/pneumaticworkflow/pull/264/files#diff-d329ed4e7f961b0122265aa4957ce23244a5eb19b98d2ba17807eab4ec3f8ffa) to recognize API errors whose `data` payload contains `message` or `detail` but no `code` (e.g. DRF-style `{detail: "Permission denied"}` responses from 403s).
> - Propagates `detail` from either `ApiError.data` or the top-level error object, and allows plain `Error`-like objects with only a `detail` field to be normalized.
> - Relaxes the plain-object check so `code + detail` (without `message`) is now accepted as a valid `ICustomError`.
> - Behavioral Change: previously, API errors with no `code` in their data payload were not normalized and fell through; they will now produce a structured error with `detail` populated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b972417.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->