### PR TITLE
🔧 48179 backend [ fieldsets ] Review fixes

### DIFF
--- a/backend/src/processes/services/fieldsets/fieldset.py
+++ b/backend/src/processes/services/fieldsets/fieldset.py
@@ -289,9 +289,9 @@ class FieldSetTemplateService(BaseModelService):
         fieldset_data = self._replace_api_names(shared_fieldset_data)
         if api_name:
             fieldset_data['api_name'] = api_name
-        if title:
+        if title is not None:
             fieldset_data['title'] = title
-        if description:
+        if description is not None:
             fieldset_data['description'] = description
         fieldset_data.pop('order', None)
         return fieldset_data

--- a/backend/src/processes/services/tasks/task_version.py
+++ b/backend/src/processes/services/tasks/task_version.py
@@ -258,6 +258,7 @@ class TaskUpdateVersionService(
                 defaults={
                     'account_id': self.instance.account_id,
                     'name': fieldset_data['name'],
+                    'title': fieldset_data['title'],
                     'description': fieldset_data['description'],
                     'order': fieldset_data['order'],
                     'label_position': fieldset_data['label_position'],

--- a/backend/src/processes/services/templates/template.py
+++ b/backend/src/processes/services/templates/template.py
@@ -60,6 +60,20 @@ class TemplateService(BaseModelService):
             refresh_attachments(self.instance, self.user)
         return result
 
+    def _register_field_placeholders(
+        self,
+        fields_data: list,
+        fields_values: dict,
+    ) -> None:
+        for field_data in fields_data:
+            api_name = field_data.get('api_name')
+            if api_name:
+                fields_values[api_name] = '{{%s}}' % api_name
+            else:
+                field_data['api_name'] = create_api_name(
+                    prefix=FieldTemplate.api_name_prefix,
+                )
+
     def fill_template_data(self, initial_data: dict) -> dict:
 
         """ initial_data - known template data,
@@ -90,14 +104,15 @@ class TemplateService(BaseModelService):
         }
 
         fields_values = {}
-        for field_data in data['kickoff']['fields']:
-            api_name = field_data.get('api_name')
-            if api_name:
-                fields_values[api_name] = '{{%s}}' % api_name
-            else:
-                field_data['api_name'] = create_api_name(
-                    prefix=FieldTemplate.api_name_prefix,
-                )
+        self._register_field_placeholders(
+            fields_data=data['kickoff']['fields'],
+            fields_values=fields_values,
+        )
+        for fieldset_data in data['kickoff']['fieldsets']:
+            self._register_field_placeholders(
+                fields_data=fieldset_data.get('fields', []),
+                fields_values=fields_values,
+            )
         for task_data in data['tasks']:
             task_data['api_name'] = task_data.get(
                 'api_name',
@@ -112,15 +127,15 @@ class TemplateService(BaseModelService):
                         'label': self.user.name,
                     },
                 ]
-            task_fields = task_data.get('fields', [])
-            for field_data in task_fields:
-                api_name = field_data.get('api_name')
-                if api_name:
-                    fields_values[api_name] = '{{%s}}' % api_name
-                else:
-                    field_data['api_name'] = create_api_name(
-                        prefix=FieldTemplate.api_name_prefix,
-                    )
+            self._register_field_placeholders(
+                fields_data=task_data.get('fields', []),
+                fields_values=fields_values,
+            )
+            for fieldset_data in task_data.get('fieldsets', []):
+                self._register_field_placeholders(
+                    fields_data=fieldset_data.get('fields', []),
+                    fields_values=fields_values,
+                )
             if task_data.get('description'):
                 task_data['description'] = insert_fields_values_to_text(
                     text=task_data['description'],

--- a/backend/src/processes/services/workflows/kickoff_version.py
+++ b/backend/src/processes/services/workflows/kickoff_version.py
@@ -144,6 +144,7 @@ class KickoffUpdateVersionService(BaseUpdateVersionService):
                 defaults={
                     'account_id': self.instance.account_id,
                     'name': fs_data['name'],
+                    'title': fs_data['title'],
                     'description': fs_data['description'],
                     'order': fs_data['order'],
                     'label_position': fs_data['label_position'],

--- a/backend/src/processes/tests/test_services/test_fieldsets/test_fieldset_template_service.py
+++ b/backend/src/processes/tests/test_services/test_fieldsets/test_fieldset_template_service.py
@@ -1734,6 +1734,38 @@ def test__get_new_fieldset_data__title_omitted__ok(mocker):
     replace_api_names_mock.assert_called_once_with(shared_fieldset_data)
 
 
+def test__get_new_fieldset_data__title_empty_string__ok(mocker):
+
+    """
+    empty title clears shared value
+    """
+
+    # arrange
+    account = create_test_account()
+    user = create_test_owner(account=account)
+    service = FieldSetTemplateService(
+        user=user,
+        is_superuser=False,
+        auth_type=AuthTokenType.USER,
+    )
+    shared_fieldset_data = {'api_name': 'old-fs'}
+    replace_api_names_mock = mocker.patch(
+        'src.processes.services.fieldsets.fieldset.'
+        'FieldSetTemplateService._replace_api_names',
+        return_value={'api_name': 'api', 'title': 'Original'},
+    )
+
+    # act
+    result = service.get_new_fieldset_data(
+        shared_fieldset_data=shared_fieldset_data,
+        title='',
+    )
+
+    # assert
+    assert result['title'] == ''
+    replace_api_names_mock.assert_called_once_with(shared_fieldset_data)
+
+
 def test__get_new_fieldset_data__description_provided__ok(mocker):
 
     """
@@ -1796,6 +1828,38 @@ def test__get_new_fieldset_data__description_omitted__ok(mocker):
 
     # assert
     assert result['description'] == original_description
+    replace_api_names_mock.assert_called_once_with(shared_fieldset_data)
+
+
+def test__get_new_fieldset_data__description_empty_string__ok(mocker):
+
+    """
+    empty description clears shared value
+    """
+
+    # arrange
+    account = create_test_account()
+    user = create_test_owner(account=account)
+    service = FieldSetTemplateService(
+        user=user,
+        is_superuser=False,
+        auth_type=AuthTokenType.USER,
+    )
+    shared_fieldset_data = {'api_name': 'old-fs'}
+    replace_api_names_mock = mocker.patch(
+        'src.processes.services.fieldsets.fieldset.'
+        'FieldSetTemplateService._replace_api_names',
+        return_value={'api_name': 'api', 'description': 'Old desc'},
+    )
+
+    # act
+    result = service.get_new_fieldset_data(
+        shared_fieldset_data=shared_fieldset_data,
+        description='',
+    )
+
+    # assert
+    assert result['description'] == ''
     replace_api_names_mock.assert_called_once_with(shared_fieldset_data)
 
 

--- a/backend/src/processes/tests/test_services/test_tasks/test_task_version_service.py
+++ b/backend/src/processes/tests/test_services/test_tasks/test_task_version_service.py
@@ -2589,6 +2589,7 @@ def test__update_fieldsets__data_provided__ok(mocker):
         task=task_1,
     )
     assert new_fieldset.name == 'New Fieldset'
+    assert new_fieldset.title == 'Test title'
     assert new_fieldset.description == 'Test description'
     assert new_fieldset.order == 2
     _update_fieldset_rules_mock.assert_called_once_with(

--- a/backend/src/processes/tests/test_services/test_templates/test_template.py
+++ b/backend/src/processes/tests/test_services/test_templates/test_template.py
@@ -799,3 +799,89 @@ def test_partial_update__without_description__refresh_attachments_not_called(
 
     # assert
     refresh_mock.assert_not_called()
+
+
+def test_fill_template_data__fieldset_fields__register_placeholders():
+
+    # arrange
+    user = create_test_user()
+    service = TemplateService(user=user)
+    initial_data = {
+        'name': 'Template with fieldsets',
+        'kickoff': {
+            'fields': [
+                {
+                    'name': 'Direct field',
+                    'type': 'text',
+                    'api_name': 'direct-field',
+                },
+            ],
+            'fieldsets': [
+                {
+                    'title': 'Kickoff fieldset',
+                    'api_name': 'kickoff-fieldset',
+                    'fields': [
+                        {
+                            'name': 'Nested kickoff field',
+                            'type': 'text',
+                            'api_name': 'nested-kickoff-field',
+                        },
+                        {
+                            'name': 'Kickoff field without api name',
+                            'type': 'text',
+                        },
+                    ],
+                },
+            ],
+        },
+        'tasks': [
+            {
+                'name': 'Task 1',
+                'number': 1,
+                'description': (
+                    'Direct {{ direct-field }} and '
+                    'nested {{ nested-kickoff-field }}'
+                ),
+                'fields': [],
+                'fieldsets': [
+                    {
+                        'title': 'Task fieldset',
+                        'api_name': 'task-fieldset',
+                        'fields': [
+                            {
+                                'name': 'Nested task field',
+                                'type': 'text',
+                                'api_name': 'nested-task-field',
+                            },
+                            {
+                                'name': 'Task field without api name',
+                                'type': 'text',
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                'name': 'Task 2',
+                'number': 2,
+                'description': 'Use {{ nested-task-field }}',
+            },
+        ],
+    }
+
+    # act
+    data = service.fill_template_data(initial_data)
+
+    # assert
+    kickoff_fieldset_fields = data['kickoff']['fieldsets'][0]['fields']
+    assert kickoff_fieldset_fields[0]['api_name'] == 'nested-kickoff-field'
+    assert kickoff_fieldset_fields[1]['api_name'].startswith('field-')
+
+    task_fieldset_fields = data['tasks'][0]['fieldsets'][0]['fields']
+    assert task_fieldset_fields[0]['api_name'] == 'nested-task-field'
+    assert task_fieldset_fields[1]['api_name'].startswith('field-')
+
+    assert data['tasks'][0]['description'] == (
+        'Direct {{direct-field}} and nested {{nested-kickoff-field}}'
+    )
+    assert data['tasks'][1]['description'] == 'Use {{nested-task-field}}'

--- a/backend/src/processes/tests/test_services/test_workflows/test_kickoff_version_service.py
+++ b/backend/src/processes/tests/test_services/test_workflows/test_kickoff_version_service.py
@@ -857,6 +857,7 @@ def test__update_fieldsets__provided__ok(mocker):
         {
             'api_name': 'fs-1',
             'name': 'Fieldset 1',
+            'title': 'Fieldset Title',
             'description': 'Desc',
             'order': 11,
             'label_position': LabelPosition.TOP,
@@ -884,6 +885,7 @@ def test__update_fieldsets__provided__ok(mocker):
         api_name='fs-1',
     )
     assert fieldset.name == 'Fieldset 1'
+    assert fieldset.title == 'Fieldset Title'
     assert fieldset.description == 'Desc'
     assert fieldset.order == 11
     assert fieldset.label_position == LabelPosition.TOP


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Targeted fieldset/template/versioning fixes with expanded test coverage; no auth or security surface changes.
> 
> **Overview**
> Follow-up fixes for fieldset handling across templates and workflow versioning.
> 
> **`get_new_fieldset_data`** now treats optional `title` and `description` with `is not None` instead of truthiness, so callers can pass `''` to clear values copied from a shared fieldset instead of keeping the shared text.
> 
> **Workflow version sync** (`TaskUpdateVersionService` and `KickoffUpdateVersionService`) includes **`title`** in `FieldSet` `update_or_create` defaults alongside existing name/description fields.
> 
> **`TemplateService.fill_template_data`** refactors field placeholder registration into **`_register_field_placeholders`** and runs it for fields nested under kickoff and task **fieldsets**, not only top-level kickoff/task fields—so task descriptions can resolve `{{...}}` references to those nested fields.
> 
> Tests cover empty title/description overrides, persisted fieldset titles on version update, and placeholder registration for nested fieldset fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82c96d970aa6b6ef7967689aa097fabd27580af4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix fieldset title/description handling and extend placeholder registration to nested fieldset fields
> - `FieldSetTemplateService.get_new_fieldset_data` now sets `title`/`description` to empty string when `''` is provided, instead of ignoring falsy values, allowing inherited values to be explicitly cleared.
> - `TaskUpdateVersionService._update_fieldsets` and `KickoffUpdateVersionService._update_fieldsets` now persist the `title` field when creating/updating `FieldSet` records.
> - `TemplateService.fill_template_data` is refactored to use a new `_register_field_placeholders` helper, extending placeholder registration and `api_name` assignment to fields nested inside kickoff and task fieldsets, and substituting those placeholders in descriptions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 82c96d9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->