### PR TITLE
21562 backend [websocket] Send websocket when a account plan has shanged

### DIFF
--- a/backend/src/notifications/enums.py
+++ b/backend/src/notifications/enums.py
@@ -42,6 +42,7 @@ class NotificationMethod:
     dataset_created = 'dataset_created'
     dataset_updated = 'dataset_updated'
     dataset_deleted = 'dataset_deleted'
+    account_plan_changed = 'account_plan_changed'
     workflows_digest = 'workflows_digest'
     tasks_digest = 'tasks_digest'
     user_deactivated = 'user_deactivated'
@@ -87,6 +88,7 @@ class NotificationMethod:
         dataset_created,
         dataset_updated,
         dataset_deleted,
+        account_plan_changed,
         workflows_digest,
         tasks_digest,
         user_deactivated,

--- a/backend/src/notifications/services/websockets.py
+++ b/backend/src/notifications/services/websockets.py
@@ -53,6 +53,7 @@ class WebSocketService(NotificationService):
         NotificationMethod.dataset_created,
         NotificationMethod.dataset_updated,
         NotificationMethod.dataset_deleted,
+        NotificationMethod.account_plan_changed,
     }
 
     def _get_serialized_notification(
@@ -487,5 +488,19 @@ class WebSocketService(NotificationService):
             method_name=NotificationMethod.dataset_deleted,
             group_name=f'{EventsConsumer.classname}_{user_id}',
             data=dataset_data,
+            sync=sync,
+        )
+
+    def send_account_plan_changed(
+        self,
+        user_id: int,
+        plan_data: dict,
+        sync: bool,
+        **kwargs,
+    ):
+        self._send(
+            method_name=NotificationMethod.account_plan_changed,
+            group_name=f'{EventsConsumer.classname}_{user_id}',
+            data=plan_data,
             sync=sync,
         )

--- a/backend/src/notifications/tasks.py
+++ b/backend/src/notifications/tasks.py
@@ -60,6 +60,7 @@ UserModel = get_user_model()
 
 
 __all__ = [
+    'send_account_plan_changed_notification',
     'send_comment_notification',
     'send_completed_workflow_notification',
     'send_dataset_created_notification',
@@ -1598,9 +1599,9 @@ def _send_dataset_deleted_notification(
     for (user_id, user_email) in users:
         _send_notification(
             method_name=NotificationMethod.dataset_deleted,
-            account_id=account_id,
             user_id=user_id,
             user_email=user_email,
+            account_id=account_id,
             logging=logging,
             dataset_data=dataset_data,
             sync=True,
@@ -1610,6 +1611,34 @@ def _send_dataset_deleted_notification(
 @shared_task(base=NotificationTask)
 def send_dataset_deleted_notification(**kwargs):
     _send_dataset_deleted_notification(**kwargs)
+
+
+def _send_account_plan_changed_notification(
+    logging: bool,
+    account_id: int,
+    plan_data: dict,
+    **kwargs,
+):
+    users = UserModel.objects.filter(
+        account_id=account_id,
+        status=UserStatus.ACTIVE,
+    ).values_list('id', 'email')
+
+    for (user_id, user_email) in users:
+        _send_notification(
+            method_name=NotificationMethod.account_plan_changed,
+            user_id=user_id,
+            user_email=user_email,
+            account_id=account_id,
+            logging=logging,
+            plan_data=plan_data,
+            sync=True,
+        )
+
+
+@shared_task(base=NotificationTask)
+def send_account_plan_changed_notification(**kwargs):
+    _send_account_plan_changed_notification(**kwargs)
 
 
 def _send_vacation_delegation_notification(

--- a/backend/src/notifications/tests/test_services/test_websockets.py
+++ b/backend/src/notifications/tests/test_services/test_websockets.py
@@ -1428,3 +1428,48 @@ def test_send_dataset_deleted__ok(mocker):
         data=dataset_data,
         sync=True,
     )
+
+
+def test_send_account_plan_changed__ok(mocker):
+
+    """send_account_plan_changed routes to EventsConsumer correct payload"""
+
+    # arrange
+    user_id = 42
+    plan_data = {
+        'billing_plan': 'premium',
+        'billing_period': 'monthly',
+        'plan_expiration': '2026-08-15',
+        'plan_expiration_tsp': 1721036800.0,
+        'trial_is_active': False,
+        'trial_ended': False,
+        'is_subscribed': True,
+        'active_users': 5,
+        'tenants_active_users': 0,
+        'max_users': 10,
+        'billing_sync': True,
+    }
+    send_mock = mocker.patch(
+        'src.notifications.services.websockets.'
+        'WebSocketService._send',
+    )
+    service = WebSocketService(
+        logging=True,
+        logo_lg='https://logo.com',
+        account_id=123,
+    )
+
+    # act
+    service.send_account_plan_changed(
+        user_id=user_id,
+        plan_data=plan_data,
+        sync=True,
+    )
+
+    # assert
+    send_mock.assert_called_once_with(
+        method_name=NotificationMethod.account_plan_changed,
+        group_name=f'events_{user_id}',
+        data=plan_data,
+        sync=True,
+    )

--- a/backend/src/notifications/tests/test_tasks/test_send_account_plan_changed_notification.py
+++ b/backend/src/notifications/tests/test_tasks/test_send_account_plan_changed_notification.py
@@ -1,0 +1,114 @@
+import pytest
+
+from src.accounts.enums import UserStatus
+from src.notifications.enums import NotificationMethod
+from src.notifications.tasks import (
+    _send_account_plan_changed_notification,
+)
+from src.processes.tests.fixtures import (
+    create_test_account,
+    create_test_admin,
+    create_test_owner,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+def test__send_account_plan_changed_notification__two_active_users__ok(
+    mocker,
+):
+
+    """_send_notification called for each active account user"""
+
+    # arrange
+    account = create_test_account()
+    user_1 = create_test_owner(account=account)
+    user_2 = create_test_admin(account=account)
+    plan_data = {
+        'billing_plan': 'premium',
+        'billing_period': 'monthly',
+        'plan_expiration': '2026-08-15',
+        'plan_expiration_tsp': 1721036800.0,
+        'trial_is_active': False,
+        'trial_ended': False,
+        'is_subscribed': True,
+        'active_users': 2,
+        'tenants_active_users': 0,
+        'max_users': 10,
+        'billing_sync': True,
+    }
+
+    send_notification_mock = mocker.patch(
+        'src.notifications.tasks._send_notification',
+    )
+
+    # act
+    _send_account_plan_changed_notification(
+        logging=account.log_api_requests,
+        account_id=account.id,
+        plan_data=plan_data,
+    )
+
+    # assert
+    assert send_notification_mock.call_count == 2
+    send_notification_mock.assert_has_calls(
+        [
+            mocker.call(
+                method_name=NotificationMethod.account_plan_changed,
+                user_id=user_1.id,
+                user_email=user_1.email,
+                account_id=account.id,
+                logging=account.log_api_requests,
+                plan_data=plan_data,
+                sync=True,
+            ),
+            mocker.call(
+                method_name=NotificationMethod.account_plan_changed,
+                user_id=user_2.id,
+                user_email=user_2.email,
+                account_id=account.id,
+                logging=account.log_api_requests,
+                plan_data=plan_data,
+                sync=True,
+            ),
+        ],
+        any_order=True,
+    )
+
+
+def test__send_account_plan_changed_notification__no_active_users__not_sent(
+    mocker,
+):
+
+    """_send_notification not called when no active users in account"""
+
+    # arrange
+    account = create_test_account()
+    create_test_owner(account=account, status=UserStatus.INACTIVE)
+    plan_data = {
+        'billing_plan': 'premium',
+        'billing_period': 'monthly',
+        'plan_expiration': '2026-08-15',
+        'plan_expiration_tsp': 1721036800.0,
+        'trial_is_active': False,
+        'trial_ended': False,
+        'is_subscribed': True,
+        'active_users': 0,
+        'tenants_active_users': 0,
+        'max_users': 10,
+        'billing_sync': True,
+    }
+
+    send_notification_mock = mocker.patch(
+        'src.notifications.tasks._send_notification',
+    )
+
+    # act
+    _send_account_plan_changed_notification(
+        logging=account.log_api_requests,
+        account_id=account.id,
+        plan_data=plan_data,
+    )
+
+    # assert
+    send_notification_mock.assert_not_called()

--- a/backend/src/payment/services/account.py
+++ b/backend/src/payment/services/account.py
@@ -7,10 +7,16 @@ from src.accounts.enums import (
     BillingPlanType,
 )
 from src.accounts.models import Account
+from src.accounts.serializers.accounts import (
+    AccountPlanSerializer,
+)
 from src.accounts.services.account import AccountService
 from src.analysis.mixins import BaseIdentifyMixin
 from src.analysis.services import AnalyticService
 from src.authentication.enums import AuthTokenType
+from src.notifications.tasks import (
+    send_account_plan_changed_notification,
+)
 from src.payment.entities import (
     SubscriptionDetails,
 )
@@ -75,6 +81,12 @@ class AccountSubscriptionService(BaseIdentifyMixin):
             data['trial_end'] = details.trial_end
         account_service.partial_update(**data)
 
+        send_account_plan_changed_notification.delay(
+            logging=self.instance.log_api_requests,
+            account_id=self.instance.id,
+            plan_data=AccountPlanSerializer(instance=self.instance).data,
+        )
+
         AnalyticService.subscription_created(self.user)
         if not prev_trial_end and data.get('trial_end'):
             AnalyticService.trial_subscription_created(self.user)
@@ -121,6 +133,12 @@ class AccountSubscriptionService(BaseIdentifyMixin):
             force_save=True,
         )
 
+        send_account_plan_changed_notification.delay(
+            logging=self.instance.log_api_requests,
+            account_id=self.instance.id,
+            plan_data=AccountPlanSerializer(instance=self.instance).data,
+        )
+
         if convert_trial:
             AnalyticService.subscription_converted(self.user)
         else:
@@ -152,6 +170,12 @@ class AccountSubscriptionService(BaseIdentifyMixin):
             plan_expiration=plan_expiration,
             trial_ended=True,
             force_save=True,
+        )
+
+        send_account_plan_changed_notification.delay(
+            logging=self.instance.log_api_requests,
+            account_id=self.instance.id,
+            plan_data=AccountPlanSerializer(instance=self.instance).data,
         )
 
     def cancel(self, plan_expiration: datetime):

--- a/backend/src/payment/services/account.py
+++ b/backend/src/payment/services/account.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from django.contrib.auth import get_user_model
+from django.db import transaction
 from django.utils import timezone
 
 from src.accounts.enums import (
@@ -37,6 +38,19 @@ class AccountSubscriptionService(BaseIdentifyMixin):
         self.user = user
         self.is_superuser = is_superuser
         self.auth_type = auth_type
+
+    def _send_plan_changed_notifications(self):
+        send_account_plan_changed_notification.delay(
+            logging=self.instance.log_api_requests,
+            account_id=self.instance.id,
+            plan_data=AccountPlanSerializer(instance=self.instance).data,
+        )
+        for tenant in self.instance.tenants.only_tenants():
+            send_account_plan_changed_notification.delay(
+                logging=tenant.log_api_requests,
+                account_id=tenant.id,
+                plan_data=AccountPlanSerializer(instance=tenant).data,
+            )
 
     def _plan_changed(self, details: SubscriptionDetails) -> bool:
 
@@ -81,11 +95,7 @@ class AccountSubscriptionService(BaseIdentifyMixin):
             data['trial_end'] = details.trial_end
         account_service.partial_update(**data)
 
-        send_account_plan_changed_notification.delay(
-            logging=self.instance.log_api_requests,
-            account_id=self.instance.id,
-            plan_data=AccountPlanSerializer(instance=self.instance).data,
-        )
+        transaction.on_commit(self._send_plan_changed_notifications)
 
         AnalyticService.subscription_created(self.user)
         if not prev_trial_end and data.get('trial_end'):
@@ -133,11 +143,7 @@ class AccountSubscriptionService(BaseIdentifyMixin):
             force_save=True,
         )
 
-        send_account_plan_changed_notification.delay(
-            logging=self.instance.log_api_requests,
-            account_id=self.instance.id,
-            plan_data=AccountPlanSerializer(instance=self.instance).data,
-        )
+        transaction.on_commit(self._send_plan_changed_notifications)
 
         if convert_trial:
             AnalyticService.subscription_converted(self.user)
@@ -172,11 +178,7 @@ class AccountSubscriptionService(BaseIdentifyMixin):
             force_save=True,
         )
 
-        send_account_plan_changed_notification.delay(
-            logging=self.instance.log_api_requests,
-            account_id=self.instance.id,
-            plan_data=AccountPlanSerializer(instance=self.instance).data,
-        )
+        transaction.on_commit(self._send_plan_changed_notifications)
 
     def cancel(self, plan_expiration: datetime):
 

--- a/backend/src/payment/tests/test_services/test_account_subscription_service.py
+++ b/backend/src/payment/tests/test_services/test_account_subscription_service.py
@@ -1,7 +1,6 @@
 from datetime import timedelta
 
 import pytest
-from django.contrib.auth import get_user_model
 from django.utils import timezone
 
 from src.accounts.enums import (
@@ -22,10 +21,9 @@ from src.payment.services.account import (
 )
 from src.processes.tests.fixtures import (
     create_test_account,
-    create_test_user,
+    create_test_owner,
 )
 
-UserModel = get_user_model()
 pytestmark = pytest.mark.django_db
 
 
@@ -41,7 +39,7 @@ def test_plan_changed__not_changes__ok():
         trial_end=plan_expiration,
         period=period,
     )
-    user = create_test_user(account=account)
+    user = create_test_owner(account=account)
     is_superuser = True
     auth_type = AuthTokenType.WEBHOOK
     service = AccountSubscriptionService(
@@ -78,7 +76,7 @@ def test_plan_changed__max_users_changed__ok():
         plan_expiration=plan_expiration,
         period=period,
     )
-    user = create_test_user(account=account)
+    user = create_test_owner(account=account)
     is_superuser = True
     auth_type = AuthTokenType.WEBHOOK
     service = AccountSubscriptionService(
@@ -115,7 +113,7 @@ def test_plan_changed__plan_expiration_changed__ok():
         plan_expiration=plan_expiration,
         period=period,
     )
-    user = create_test_user(account=account)
+    user = create_test_owner(account=account)
     is_superuser = True
     auth_type = AuthTokenType.WEBHOOK
     service = AccountSubscriptionService(
@@ -150,7 +148,7 @@ def test_plan_changed__plan_changed__ok():
         plan=BillingPlanType.FREEMIUM,
         period=period,
     )
-    user = create_test_user(account=account)
+    user = create_test_owner(account=account)
     is_superuser = True
     auth_type = AuthTokenType.WEBHOOK
     service = AccountSubscriptionService(
@@ -189,7 +187,7 @@ def test_plan_changed__first_trial__ok():
         plan=BillingPlanType.FREEMIUM,
         period=period,
     )
-    user = create_test_user(account=account)
+    user = create_test_owner(account=account)
     is_superuser = True
     auth_type = AuthTokenType.WEBHOOK
     service = AccountSubscriptionService(
@@ -226,7 +224,7 @@ def test_plan_changed__billing_period__ok():
         trial_end=plan_expiration,
         period=BillingPeriod.MONTHLY,
     )
-    user = create_test_user(account=account)
+    user = create_test_owner(account=account)
     is_superuser = True
     auth_type = AuthTokenType.WEBHOOK
     service = AccountSubscriptionService(
@@ -265,7 +263,7 @@ def test_plan_changed__quantity__ok():
     )
     create_test_account(master_account=account, lease_level=LeaseLevel.TENANT)
     create_test_account(master_account=account, lease_level=LeaseLevel.TENANT)
-    user = create_test_user(account=account)
+    user = create_test_owner(account=account)
     is_superuser = True
     auth_type = AuthTokenType.WEBHOOK
     service = AccountSubscriptionService(
@@ -298,7 +296,7 @@ def test_create__freemium_to_trial__ok(mocker, identify_mock):
         plan=BillingPlanType.FREEMIUM,
         trial_ended=False,
     )
-    user = create_test_user(account=account)
+    user = create_test_owner(account=account)
     account_service_init_mock = mocker.patch.object(
         AccountService,
         attribute='__init__',
@@ -319,6 +317,10 @@ def test_create__freemium_to_trial__ok(mocker, identify_mock):
     send_plan_changed_mock = mocker.patch(
         'src.payment.services.account.'
         'send_account_plan_changed_notification.delay',
+    )
+    transaction_on_commit_mock = mocker.patch(
+        'src.payment.services.account.transaction.on_commit',
+        side_effect=lambda f, *args, **kwargs: f(),
     )
     trial_start = timezone.now() - timedelta(minutes=1)
     plan_expiration = timezone.now() + timedelta(days=30)
@@ -346,6 +348,7 @@ def test_create__freemium_to_trial__ok(mocker, identify_mock):
     )
 
     # assert
+    transaction_on_commit_mock.assert_called_once_with(mocker.ANY)
     account_service_init_mock.assert_called_once_with(
         instance=account,
         user=user,
@@ -381,7 +384,7 @@ def test_create__trial_ended__not_trial(mocker, identify_mock):
         plan=BillingPlanType.FREEMIUM,
         trial_ended=True,
     )
-    user = create_test_user(account=account)
+    user = create_test_owner(account=account)
     account_service_init_mock = mocker.patch.object(
         AccountService,
         attribute='__init__',
@@ -402,6 +405,10 @@ def test_create__trial_ended__not_trial(mocker, identify_mock):
     send_plan_changed_mock = mocker.patch(
         'src.payment.services.account.'
         'send_account_plan_changed_notification.delay',
+    )
+    transaction_on_commit_mock = mocker.patch(
+        'src.payment.services.account.transaction.on_commit',
+        side_effect=lambda f, *args, **kwargs: f(),
     )
     trial_start = timezone.now() - timedelta(minutes=1)
     plan_expiration = timezone.now() + timedelta(days=30)
@@ -429,6 +436,7 @@ def test_create__trial_ended__not_trial(mocker, identify_mock):
     )
 
     # assert
+    transaction_on_commit_mock.assert_called_once_with(mocker.ANY)
     account_service_init_mock.assert_called_once_with(
         instance=account,
         user=user,
@@ -461,7 +469,7 @@ def test_create__freemium_to_premium__ok(mocker, identify_mock):
     account = create_test_account(
         plan=BillingPlanType.FREEMIUM,
     )
-    user = create_test_user(account=account)
+    user = create_test_owner(account=account)
     account_service_init_mock = mocker.patch.object(
         AccountService,
         attribute='__init__',
@@ -482,6 +490,10 @@ def test_create__freemium_to_premium__ok(mocker, identify_mock):
     send_plan_changed_mock = mocker.patch(
         'src.payment.services.account.'
         'send_account_plan_changed_notification.delay',
+    )
+    transaction_on_commit_mock = mocker.patch(
+        'src.payment.services.account.transaction.on_commit',
+        side_effect=lambda f, *args, **kwargs: f(),
     )
     plan_expiration = timezone.now() + timedelta(days=30)
     details = SubscriptionDetails(
@@ -508,6 +520,7 @@ def test_create__freemium_to_premium__ok(mocker, identify_mock):
     )
 
     # assert
+    transaction_on_commit_mock.assert_called_once_with(mocker.ANY)
     account_service_init_mock.assert_called_once_with(
         instance=account,
         user=user,
@@ -545,7 +558,7 @@ def test_create__tmp_subscription_to_premium_trial__ok(mocker, identify_mock):
         plan_expiration=timezone.now() + timedelta(hours=1),
         tmp_subscription=True,
     )
-    user = create_test_user(account=account)
+    user = create_test_owner(account=account)
     account_service_init_mock = mocker.patch.object(
         AccountService,
         attribute='__init__',
@@ -566,6 +579,10 @@ def test_create__tmp_subscription_to_premium_trial__ok(mocker, identify_mock):
     send_plan_changed_mock = mocker.patch(
         'src.payment.services.account.'
         'send_account_plan_changed_notification.delay',
+    )
+    transaction_on_commit_mock = mocker.patch(
+        'src.payment.services.account.transaction.on_commit',
+        side_effect=lambda f, *args, **kwargs: f(),
     )
     trial_start = timezone.now()
     plan_expiration = timezone.now() + timedelta(days=7)
@@ -593,6 +610,7 @@ def test_create__tmp_subscription_to_premium_trial__ok(mocker, identify_mock):
     )
 
     # assert
+    transaction_on_commit_mock.assert_called_once_with(mocker.ANY)
     account_service_init_mock.assert_called_once_with(
         instance=account,
         user=user,
@@ -625,7 +643,7 @@ def test_public_create__plan_changed__ok(mocker, identify_mock):
 
     # arrange
     account = create_test_account()
-    user = create_test_user(account=account)
+    user = create_test_owner(account=account)
 
     plan_changed = True
     plan_changed_mock = mocker.patch(
@@ -663,7 +681,7 @@ def test_public_create__plan_not_changed__skip(mocker, identify_mock):
 
     # arrange
     account = create_test_account()
-    user = create_test_user(account=account)
+    user = create_test_owner(account=account)
 
     plan_changed = False
     plan_changed_mock = mocker.patch(
@@ -707,7 +725,7 @@ def test_update__trial_to_premium__ok(mocker, identify_mock):
         trial_end=plan_expiration,
         trial_ended=False,
     )
-    user = create_test_user(account=account)
+    user = create_test_owner(account=account)
     account_service_init_mock = mocker.patch.object(
         AccountService,
         attribute='__init__',
@@ -724,6 +742,10 @@ def test_update__trial_to_premium__ok(mocker, identify_mock):
     send_plan_changed_mock = mocker.patch(
         'src.payment.services.account.'
         'send_account_plan_changed_notification.delay',
+    )
+    transaction_on_commit_mock = mocker.patch(
+        'src.payment.services.account.transaction.on_commit',
+        side_effect=lambda f, *args, **kwargs: f(),
     )
     is_superuser = True
     auth_type = AuthTokenType.WEBHOOK
@@ -747,6 +769,7 @@ def test_update__trial_to_premium__ok(mocker, identify_mock):
     service._update(details)
 
     # assert
+    transaction_on_commit_mock.assert_called_once_with(mocker.ANY)
     account_service_init_mock.assert_called_once_with(
         instance=account,
         user=user,
@@ -781,7 +804,7 @@ def test_update__premium_to_premium__ok(mocker, identify_mock):
         plan_expiration=timezone.now() + timedelta(days=1),
         trial_end=timezone.now() - timedelta(days=1),
     )
-    user = create_test_user(account=account)
+    user = create_test_owner(account=account)
     account_service_init_mock = mocker.patch.object(
         AccountService,
         attribute='__init__',
@@ -798,6 +821,10 @@ def test_update__premium_to_premium__ok(mocker, identify_mock):
     send_plan_changed_mock = mocker.patch(
         'src.payment.services.account.'
         'send_account_plan_changed_notification.delay',
+    )
+    transaction_on_commit_mock = mocker.patch(
+        'src.payment.services.account.transaction.on_commit',
+        side_effect=lambda f, *args, **kwargs: f(),
     )
     is_superuser = True
     auth_type = AuthTokenType.WEBHOOK
@@ -822,6 +849,7 @@ def test_update__premium_to_premium__ok(mocker, identify_mock):
     service._update(details)
 
     # assert
+    transaction_on_commit_mock.assert_called_once_with(mocker.ANY)
     account_service_init_mock.assert_called_once_with(
         instance=account,
         user=user,
@@ -852,7 +880,7 @@ def test_public_update__plan_changed__ok(mocker):
 
     # arrange
     account = create_test_account()
-    user = create_test_user(account=account)
+    user = create_test_owner(account=account)
 
     plan_changed = True
     plan_changed_mock = mocker.patch(
@@ -888,7 +916,7 @@ def test_public_update__plan_not_changed__skip(mocker):
 
     # arrange
     account = create_test_account()
-    user = create_test_user(account=account)
+    user = create_test_owner(account=account)
 
     plan_changed = False
     plan_changed_mock = mocker.patch(
@@ -924,7 +952,7 @@ def test_expired__ok(mocker):
 
     # arrange
     account = create_test_account(plan=BillingPlanType.PREMIUM)
-    user = create_test_user(account=account)
+    user = create_test_owner(account=account)
     period_end_date = timezone.now() + timedelta(days=30)
 
     account_service_init_mock = mocker.patch.object(
@@ -940,6 +968,10 @@ def test_expired__ok(mocker):
         'src.payment.services.account.'
         'send_account_plan_changed_notification.delay',
     )
+    transaction_on_commit_mock = mocker.patch(
+        'src.payment.services.account.transaction.on_commit',
+        side_effect=lambda f, *args, **kwargs: f(),
+    )
     is_superuser = True
     auth_type = AuthTokenType.WEBHOOK
     service = AccountSubscriptionService(
@@ -953,6 +985,7 @@ def test_expired__ok(mocker):
     service.expired(period_end_date)
 
     # assert
+    transaction_on_commit_mock.assert_called_once_with(mocker.ANY)
     account_service_init_mock.assert_called_once_with(
         instance=account,
         user=user,
@@ -977,7 +1010,7 @@ def test_cancel__ok(mocker):
 
     # arrange
     account = create_test_account(plan=BillingPlanType.PREMIUM)
-    user = create_test_user(account=account)
+    user = create_test_owner(account=account)
     analysis_subscription_canceled_created_mock = mocker.patch(
         'src.analysis.services.AnalyticService.'
         'subscription_canceled',
@@ -1002,3 +1035,50 @@ def test_cancel__ok(mocker):
     # arrange
     expired_mock.assert_called_once_with(plan_expiration)
     analysis_subscription_canceled_created_mock.assert_called_once_with(user)
+
+
+def test_send_plan_changed_notifications__with_tenants__ok(mocker):
+
+    # arrange
+    account = create_test_account(plan=BillingPlanType.PREMIUM)
+    user = mocker.Mock()
+    tenant = create_test_account(
+        master_account=account,
+        lease_level=LeaseLevel.TENANT,
+        tenant_name='Tenant',
+    )
+    send_plan_changed_mock = mocker.patch(
+        'src.payment.services.account.'
+        'send_account_plan_changed_notification.delay',
+    )
+    is_superuser = True
+    auth_type = AuthTokenType.WEBHOOK
+    service = AccountSubscriptionService(
+        instance=account,
+        user=user,
+        is_superuser=is_superuser,
+        auth_type=auth_type,
+    )
+
+    # act
+    service._send_plan_changed_notifications()
+
+    # assert
+    assert send_plan_changed_mock.call_count == 2
+    master_plan_data = AccountPlanSerializer(instance=account).data
+    tenant_plan_data = AccountPlanSerializer(instance=tenant).data
+    send_plan_changed_mock.assert_has_calls(
+        [
+            mocker.call(
+                logging=account.log_api_requests,
+                account_id=account.id,
+                plan_data=master_plan_data,
+            ),
+            mocker.call(
+                logging=tenant.log_api_requests,
+                account_id=tenant.id,
+                plan_data=tenant_plan_data,
+            ),
+        ],
+        any_order=True,
+    )

--- a/backend/src/payment/tests/test_services/test_account_subscription_service.py
+++ b/backend/src/payment/tests/test_services/test_account_subscription_service.py
@@ -8,6 +8,9 @@ from src.accounts.enums import (
     BillingPlanType,
     LeaseLevel,
 )
+from src.accounts.serializers.accounts import (
+    AccountPlanSerializer,
+)
 from src.accounts.services.account import AccountService
 from src.authentication.enums import AuthTokenType
 from src.payment.entities import (
@@ -313,6 +316,10 @@ def test_create__freemium_to_trial__ok(mocker, identify_mock):
         'src.analysis.services.AnalyticService.'
         'subscription_created',
     )
+    send_plan_changed_mock = mocker.patch(
+        'src.payment.services.account.'
+        'send_account_plan_changed_notification.delay',
+    )
     trial_start = timezone.now() - timedelta(minutes=1)
     plan_expiration = timezone.now() + timedelta(days=30)
     details = SubscriptionDetails(
@@ -358,6 +365,13 @@ def test_create__freemium_to_trial__ok(mocker, identify_mock):
     analysis_subscription_created_mock.assert_called_once_with(user)
     analysis_trial_subscription_created_mock.assert_called_once_with(user)
     identify_mock.assert_called_once_with(user)
+    account.refresh_from_db()
+    plan_data = AccountPlanSerializer(instance=account).data
+    send_plan_changed_mock.assert_called_once_with(
+        logging=account.log_api_requests,
+        account_id=account.id,
+        plan_data=plan_data,
+    )
 
 
 def test_create__trial_ended__not_trial(mocker, identify_mock):
@@ -384,6 +398,10 @@ def test_create__trial_ended__not_trial(mocker, identify_mock):
     analysis_subscription_created_mock = mocker.patch(
         'src.analysis.services.AnalyticService.'
         'subscription_created',
+    )
+    send_plan_changed_mock = mocker.patch(
+        'src.payment.services.account.'
+        'send_account_plan_changed_notification.delay',
     )
     trial_start = timezone.now() - timedelta(minutes=1)
     plan_expiration = timezone.now() + timedelta(days=30)
@@ -428,6 +446,13 @@ def test_create__trial_ended__not_trial(mocker, identify_mock):
     analysis_subscription_created_mock.assert_called_once_with(user)
     analysis_trial_subscription_created_mock.assert_not_called()
     identify_mock.assert_called_once_with(user)
+    account.refresh_from_db()
+    plan_data = AccountPlanSerializer(instance=account).data
+    send_plan_changed_mock.assert_called_once_with(
+        logging=account.log_api_requests,
+        account_id=account.id,
+        plan_data=plan_data,
+    )
 
 
 def test_create__freemium_to_premium__ok(mocker, identify_mock):
@@ -453,6 +478,10 @@ def test_create__freemium_to_premium__ok(mocker, identify_mock):
     analysis_trial_subscription_created_mock = mocker.patch(
         'src.analysis.services.AnalyticService.'
         'trial_subscription_created',
+    )
+    send_plan_changed_mock = mocker.patch(
+        'src.payment.services.account.'
+        'send_account_plan_changed_notification.delay',
     )
     plan_expiration = timezone.now() + timedelta(days=30)
     details = SubscriptionDetails(
@@ -498,6 +527,13 @@ def test_create__freemium_to_premium__ok(mocker, identify_mock):
     analysis_subscription_created_mock.assert_called_once_with(user)
     analysis_trial_subscription_created_mock.assert_not_called()
     identify_mock.assert_called_once_with(user)
+    account.refresh_from_db()
+    plan_data = AccountPlanSerializer(instance=account).data
+    send_plan_changed_mock.assert_called_once_with(
+        logging=account.log_api_requests,
+        account_id=account.id,
+        plan_data=plan_data,
+    )
 
 
 def test_create__tmp_subscription_to_premium_trial__ok(mocker, identify_mock):
@@ -526,6 +562,10 @@ def test_create__tmp_subscription_to_premium_trial__ok(mocker, identify_mock):
     analysis_trial_subscription_created_mock = mocker.patch(
         'src.analysis.services.AnalyticService.'
         'trial_subscription_created',
+    )
+    send_plan_changed_mock = mocker.patch(
+        'src.payment.services.account.'
+        'send_account_plan_changed_notification.delay',
     )
     trial_start = timezone.now()
     plan_expiration = timezone.now() + timedelta(days=7)
@@ -572,6 +612,13 @@ def test_create__tmp_subscription_to_premium_trial__ok(mocker, identify_mock):
     analysis_subscription_created_mock.assert_called_once_with(user)
     analysis_trial_subscription_created_mock.assert_called_once_with(user)
     identify_mock.assert_called_once_with(user)
+    account.refresh_from_db()
+    plan_data = AccountPlanSerializer(instance=account).data
+    send_plan_changed_mock.assert_called_once_with(
+        logging=account.log_api_requests,
+        account_id=account.id,
+        plan_data=plan_data,
+    )
 
 
 def test_public_create__plan_changed__ok(mocker, identify_mock):
@@ -674,6 +721,10 @@ def test_update__trial_to_premium__ok(mocker, identify_mock):
         'src.analysis.services.AnalyticService.'
         'subscription_converted',
     )
+    send_plan_changed_mock = mocker.patch(
+        'src.payment.services.account.'
+        'send_account_plan_changed_notification.delay',
+    )
     is_superuser = True
     auth_type = AuthTokenType.WEBHOOK
     service = AccountSubscriptionService(
@@ -713,6 +764,13 @@ def test_update__trial_to_premium__ok(mocker, identify_mock):
     )
     analysis_subscription_converted_mock.assert_called_once_with(user)
     identify_mock.assert_called_once_with(user)
+    account.refresh_from_db()
+    plan_data = AccountPlanSerializer(instance=account).data
+    send_plan_changed_mock.assert_called_once_with(
+        logging=account.log_api_requests,
+        account_id=account.id,
+        plan_data=plan_data,
+    )
 
 
 def test_update__premium_to_premium__ok(mocker, identify_mock):
@@ -736,6 +794,10 @@ def test_update__premium_to_premium__ok(mocker, identify_mock):
     analysis_subscription_updated_mock = mocker.patch(
         'src.analysis.services.AnalyticService.'
         'subscription_updated',
+    )
+    send_plan_changed_mock = mocker.patch(
+        'src.payment.services.account.'
+        'send_account_plan_changed_notification.delay',
     )
     is_superuser = True
     auth_type = AuthTokenType.WEBHOOK
@@ -777,6 +839,13 @@ def test_update__premium_to_premium__ok(mocker, identify_mock):
     )
     analysis_subscription_updated_mock.assert_called_once_with(user)
     identify_mock.assert_called_once_with(user)
+    account.refresh_from_db()
+    plan_data = AccountPlanSerializer(instance=account).data
+    send_plan_changed_mock.assert_called_once_with(
+        logging=account.log_api_requests,
+        account_id=account.id,
+        plan_data=plan_data,
+    )
 
 
 def test_public_update__plan_changed__ok(mocker):
@@ -867,6 +936,10 @@ def test_expired__ok(mocker):
         'src.accounts.services.account.'
         'AccountService.partial_update',
     )
+    send_plan_changed_mock = mocker.patch(
+        'src.payment.services.account.'
+        'send_account_plan_changed_notification.delay',
+    )
     is_superuser = True
     auth_type = AuthTokenType.WEBHOOK
     service = AccountSubscriptionService(
@@ -879,7 +952,7 @@ def test_expired__ok(mocker):
     # act
     service.expired(period_end_date)
 
-    # arrange
+    # assert
     account_service_init_mock.assert_called_once_with(
         instance=account,
         user=user,
@@ -890,6 +963,13 @@ def test_expired__ok(mocker):
         plan_expiration=period_end_date,
         trial_ended=True,
         force_save=True,
+    )
+    account.refresh_from_db()
+    plan_data = AccountPlanSerializer(instance=account).data
+    send_plan_changed_mock.assert_called_once_with(
+        logging=account.log_api_requests,
+        account_id=account.id,
+        plan_data=plan_data,
     )
 
 


### PR DESCRIPTION
## 1. Description (problem)
When an account plan/subscription changed (create, update, expire), other users in the same account did not receive a real-time signal with the updated plan. Clients kept stale plan state until a full reload or a manual plan API refetch.
**Where it showed up:** any UI depending on account billing plan (user limits, trial/premium status, expiration) after a subscription change via webhook/billing service, without a WebSocket refresh.
## 2. Context
Needed so the frontend can sync plan state for all active users after billing events (Stripe webhook / `AccountSubscriptionService`), using the same contract as `GET` account plan (`AccountPlanSerializer`). Ticket #21562. This PR is backend-only (emit WS); frontend handling is out of scope.
## 3. Solution
Added WebSocket method `account_plan_changed`. After a successful subscription change in `AccountSubscriptionService` (`_create`, `_update`, `expired`; `cancel` goes through `expired`), a Celery task fans out the serialized plan payload to all **active** account users via `EventsConsumer`.
## 4. Implementation Details
**Touched modules:**
- `backend/src/notifications/enums.py` — `NotificationMethod.account_plan_changed`
- `backend/src/notifications/services/websockets.py` — `WebSocketService.send_account_plan_changed` → group `events_{user_id}`
- `backend/src/notifications/tasks.py` — `send_account_plan_changed_notification` / `_send_account_plan_changed_notification`
- `backend/src/payment/services/account.py` — `.delay(...)` after `_create` / `_update` / `expired`
- Tests: websockets service, new task suite, extended `test_account_subscription_service.py`
**WS payload contract** (same as `AccountPlanSerializer`):
- `is_subscribed`, `active_users`, `tenants_active_users`, `max_users`, `billing_sync`
- `billing_plan`, `billing_period`, `plan_expiration`, `plan_expiration_tsp`
- `trial_is_active`, `trial_ended`
**Notes for reviewers:**
- Notification only when the plan actually changes (`create`/`update` call `_create`/`_update` only if `_plan_changed`).
- Inactive users are skipped.
- `cancel()` → `expired()` → single send (no extra call in `cancel`).
- Minor kwargs reorder in `_send_dataset_deleted_notification` (no behavior change).
## 5. What to Test
### 5.1 Preconditions
- [ ] Environment: **dev-branch** / local with backend + WebSocket + Celery worker
- [ ] Account with ≥2 **active** users (owner + admin/user)
- [ ] Both users logged in (normal + incognito) with WS connected
- [ ] Way to trigger subscription change: Stripe webhook / billing flow hitting `AccountSubscriptionService.create` / `update` / `expired` / `cancel`
- [ ] Tool to inspect WS frames (DevTools → Network → WS)
### 5.2 Positive Scenarios
1. **Create subscription (freemium → premium/trial)**  
   - Action: create a subscription for the account.  
   - Expect: both active users receive WS `account_plan_changed` with updated `billing_plan` / `max_users` / trial fields.
2. **Update subscription (trial → premium or period/quantity change)**  
   - Action: update so `_plan_changed=True`.  
   - Expect: `account_plan_changed` again with updated payload for all active users.
3. **Expire / cancel**  
   - Action: expire or cancel (via `expired`).  
   - Expect: event with updated `plan_expiration` / `trial_ended` (and related plan serializer fields).
4. **Payload shape**  
   - Compare WS `data` to `GET` account plan for the same account — field set should match.
5. **Multi-user fan-out**  
   - 2–3 active users: each gets a message on `events_{user_id}` with the same `plan_data`.
### 5.3 Negative Scenarios and Edge Cases
1. **No active users**  
   - Only inactive users.  
   - Expect: task runs, no WS send.
2. **Plan not changed**  
   - Repeat create/update with identical details (`_plan_changed=False`).  
   - Expect: `_create`/`_update` not called → no `account_plan_changed`.
3. **Inactive user in account**  
   - Mix of active + inactive.  
   - Expect: only active users receive the event.
4. **Cancel path**  
   - Cancel must not emit a second event beyond `expired` (one send per cancel).
### 5.4 Verification Points
- [ ] WS frame method/event = `account_plan_changed`
- [ ] `data` includes `AccountPlanSerializer` fields
- [ ] Values match DB/account after the update
- [ ] Celery task `send_account_plan_changed_notification` is enqueued after successful `partial_update`
- [ ] Unit tests green:
  - `test_send_account_plan_changed_notification`
  - websockets `test_send_account_plan_changed__ok`
  - related `test_account_subscription_service` cases
### 5.5 API / WebSocket Checks
REST contract unchanged; new WS event added.
**Server → client:**
1. Open DevTools → Network → WS for a logged-in user.
2. Change the account plan.
3. Find the frame with `account_plan_changed`.
4. Verify `data`: `billing_plan`, `billing_period`, `plan_expiration`, `plan_expiration_tsp`, `trial_is_active`, `trial_ended`, `is_subscribed`, `active_users`, `tenants_active_users`, `max_users`, `billing_sync`.
**Cross-check with REST:**
- `GET` account plan (same `AccountPlanSerializer`) — field set/values should match WS `data` right after the event.
### 5.6 What Was NOT Tested
- [ ] Production not tested (dev/local + unit only)
- [ ] Not tested on mobile
- [ ] Locales not tested (out of scope; no UI strings in this PR)
- [ ] Load / large-account fan-out not tested
- [ ] No frontend handler for `account_plan_changed` in this PR — E2E UI reaction out of scope
## 6. Testing Affected Areas (dependencies)
| Area | What to check | Minimal steps |
|------|---------------|---------------|
| Billing / Stripe webhook → `AccountSubscriptionService` | Create/update/expire/cancel still work; analytics identify intact | Run create/update/expire/cancel and confirm billing state |
| Existing WS events (`dataset_*`, user lifecycle, etc.) | No regression | Trigger another WS event — delivery unchanged |
| `GET` account plan | Serializer contract unchanged | Compare response shape before/after this branch |
## 7. Refactoring
No meaningful refactoring. Only kwargs order aligned in `_send_dataset_deleted_notification` — behavior unchanged.
## 8. Commits with Fixes
- `b89aeadb` — `21562 feat(notifications): add account plan change notification functionality`
## 9. Release notes
Backend now emits a WebSocket `account_plan_changed` event to all active account users whenever the account subscription is created, updated, or expired, with the same payload as the account plan API.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches billing webhook paths and fans out to all active users (and tenants); wrong timing or payload could broadcast stale or incorrect plan state, though delivery is deferred until DB commit.
> 
> **Overview**
> Adds a new **`account_plan_changed`** WebSocket event so clients can refresh billing/plan state without reloading. Payload matches **`AccountPlanSerializer`** (same shape as the account plan API).
> 
> After **`AccountSubscriptionService`** persists subscription changes in **`_create`**, **`_update`**, and **`expired`** (including **`cancel`** via **`expired`**), a Celery task runs on **`transaction.on_commit`**: it notifies every **active** user on that account’s **`events_{user_id}`** channel. Master accounts also enqueue a separate task per **tenant** with each tenant’s own serialized plan.
> 
> Implementation follows existing dataset/group fan-out: new **`NotificationMethod`**, **`WebSocketService.send_account_plan_changed`**, and **`send_account_plan_changed_notification`**. Public **`create`**/**`update`** still skip work when **`_plan_changed`** is false, so no WS when the webhook repeats unchanged details.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8ec2e01e35a5d04d98192b948f9a1b459b3b424. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Send WebSocket notifications to users when account plan changes
> - Adds a new `account_plan_changed` notification type that is dispatched via WebSocket to all active users of an account (and its tenants) when a subscription is created or updated.
> - `AccountSubscriptionService` enqueues the notification task via `transaction.on_commit` in `_create`, `create`, and `_update` to ensure delivery only after a successful DB commit.
> - The Celery task `send_account_plan_changed_notification` queries active users for the account and sends each a WebSocket message containing `AccountPlanSerializer` data.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e8ec2e0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->