### PR TITLE
🔧 29571 backend [workflows] Allow resume ended workflows

### DIFF
--- a/backend/src/processes/services/workflow_action.py
+++ b/backend/src/processes/services/workflow_action.py
@@ -172,7 +172,13 @@ class WorkflowActionService:
 
     def force_resume_workflow(self):
 
-        """ Resume delayed workflow before the timeout """
+        """Resume delayed or completed workflow.
+
+        AnalyticService is intentionally not called here:
+        DELAYED resume is a reversal, not a new user action;
+        DONE resume re-opens a workflow without creating
+        a new analytics event (no dedicated metric exists).
+        """
 
         if self.workflow.is_running:
             return

--- a/backend/src/processes/services/workflow_action.py
+++ b/backend/src/processes/services/workflow_action.py
@@ -176,12 +176,14 @@ class WorkflowActionService:
 
         if self.workflow.is_running:
             return
-        if self.workflow.is_completed:
-            raise exceptions.ResumeCompletedWorkflow
 
         with transaction.atomic():
+            update_fields = ['status']
+            if self.workflow.is_completed:
+                self.workflow.date_completed = None
+                update_fields.append('date_completed')
             self.workflow.status = WorkflowStatus.RUNNING
-            self.workflow.save(update_fields=['status'])
+            self.workflow.save(update_fields=update_fields)
             WorkflowEventService.force_resume_workflow_event(
                 workflow=self.workflow,
                 user=self.user,

--- a/backend/src/processes/tests/test_services/test_workflow_action_service.py
+++ b/backend/src/processes/tests/test_services/test_workflow_action_service.py
@@ -2422,9 +2422,13 @@ def test_force_resume_workflow__workflow_done__resume_ok(mocker):
         'src.processes.services.workflow_action.WorkflowEventService'
         '.force_resume_workflow_event',
     )
-    mocker.patch(
+    send_resumed_notification_mock = mocker.patch(
         'src.processes.services.workflow_action'
         '.send_resumed_workflow_notification.delay',
+    )
+    continue_task_mock = mocker.patch(
+        'src.processes.services.workflow_action.WorkflowActionService'
+        '.continue_task',
     )
     service = WorkflowActionService(user=owner, workflow=workflow)
 
@@ -2439,6 +2443,8 @@ def test_force_resume_workflow__workflow_done__resume_ok(mocker):
         workflow=workflow,
         user=owner,
     )
+    send_resumed_notification_mock.assert_not_called()
+    continue_task_mock.assert_not_called()
 
 
 def test_force_resume_workflow__workflow_done__active_task_unchanged(mocker):
@@ -2452,11 +2458,14 @@ def test_force_resume_workflow__workflow_done__active_task_unchanged(mocker):
         tasks_count=3,
     )
     task = workflow.tasks.get(number=1)
-    mocker.patch(
+    date_started = task.date_started
+    date_completed = task.date_completed
+    due_date = task.due_date
+    force_resume_event_mock = mocker.patch(
         'src.processes.services.workflow_action.WorkflowEventService'
         '.force_resume_workflow_event',
     )
-    mocker.patch(
+    send_resumed_notification_mock = mocker.patch(
         'src.processes.services.workflow_action'
         '.send_resumed_workflow_notification.delay',
     )
@@ -2471,6 +2480,59 @@ def test_force_resume_workflow__workflow_done__active_task_unchanged(mocker):
     assert workflow.status == WorkflowStatus.RUNNING
     assert workflow.date_completed is None
     assert task.status == TaskStatus.ACTIVE
+    assert task.date_started == date_started
+    assert task.date_completed == date_completed
+    assert task.due_date == due_date
+    force_resume_event_mock.assert_called_once_with(
+        workflow=workflow,
+        user=owner,
+    )
+    send_resumed_notification_mock.assert_not_called()
+
+
+def test_force_resume_workflow__workflow_done__completed_tasks_unchanged(
+    mocker,
+):
+
+    # arrange
+    account = create_test_account()
+    owner = create_test_owner(account=account)
+    workflow = create_test_workflow(
+        user=owner,
+        status=WorkflowStatus.DONE,
+        tasks_count=3,
+    )
+    workflow.tasks.update(status=TaskStatus.COMPLETED)
+    force_resume_event_mock = mocker.patch(
+        'src.processes.services.workflow_action.WorkflowEventService'
+        '.force_resume_workflow_event',
+    )
+    send_resumed_notification_mock = mocker.patch(
+        'src.processes.services.workflow_action'
+        '.send_resumed_workflow_notification.delay',
+    )
+    continue_task_mock = mocker.patch(
+        'src.processes.services.workflow_action.WorkflowActionService'
+        '.continue_task',
+    )
+    service = WorkflowActionService(user=owner, workflow=workflow)
+
+    # act
+    service.force_resume_workflow()
+
+    # assert
+    workflow.refresh_from_db()
+    assert workflow.status == WorkflowStatus.RUNNING
+    assert workflow.date_completed is None
+    assert workflow.tasks.active().exists() is False
+    assert workflow.tasks.delayed().exists() is False
+    assert workflow.tasks.completed().count() == 3
+    force_resume_event_mock.assert_called_once_with(
+        workflow=workflow,
+        user=owner,
+    )
+    send_resumed_notification_mock.assert_not_called()
+    continue_task_mock.assert_not_called()
 
 
 def test_force_resume_workflow__workflow_delayed__resume_and_notify(mocker):

--- a/backend/src/processes/tests/test_services/test_workflow_action_service.py
+++ b/backend/src/processes/tests/test_services/test_workflow_action_service.py
@@ -2412,19 +2412,65 @@ def test_force_resume_workflow__workflow_running__return_early(mocker):
     continue_task_mock.assert_not_called()
 
 
-def test_force_resume_workflow__workflow_completed__raise_exception(mocker):
+def test_force_resume_workflow__workflow_done__resume_ok(mocker):
 
     # arrange
     account = create_test_account()
     owner = create_test_owner(account=account)
-    workflow = create_test_workflow(user=owner)
-    workflow.status = WorkflowStatus.DONE
-    workflow.save()
+    workflow = create_test_workflow(user=owner, status=WorkflowStatus.DONE)
+    force_resume_event_mock = mocker.patch(
+        'src.processes.services.workflow_action.WorkflowEventService'
+        '.force_resume_workflow_event',
+    )
+    mocker.patch(
+        'src.processes.services.workflow_action'
+        '.send_resumed_workflow_notification.delay',
+    )
     service = WorkflowActionService(user=owner, workflow=workflow)
 
-    # act / assert
-    with pytest.raises(exceptions.ResumeCompletedWorkflow):
-        service.force_resume_workflow()
+    # act
+    service.force_resume_workflow()
+
+    # assert
+    workflow.refresh_from_db()
+    assert workflow.status == WorkflowStatus.RUNNING
+    assert workflow.date_completed is None
+    force_resume_event_mock.assert_called_once_with(
+        workflow=workflow,
+        user=owner,
+    )
+
+
+def test_force_resume_workflow__workflow_done__active_task_unchanged(mocker):
+
+    # arrange
+    account = create_test_account()
+    owner = create_test_owner(account=account)
+    workflow = create_test_workflow(
+        user=owner,
+        status=WorkflowStatus.DONE,
+        tasks_count=3,
+    )
+    task = workflow.tasks.get(number=1)
+    mocker.patch(
+        'src.processes.services.workflow_action.WorkflowEventService'
+        '.force_resume_workflow_event',
+    )
+    mocker.patch(
+        'src.processes.services.workflow_action'
+        '.send_resumed_workflow_notification.delay',
+    )
+    service = WorkflowActionService(user=owner, workflow=workflow)
+
+    # act
+    service.force_resume_workflow()
+
+    # assert
+    workflow.refresh_from_db()
+    task.refresh_from_db()
+    assert workflow.status == WorkflowStatus.RUNNING
+    assert workflow.date_completed is None
+    assert task.status == TaskStatus.ACTIVE
 
 
 def test_force_resume_workflow__workflow_delayed__resume_and_notify(mocker):

--- a/backend/src/processes/tests/test_views/test_workflow/test_resume.py
+++ b/backend/src/processes/tests/test_views/test_workflow/test_resume.py
@@ -233,6 +233,7 @@ def test_resume__workflow_done__ok(api_client):
 
     # assert
     assert response.status_code == 200
+    assert response.data['id'] == workflow.id
     assert response.data['status'] == WorkflowStatus.RUNNING
     assert response.data['date_completed_tsp'] is None
     workflow.refresh_from_db()

--- a/backend/src/processes/tests/test_views/test_workflow/test_resume.py
+++ b/backend/src/processes/tests/test_views/test_workflow/test_resume.py
@@ -217,6 +217,29 @@ def test_resume__service_exception__validation_error(
     resume_mock.assert_called_once()
 
 
+def test_resume__workflow_done__ok(api_client):
+
+    # arrange
+    user = create_test_owner()
+    workflow = create_test_workflow(
+        user,
+        tasks_count=1,
+        status=WorkflowStatus.DONE,
+    )
+    api_client.token_authenticate(user)
+
+    # act
+    response = api_client.post(f'/workflows/{workflow.id}/resume')
+
+    # assert
+    assert response.status_code == 200
+    assert response.data['status'] == WorkflowStatus.RUNNING
+    assert response.data['date_completed_tsp'] is None
+    workflow.refresh_from_db()
+    assert workflow.status == WorkflowStatus.RUNNING
+    assert workflow.date_completed is None
+
+
 def test_resume__not_authenticated__permission_denied(api_client):
 
     # arrange

--- a/frontend/src/public/components/Workflows/WorkflowControlls/WorkflowControlls.tsx
+++ b/frontend/src/public/components/Workflows/WorkflowControlls/WorkflowControlls.tsx
@@ -78,7 +78,9 @@ export function WorkflowControllsComponents({
   const canCloneWorkflow = Boolean(workflow.template?.isActive);
   const canEndWorkflow = workflow.finalizable && workflow.status !== EWorkflowStatus.Finished;
   const canSnoozeWorkflow = workflow.status === EWorkflowStatus.Running;
-  const canResumeWorkflow = workflow.status === EWorkflowStatus.Snoozed;
+  const canResumeWorkflow =
+    workflow.status === EWorkflowStatus.Snoozed ||
+    workflow.status === EWorkflowStatus.Finished;
 
   const handleOnClone = () => {
     if (!workflow.template) {

--- a/frontend/src/public/components/Workflows/WorkflowControlls/__tests__/WorkflowControlls.test.tsx
+++ b/frontend/src/public/components/Workflows/WorkflowControlls/__tests__/WorkflowControlls.test.tsx
@@ -1,0 +1,95 @@
+// <reference types="jest" />
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { TDropdownOption } from '../../../UI';
+import { enMessages } from '../../../../lang/locales/en_US';
+import { EWorkflowStatus, IWorkflowClient } from '../../../../types/workflow';
+
+import { WorkflowControllsComponents } from '../WorkflowControlls';
+
+jest.mock('../../utils/getSnoozeOptions', () => ({
+  getSnoozeOptions: () => [],
+}));
+
+type TResumeCase = {
+  name: string;
+  status: EWorkflowStatus;
+  isHidden: boolean;
+};
+
+describe('WorkflowControllsComponents', () => {
+  const RESUME_LABEL = enMessages['workflows.card-resume'];
+  const authUser = { id: 1, isAccountOwner: true, isAdmin: false };
+  const createWorkflow = (status: EWorkflowStatus) => {
+    const workflow: Partial<IWorkflowClient> = {
+      id: 1,
+      owners: [authUser.id],
+      status,
+      isUrgent: false,
+      finalizable: true,
+      template: null,
+      completedTasks: [],
+    };
+
+    return workflow as IWorkflowClient;
+  };
+
+  const renderResumeOption = (status: EWorkflowStatus) => {
+    render(
+      <WorkflowControllsComponents
+        workflow={createWorkflow(status)}
+        timezone="UTC"
+      >
+        {(options: TDropdownOption[]) => {
+          const option = options.find(({ label }) => label === RESUME_LABEL);
+
+          expect(option).toBeDefined();
+
+          return (
+            <span
+              aria-label={RESUME_LABEL}
+              data-hidden={String(Boolean(option?.isHidden))}
+            />
+          );
+        }}
+      </WorkflowControllsComponents>,
+    );
+  };
+
+  beforeEach(() => {
+    (useDispatch as jest.Mock).mockReturnValue(jest.fn());
+    (useSelector as jest.Mock).mockReturnValue({ authUser });
+  });
+
+  const cases: TResumeCase[] = [
+    {
+      name: 'finished',
+      status: EWorkflowStatus.Finished,
+      isHidden: false,
+    },
+    {
+      name: 'snoozed',
+      status: EWorkflowStatus.Snoozed,
+      isHidden: false,
+    },
+    {
+      name: 'running',
+      status: EWorkflowStatus.Running,
+      isHidden: true,
+    },
+  ];
+
+  it.each(cases)(
+    'sets resume hidden=$isHidden for $name workflow',
+    ({ status, isHidden }: TResumeCase) => {
+      renderResumeOption(status);
+
+      expect(screen.getByLabelText(RESUME_LABEL)).toHaveAttribute(
+        'data-hidden',
+        String(isHidden),
+      );
+    },
+  );
+});


### PR DESCRIPTION
# Problem

`POST /workflows/:id/resume` only worked for snoozed (`DELAYED`) workflows. Calling it for a finished workflow (`WorkflowStatus.DONE`) returned **400** with `MSG_PW_0017` (“Completed workflow cannot be changed.”). Users need to bring a completed workflow back to `RUNNING` via API and the **Resume** control in the UI.

# Fix / Solution

- Allow `POST /workflows/:id/resume` for `WorkflowStatus.DONE`.
- In `force_resume_workflow`, remove the completed-workflow guard, clear `date_completed`, set status to `RUNNING`, and keep existing delayed-task resume / notification / `FORCE_RESUME` log behavior.
- Show the **Resume** button for finished workflows in `WorkflowControlls`.
- Update and extend backend tests for service and API resume paths.

# Release notes

The "Resume" context action now applies to prematurely completed workflows.

# Changes

## Summary

- Allow `POST /workflows/:id/resume` for `WorkflowStatus.DONE`.
- Backend: `force_resume_workflow` clears `date_completed` and sets `RUNNING`.
- Frontend: **Resume** button for finished workflows.
- Tests added/updated for service and view resume flows.
- Manual testing passed (backend API, UI after frontend rebuild).

## API

- `POST /workflows/:id/resume` accepts finished (`DONE`) workflows and returns **200** with `status=RUNNING` and `date_completed=null`.

## Web-client

- **Resume** is available for finished workflows in workflow controls (same entry point as snoozed resume).

# Test plan

## Automated (pytest)

- [x] `src/processes/tests/test_services/test_workflow_action_service.py` — `force_resume` cases for `DONE` (including rewritten completed-workflow test).
- [x] `src/processes/tests/test_views/test_workflow/test_resume.py` — API resume for `DONE` workflows.
- [x] Regression: delayed resume, running no-op, auth/permission, `resume_task` still rejects completed workflow on Celery path.

Suggested commands:

```bash
make test-backend ARGS="src/processes/tests/test_views/test_workflow/test_resume.py -vv"
make test-backend ARGS="src/processes/tests/test_services/test_workflow_action_service.py -k force_resume -vv"
```

## Manual

- [x] Complete a workflow, call `POST /workflows/:id/resume` — **200**, workflow **Running**, `date_completed` cleared.
- [x] Rebuild frontend, open a finished workflow — **Resume** visible and succeeds.

Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow resuming completed (DONE) workflows in addition to snoozed ones
> - `WorkflowActionService.force_resume_workflow` no longer raises an exception for completed workflows; it now sets status to `RUNNING` and clears `date_completed` inside a transaction.
> - The Resume action in [`WorkflowControlls.tsx`](https://github.com/pneumaticapp/pneumaticworkflow/pull/266/files#diff-466568c782fed2cd0d25610d3147a38d497898a0cc17fdaf2afa14192fe2b5d8) is now visible for workflows in `Finished` status, in addition to `Snoozed`.
> - Notifications and task continuation are only triggered for delayed tasks, as before; resuming a DONE workflow does not notify or alter existing task states.
> - Behavioral Change: workflows previously in a terminal `DONE` state can now be transitioned back to `RUNNING`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ca3203b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

