### PR TITLE
⚙️ 48124 backend [ nginx ] Filtering spam requests at the Nginx level

### DIFF
--- a/nginx/includes/location_bot_block.conf
+++ b/nginx/includes/location_bot_block.conf
@@ -1,0 +1,9 @@
+# Drop common scanner/bot probes before they reach upstreams.
+location ~* \.(php|asp|aspx|jsp|cgi)$ {
+    access_log off;
+    return 444;
+}
+location ~* /(wp-admin|wp-login|wordpress|phpmyadmin|\.env) {
+    access_log off;
+    return 444;
+}

--- a/nginx/ssl_forms_templates/nginx.conf.template
+++ b/nginx/ssl_forms_templates/nginx.conf.template
@@ -16,6 +16,20 @@ http {
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_prefer_server_ciphers on;
 
+    # Reject requests whose Host does not match any server_name below.
+    # Uses the main domain certificate only to complete the TLS handshake.
+    server {
+        listen 80 default_server;
+        listen 8001 ssl default_server;
+        listen 443 ssl default_server;
+        server_name _;
+
+        ssl_certificate     /etc/keys/${SERVER_ADDRESS}/fullchain.pem;
+        ssl_certificate_key /etc/keys/${SERVER_ADDRESS}/privkey.pem;
+
+        return 444;
+    }
+
     ##
     # Backend
     ##
@@ -30,6 +44,7 @@ http {
 
         server_name ${SERVER_ADDRESS};
 
+        include /etc/nginx/includes/location_bot_block.conf;
         location / {
             include /etc/nginx/includes/proxy_to_backend.conf;
         }
@@ -43,7 +58,7 @@ http {
         index index.html index.htm index.nginx-debian.html;
 
         server_name pneumatic-nginx;
-
+        include /etc/nginx/includes/location_bot_block.conf;
         location / {
             include /etc/nginx/includes/proxy_to_private_backend.conf;
         }
@@ -70,7 +85,7 @@ http {
         index index.html index.nginx-debian.html;
 
         server_name ${SERVER_ADDRESS};
-
+        include /etc/nginx/includes/location_bot_block.conf;
         include /etc/nginx/includes/location_frontend_common.conf;
     }
 
@@ -87,7 +102,7 @@ http {
         index index.html index.nginx-debian.html;
 
         server_name ${FORM_DOMAIN};
-
+        include /etc/nginx/includes/location_bot_block.conf;
         include /etc/nginx/includes/location_frontend_common.conf;
 
     }

--- a/nginx/ssl_templates/nginx.conf.template
+++ b/nginx/ssl_templates/nginx.conf.template
@@ -15,6 +15,20 @@ http {
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_prefer_server_ciphers on;
 
+    # Reject requests whose Host does not match any server_name below.
+    # Uses the main domain certificate only to complete the TLS handshake.
+    server {
+        listen 80 default_server;
+        listen 8001 ssl default_server;
+        listen 443 ssl default_server;
+        server_name _;
+
+        ssl_certificate     /etc/keys/${SERVER_ADDRESS}/fullchain.pem;
+        ssl_certificate_key /etc/keys/${SERVER_ADDRESS}/privkey.pem;
+
+        return 444;
+    }
+
     ##
     # Backend
     ##
@@ -29,6 +43,7 @@ http {
 
         server_name ${SERVER_ADDRESS};
 
+        include /etc/nginx/includes/location_bot_block.conf;
         location / {
             include /etc/nginx/includes/proxy_to_backend.conf;
         }
@@ -43,6 +58,7 @@ http {
 
         server_name pneumatic-nginx;
 
+        include /etc/nginx/includes/location_bot_block.conf;
         location / {
             include /etc/nginx/includes/proxy_to_private_backend.conf;
         }
@@ -70,6 +86,7 @@ http {
 
         server_name ${SERVER_ADDRESS};
 
+        include /etc/nginx/includes/location_bot_block.conf;
         include /etc/nginx/includes/location_frontend_common.conf;
     }
 }

--- a/nginx/templates/nginx.conf.template
+++ b/nginx/templates/nginx.conf.template
@@ -8,6 +8,14 @@ http {
 
     include /etc/nginx/includes/http_base.conf;
 
+    # Reject requests whose Host does not match any server_name below.
+    server {
+        listen 80 default_server;
+        listen 8001 default_server;
+        server_name _;
+        return 444;
+    }
+
     ##
     # Backend
     ##
@@ -18,6 +26,8 @@ http {
         index index.html index.nginx-debian.html;
 
         server_name ${SERVER_ADDRESS};
+
+        include /etc/nginx/includes/location_bot_block.conf;
 
         location / {
             include /etc/nginx/includes/proxy_to_backend.conf;
@@ -33,6 +43,8 @@ http {
         index index.html index.htm index.nginx-debian.html;
 
         server_name pneumatic-nginx;
+
+        include /etc/nginx/includes/location_bot_block.conf;
 
         location / {
             include /etc/nginx/includes/proxy_to_private_backend.conf;
@@ -58,6 +70,7 @@ http {
 
         server_name ${SERVER_ADDRESS};
 
+        include /etc/nginx/includes/location_bot_block.conf;
         include /etc/nginx/includes/location_frontend_common.conf;
     }
 }


### PR DESCRIPTION
# Problem

Automated scanners and bots were hitting the product with unknown website addresses and junk URLs that do not belong to the application. Those requests never helped real users, but they still reached the system, created noisy error reports, and wasted resources that should serve legitimate traffic.

# Fix / Solution

- Add a default nginx virtual host that closes connections when the request Host does not match a known server name (no proxy to the application).
- For SSL templates, reuse the main domain certificate on that default host only to complete the TLS handshake, then close the connection.
- Add a shared nginx include that drops common scanner paths (for example `.php` and WordPress/admin probes) before they reach backend or frontend upstreams.
- Wire the bot-block include into HTTP, SSL, and SSL+forms nginx templates (backend, private, frontend, and form server blocks). Railway nginx config is out of scope.

# Release notes

Nginx now rejects requests with unknown Host headers and drops common bot/scanner URL probes before they reach the application, reducing spam noise in logs and error monitoring.

# Changes

## API

No API changes.

## Web-client

No web-client changes.

## Nginx / infrastructure

- New include: `nginx/includes/location_bot_block.conf`
- Updated templates:
  - `nginx/templates/nginx.conf.template` (HTTP)
  - `nginx/ssl_templates/nginx.conf.template` (SSL)
  - `nginx/ssl_forms_templates/nginx.conf.template` (SSL + form domain)
- Not changed: `nginx/railway/*`

# Test cases

## API

| Authorization | Test case | Expected result |
| --- | --- | --- |
| N/A | No API endpoints changed in this task | N/A |

## Web-client

| Browser | Device | Authorization | Test scenario | Expected result |
| --- | --- | --- | --- | --- |
| Chrome | Desktop browser | N/A | No UI changes in this task | N/A |

## Nginx / infrastructure

| Authorization | Test case | Expected result |
| --- | --- | --- |
| N/A (infra) | After deploy, run `nginx -t` in the nginx container/host | Configuration test passes |
| N/A (infra) | HTTP/HTTPS request with a valid Host equal to `SERVER_ADDRESS` to frontend and backend ports | Application responds as before (page/API available) |
| N/A (infra) | Internal request with Host `pneumatic-nginx` to port 80 (private backend path used by frontend) | Private backend proxy still works |
| N/A (infra) | SSL+forms setup: request with Host equal to `FORM_DOMAIN` on port 443 | Form virtual host serves as before with its own certificate |
| N/A (infra) | Request with unknown/foreign Host (e.g. IP reverse DNS or random domain) to ports 80 / 443 / 8001 | Connection closed (`444`); request does not reach Django; no `Invalid HTTP_HOST` in application logs |
| N/A (infra) | Request to a known Host for a scanner path such as `/wp-login.php`, `/wordpress/`, `/phpmyadmin`, `/.env`, or `*.php` | Connection closed (`444`); request does not reach backend/frontend upstreams |
| N/A (infra) | Legitimate product URLs on a known Host (login, workflows, API, forms, static assets) | Behavior unchanged vs pre-change baseline |
| N/A (infra) | Internal docker networking still uses Host `pneumatic-nginx` | No regressions in frontend→backend private calls |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes public request routing and TLS default vhosts; misconfiguration could block valid Hosts or internal `pneumatic-nginx` traffic, though patterns target known bot probes only.
> 
> **Overview**
> Nginx is tightened at the edge so junk traffic stops before it hits Django or upstreams.
> 
> A new shared include **`location_bot_block.conf`** closes connections (`444`) for typical scanner URLs (script extensions like `.php`, WordPress/admin paths, `phpmyadmin`, `/.env`) with access logging off. That include is wired into the HTTP, SSL, and SSL+forms nginx templates on backend, private `pneumatic-nginx`, frontend, and form server blocks (Railway configs unchanged).
> 
> Each of those templates also gains a **`default_server`** virtual host on the public listen ports that **`return 444`** when the `Host` does not match a configured `server_name`, so unknown hosts never proxy to the app. SSL templates use the main domain cert on that catch-all host only to finish TLS, then drop the connection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 806b49c21ead2ebdebb71f4bf1acb4874468303d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Filter spam and scanner requests at the Nginx level with HTTP 444
> - Adds [`location_bot_block.conf`](https://github.com/pneumaticapp/pneumaticworkflow/pull/271/files#diff-1fa92d06495ed43ef972019233268654e813bf6ec781a60743043ecb5803bb10) with two regex location blocks that return 444 and suppress access logging for requests matching common scanner targets (`.php`, `.asp`, `.aspx`, `.jsp`, `.cgi` extensions, and paths like `wp-admin`, `phpmyadmin`, `.env`).
> - Adds a catch-all default server block (`server_name _`) to all Nginx config templates that returns 444 for requests with unrecognized `Host` headers on ports 80, 443, and 8001.
> - Includes `location_bot_block.conf` in all public/private backend and frontend server blocks across the plain, SSL, and forms SSL templates.
> - Behavioral Change: Unmatched hosts and scanner-pattern paths are now terminated at Nginx before reaching any upstream, and are excluded from access logs.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 806b49c. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->