### PR TITLE
44655 backend [ My tasks ] Handle null values in /v3/tasks API

### DIFF
--- a/backend/src/generics/validators.py
+++ b/backend/src/generics/validators.py
@@ -3,10 +3,26 @@ from urllib.parse import urlsplit, urlunsplit
 
 from django.core.exceptions import ValidationError
 from django.core.validators import (
+    BaseValidator,
     URLValidator,
     _lazy_re_compile,
     validate_ipv6_address,
 )
+from django.utils.translation import gettext_lazy as _
+
+
+class RejectNullStringValidator(BaseValidator):
+
+    """Reject the literal string 'null' (common in query parameters)."""
+
+    message = _('This field may not be null.')
+    code = 'null'
+
+    def __init__(self, limit_value: str = 'null', message=None):
+        super().__init__(limit_value=limit_value, message=message)
+
+    def compare(self, a: str, b: str) -> bool:
+        return a == b
 
 
 class NoSchemaURLValidator(URLValidator):

--- a/backend/src/processes/serializers/workflows/task.py
+++ b/backend/src/processes/serializers/workflows/task.py
@@ -7,6 +7,7 @@ from rest_framework.exceptions import ValidationError
 
 from src.generics.fields import TimeStampField
 from src.generics.serializers import CustomValidationErrorMixin
+from src.generics.validators import RejectNullStringValidator
 from src.processes.enums import OwnerRole, OwnerType, TaskOrdering
 from src.processes.messages.workflow import (
     MSG_PW_0057,
@@ -269,14 +270,17 @@ class TaskListFilterSerializer(
     assigned_to = serializers.IntegerField(required=False)
     search = serializers.CharField(required=False)
     template_id = serializers.IntegerField(required=False)
-    template_task_api_name = serializers.CharField(required=False)
+    template_task_api_name = serializers.CharField(
+        required=False,
+        validators=[RejectNullStringValidator()],
+    )
     limit = serializers.IntegerField(required=False)
     offset = serializers.IntegerField(required=False)
 
     def validate_search(self, value: str) -> Optional[str]:
         removed_chars_regex = r'\s\s+'
         clear_text = re.sub(removed_chars_regex, '', value).strip()
-        return clear_text if clear_text else None
+        return clear_text or None
 
     def validate_assigned_to(self, value):
         if not self.context['user'].is_admin:

--- a/backend/src/processes/tests/test_views/test_tasks/test_list.py
+++ b/backend/src/processes/tests/test_views/test_tasks/test_list.py
@@ -1603,6 +1603,24 @@ def test_list__filter_assigned_to_not_number__validation_error(api_client):
     assert response.data['details']['name'] == 'assigned_to'
 
 
+def test_list__filter_assigned_to_null_string__validation_error(api_client):
+
+    # arrange
+    user = create_test_admin()
+    api_client.token_authenticate(user=user)
+
+    # act
+    response = api_client.get('/v3/tasks?assigned_to=null')
+
+    # assert
+    message = 'A valid integer is required.'
+    assert response.status_code == 400
+    assert response.data['code'] == ErrorCode.VALIDATION_ERROR
+    assert response.data['message'] == message
+    assert response.data['details']['reason'] == message
+    assert response.data['details']['name'] == 'assigned_to'
+
+
 def test_list__filter_assigned_to_not_admin__validation_error(api_client):
 
     # arrange
@@ -2067,6 +2085,66 @@ def test_list__filter_template_id_not_number__validation_error(api_client):
 
     # act
     response = api_client.get("/v3/tasks?template_id=' OR 1='1")
+
+    # assert
+    message = 'A valid integer is required.'
+    assert response.status_code == 400
+    assert response.data['code'] == ErrorCode.VALIDATION_ERROR
+    assert response.data['message'] == message
+    assert response.data['details']['reason'] == message
+    assert response.data['details']['name'] == 'template_id'
+
+
+def test_list__filter_template_id_null_string__validation_error(api_client):
+
+    # arrange
+    user = create_test_user()
+    api_client.token_authenticate(user=user)
+
+    # act
+    response = api_client.get('/v3/tasks?template_id=null')
+
+    # assert
+    message = 'A valid integer is required.'
+    assert response.status_code == 400
+    assert response.data['code'] == ErrorCode.VALIDATION_ERROR
+    assert response.data['message'] == message
+    assert response.data['details']['reason'] == message
+    assert response.data['details']['name'] == 'template_id'
+
+
+def test_list__filter_template_task_api_name_null_string__validation_error(
+    api_client,
+):
+
+    # arrange
+    user = create_test_user()
+    api_client.token_authenticate(user=user)
+
+    # act
+    response = api_client.get('/v3/tasks?template_task_api_name=null')
+
+    # assert
+    message = 'This field may not be null.'
+    assert response.status_code == 400
+    assert response.data['code'] == ErrorCode.VALIDATION_ERROR
+    assert response.data['message'] == message
+    assert response.data['details']['reason'] == message
+    assert response.data['details']['name'] == 'template_task_api_name'
+
+
+def test_list__filter_both_null_strings__validation_error(
+    api_client,
+):
+
+    # arrange
+    user = create_test_user()
+    api_client.token_authenticate(user=user)
+
+    # act
+    response = api_client.get(
+        '/v3/tasks?template_id=null&template_task_api_name=null',
+    )
 
     # assert
     message = 'A valid integer is required.'

--- a/backend/src/processes/views/task.py
+++ b/backend/src/processes/views/task.py
@@ -461,6 +461,7 @@ class TaskViewSet(
         task = self.get_object()
         qst = (
             WorkflowEvent.objects
+            .select_related('workflow')
             .prefetch_related('storage_attachments')
             .on_task(task.id)
             .type_in(WorkflowEventType.TASK_EVENTS)

--- a/backend/src/processes/views/task.py
+++ b/backend/src/processes/views/task.py
@@ -461,7 +461,6 @@ class TaskViewSet(
         task = self.get_object()
         qst = (
             WorkflowEvent.objects
-            .select_related('workflow')
             .prefetch_related('storage_attachments')
             .on_task(task.id)
             .type_in(WorkflowEventType.TASK_EVENTS)


### PR DESCRIPTION
# Problem

When a user opens their task list and no filters are actively selected, some clients send empty filter values as the literal string `null`. The server treated those values as real filter criteria, which could return an empty task list even when the user had assigned tasks.

# Fix / Solution

`GET /v3/tasks` now rejects the literal query-string value `null` for filter parameters with a 400 validation error. Validation lives in `TaskListFilterSerializer` (including shared `RejectNullStringValidator` for string fields).

Related staging work: #256 (merged into `dev`). This PR brings the same change cleanly onto `master`.

# Release notes

Fixed an issue where the task list could return no results when clients sent the literal string `null` for filter parameters. The API now returns a clear 400 validation error instead.

# Changes
## API
- `GET /v3/tasks` — query parameters `template_id`, `template_task_api_name`, and `assigned_to` with the literal value `null` now return **400**:
  - `template_id` / `assigned_to`: "A valid integer is required."
  - `template_task_api_name`: "This field may not be null."

## Web-client
No changes in this PR. Related frontend fix covered separately (clients should omit unset filters instead of sending `null`).

# Test cases
## API

| Authorization | Test case | Expected result |
|---|---|---|
| Token auth (account owner) | `GET /v3/tasks?template_id=null` | 400, "A valid integer is required.", `details.name` = `template_id` |
| Token auth (account owner) | `GET /v3/tasks?template_task_api_name=null` | 400, "This field may not be null.", `details.name` = `template_task_api_name` |
| Token auth (admin) | `GET /v3/tasks?assigned_to=null` | 400, "A valid integer is required.", `details.name` = `assigned_to` |
| Token auth (account owner) | `GET /v3/tasks?template_id=null&template_task_api_name=null` | 400, "A valid integer is required.", `details.name` = `template_id` |

## Web-client

No changes.


Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject literal string 'null' in `/v3/tasks` filter parameters
> - Adds `RejectNullStringValidator` in [validators.py](https://github.com/pneumaticapp/pneumaticworkflow/pull/276/files#diff-a80090cd8dcf2e13c3d25d2e13740d4fcf33e2292c3b02c8ad4eee26768dfec3), a `BaseValidator` subclass that fails validation when a field value is exactly the string `'null'`, returning code `null` and message `'This field may not be null.'`
> - Applies the validator to the `template_task_api_name` field in `TaskListFilterSerializer` so `?template_task_api_name=null` returns a 400 error.
> - Integer fields (`assigned_to`, `template_id`) already reject `'null'` via their existing integer validation; new tests cover all three fields plus combined cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 04c677c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->