### PR TITLE
48185 frontend [ fieldsets ] hotfix long string

### DIFF
--- a/frontend/src/public/components/Fieldsets/FieldsetDetails/FieldsetDetailsSkeleton.tsx
+++ b/frontend/src/public/components/Fieldsets/FieldsetDetails/FieldsetDetailsSkeleton.tsx
@@ -9,7 +9,10 @@ export function FieldsetDetailsSkeleton() {
         <div className={styles['header-skeleton']} style={{ width: '30rem', height: '3.2rem', borderRadius: '0.8rem' }} />
       </header>
       <div className={styles['list']}>
-        <div className={styles['header-skeleton']} style={{ width: '20rem', height: '2.4rem', borderRadius: '0.8rem', marginBottom: '1.6rem' }} />
+        <div
+          className={styles['header-skeleton']}
+          style={{ width: '20rem', height: '2.4rem', borderRadius: '0.8rem', marginBottom: '1.6rem' }}
+        />
         <div className={styles['header-skeleton']} style={{ width: '100%', height: '8rem', borderRadius: '0.8rem' }} />
       </div>
     </div>


### PR DESCRIPTION
### 1. Release notes
Fixed long line in fieldset details skeleton to meet code formatting requirements (max-len).

### 2. Context
- Task: #48185
- Component: `frontend/src/public/components/Fieldsets/FieldsetDetails/FieldsetDetailsSkeleton.tsx`
- Page: Fieldset details (`/fieldsets/:id`) during data loading.

### 3. Solution
Formatted a long line with inline styles of a JSX element in the fieldset details loading skeleton across multiple lines according to the `max-len` linter rule.

### 4. What to test

#### 4.1 Preconditions
- Application dev-server is running.
- Authenticated user with access to the Fieldsets section (`/fieldsets`).

#### 4.2 Positive Scenarios / Test Report
| Scenario | Description (action & expected result) | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| :--- | :--- | :--- | :--- | :--- | :--- |
| **Skeleton rendering** | Open fieldset details page `/fieldsets/:id` → During loading, skeleton renders correctly without layout breakage. | [ ] | [ ] | [ ] | [ ] |

#### 4.3 Negative Scenarios and Edge Cases
| Scenario | Description (action & expected result) | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| :--- | :--- | :--- | :--- | :--- | :--- |
| **Fast page navigation** | Rapidly navigate between fieldsets → Skeleton displays correct height and margins without visual glitches. | [ ] | [ ] | [ ] | [ ] |

#### 4.4 Verification points
- UI: `FieldsetDetailsSkeleton` renders without visual artifacts during loading.

#### 4.5 What was NOT tested
- Locales were not tested (change does not affect text/translations).
- Backend data loading logic was not tested.

### 5. Touched areas
| Scenario | Description | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| :--- | :--- | :--- | :--- | :--- | :--- |
| **Fieldset view page** | Verify skeleton component in `FieldsetDetails.tsx` loads without type or JSX errors. | [ ] | [ ] | [ ] | [ ] |

### 6. Commits
- `8a0f9219` (`44a30f9a` in `dev`) — `48185 fix(fieldsets): split long line to pass max-len lint`


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Cosmetic formatting in a skeleton component with no runtime impact.
> 
> **Overview**
> **Formatting-only** change in `FieldsetDetailsSkeleton.tsx`: the list section’s middle skeleton `div` is split across multiple lines so the inline `style` object no longer exceeds the project’s max line length. **No behavior or layout changes**—same classes and styles as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a0f9219b7013bcd2165ca311d103b55714fd85b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reformat long JSX line in `FieldsetDetailsSkeleton` for readability
> Splits a single long `<div>` element across multiple lines in [FieldsetDetailsSkeleton.tsx](https://github.com/pneumaticapp/pneumaticworkflow/pull/281/files#diff-0132fc628e5d158a947f816dfb7ce222b899ca09165f8e4a59e1ce4f5f1f2370). No logic, props, or styling values are changed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8a0f921.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->