### PR TITLE
feat(github): add GitHub actions for file service

### DIFF
--- a/.github/workflows/file-service-latest-push.yml
+++ b/.github/workflows/file-service-latest-push.yml
@@ -1,32 +1,16 @@
-name: Build and push a new stable version
+name: Build and push a new file-service latest version
 
 on:
   push:
-    tags:
-      - 'v*'
+    paths:
+      - 'storage/**'
+    branches:
+      - 'master'
 
 jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - image: pneumaticworkflow/pneumatic-frontend
-            dockerfile: frontend/Dockerfile
-            build_context: frontend
-          - image: pneumaticworkflow/pneumatic-backend
-            dockerfile: backend/Dockerfile
-            build_context: backend
-          - image: pneumaticworkflow/pneumatic-celery
-            dockerfile: backend/Dockerfile
-            build_context: backend
-          - image: pneumaticworkflow/pneumatic-celery-beat
-            dockerfile: backend/Dockerfile
-            build_context: backend
-          - image: pneumaticworkflow/file-service
-            dockerfile: storage/Dockerfile
-            build_context: storage
     permissions:
       packages: write
       contents: read
@@ -46,7 +30,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ matrix.image }}
+          images: "pneumaticworkflow/file-service"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -57,12 +41,12 @@ jobs:
           driver: cloud
           endpoint: "pneumaticworkflow/pneumatic-release-builder"
 
-      - name: Build and push ${{ matrix.image }}
+      - name: Build and push pneumaticworkflow/file-service
         uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
-          context: ${{ matrix.build_context }}
-          file: ${{ matrix.dockerfile }}
+          context: storage
+          file: "storage/Dockerfile"
           push: true
-          tags: "${{ steps.meta.outputs.tags }},${{ matrix.image }}:stable"
+          tags: "pneumaticworkflow/file-service:latest"
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only workflow changes with no application runtime or security logic modified.
> 
> **Overview**
> Adds CI to build and publish **`pneumaticworkflow/file-service`** alongside the existing app images.
> 
> A new workflow runs on **`master`** when **`storage/**`** changes, building from **`storage/Dockerfile`** and pushing **`pneumaticworkflow/file-service:latest`** (multi-arch via Buildx cloud builder, same pattern as other services).
> 
> The **`v*`** tag release workflow’s build matrix now includes **file-service**, so tagged releases also produce the versioned and **`:stable`** tags for that image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba172176e9f502612b1ad873d82b03f93cde8138. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add GitHub Actions CI workflows to build and push the `file-service` Docker image
> - Adds [file-service-latest-push.yml](.github/workflows/file-service-latest-push.yml): triggers on pushes to `master` that touch `storage/**`, builds a multi-arch Docker image from `storage/Dockerfile`, and pushes it as `pneumaticworkflow/file-service:latest` to Docker Hub.
> - Extends the matrix in [new-tag-push.yml](.github/workflows/new-tag-push.yml) to include `pneumaticworkflow/file-service`, so tag-triggered builds now cover this image alongside existing ones.
> - Both workflows use QEMU, Buildx with the cloud driver endpoint `pneumaticworkflow/pneumatic-release-builder`, and Docker Hub credentials for the push.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ba17217.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->