### PR TITLE
hotfix(tasks): remove broken prefetch to "fieldsets__fields__attachme…

### DIFF
--- a/backend/src/processes/views/task.py
+++ b/backend/src/processes/views/task.py
@@ -288,7 +288,6 @@ class TaskViewSet(
                         ),
                     ),
                 ),
-                'fieldsets__fields__attachments',
                 Prefetch(
                     'fieldsets__fields__selections',
                     queryset=FieldSelection.objects.order_by('id'),
@@ -554,7 +553,6 @@ class TaskViewSet(
                         ),
                     ),
                 ),
-                'fieldsets__fields__attachments',
                 Prefetch(
                     'fieldsets__fields__selections',
                     queryset=FieldSelection.objects.order_by('id'),


### PR DESCRIPTION
…nts"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow query-shape fix with no auth or write-path changes; possible minor N+1 for fieldset file fields if serializers still expect prefetched attachments.
> 
> **Overview**
> Removes the **`fieldsets__fields__attachments`** `prefetch_related` entry from task loading in **`TaskViewSet`**, in both **`prefetch_queryset`** (task **retrieve**) and the post-**complete** **`TaskSerializer`** reload.
> 
> That prefetch was invalid or misaligned with how field attachments are modeled (top-level output fields still prefetch **`storage_attachments`**). Keeping it could break task detail and complete responses with ORM errors or bad queries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3700a2391b621f15d10d08b0d3032940ca98df07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove broken `fieldsets__fields__attachments` prefetch from `TaskViewSet`
> Removes `fieldsets__fields__attachments` from the `prefetch_related` calls in [task.py](https://github.com/pneumaticapp/pneumaticworkflow/pull/283/files#diff-05bbc1161f014d6d000b960096668f7514b15d33e775435c37d1ec7d80849ef0), which was causing errors. Attachments on task fields are now loaded lazily on access instead of being prefetched upfront.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3700a23.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->