### PR TITLE
🔧 48176 frontend [ ui ] Increase the width of the template selection drop-down list

### DIFF
--- a/frontend/src/public/assets/css/mixins/fonts.pcss
+++ b/frontend/src/public/assets/css/mixins/fonts.pcss
@@ -126,6 +126,11 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  /* Expand clip box for emoji without changing visual line-height */
+  padding-top: 0.2em;
+  padding-bottom: 0.2em;
+  margin-top: -0.2em;
+  margin-bottom: -0.2em;
 }
 
 @define-mixin text-overflow $line: 1 {
@@ -137,6 +142,11 @@
   line-clamp: $line;
   text-wrap: wrap;
   word-break: break-word;
+  /* Expand clip box for emoji without changing visual line-height */
+  padding-top: 0.2em;
+  padding-bottom: 0.2em;
+  margin-top: -0.2em;
+  margin-bottom: -0.2em;
 }
 
 @define-mixin text-wrap {

--- a/frontend/src/public/components/UI/Select/FilterSelect.tsx
+++ b/frontend/src/public/components/UI/Select/FilterSelect.tsx
@@ -49,6 +49,7 @@ interface IFilterSelectCommonProps<
   toggleClassName?: string;
   arrowClassName?: string;
   menuClassName?: string;
+  isWideMenu?: boolean;
   optionIdKey: IdKey;
   optionLabelKey: LabelKey;
   containerClassname?: string;
@@ -99,6 +100,7 @@ export function FilterSelect<
     toggleClassName,
     arrowClassName,
     menuClassName,
+    isWideMenu,
     options,
     groupedOptions,
     flatGroupedOptions,
@@ -438,6 +440,7 @@ export function FilterSelect<
           className={classnames(
             styles['dropdown-menu'],
             styles['dropdown-menu_search'],
+            isWideMenu && styles['dropdown-menu_wide'],
             menuClassName,
             positionFixed && styles['dropdown-menu__position-fixed'],
           )}

--- a/frontend/src/public/components/UI/Select/FilterSelect.tsx
+++ b/frontend/src/public/components/UI/Select/FilterSelect.tsx
@@ -173,6 +173,8 @@ export function FilterSelect<
             onClear={handleClearSearchText}
             fieldSize="md"
             autoFocus
+            autoComplete="one-time-code"
+            name="filter-select-search"
             placeholder={searchPlaceholder}
           />
         </div>

--- a/frontend/src/public/components/UI/Select/Select.css
+++ b/frontend/src/public/components/UI/Select/Select.css
@@ -92,22 +92,20 @@
 }
 
 .dropdown-item-content__text {
-  overflow: hidden;
+  @mixin text-truncate;
+
   min-width: 0;
-  white-space: nowrap;
-  text-overflow: ellipsis;
   flex: 1 1 0;
+
   > * {
-    overflow: hidden;
-    text-overflow: ellipsis;
+    @mixin text-truncate;
   }
 }
 
 .dropdown-item-content__subtitle {
+  @mixin text-small-extra bold;
+
   margin: 0 0.8rem;
-  font-size: 1.1rem;
-  font-weight: bold;
-  line-height: 1.6rem;
   text-align: center;
   letter-spacing: 0.05em;
   text-transform: uppercase;
@@ -115,13 +113,12 @@
 }
 
 .dropdown-item-content__count {
+  @mixin text-small-extra bold;
+
   display: flex;
   flex-shrink: 0;
   min-width: 2rem;
   height: 2rem;
-  font-size: 1.1rem;
-  font-weight: bold;
-  line-height: 1.6rem;
   letter-spacing: 0.05em;
   color: var(--pneumatic-color-black48);
   border-radius: 1.2rem;
@@ -130,19 +127,18 @@
 }
 
 .dropdown-item__text_stub {
-  font-family: Nunito, sans-serif;
-  font-size: 1.5rem;
-  line-height: 2rem;
+  @mixin text-base;
+
   color: var(--pneumatic-color-black32);
 }
 
 .active-value {
+  @mixin text-small bold;
+
   padding: 0;
   display: flex;
   width: 100%;
-  font-size: 1.3rem;
   font-weight: bold !important;
-  line-height: 1.6rem;
   white-space: nowrap;
   color: var(--pneumatic-color-black100);
   background: transparent;
@@ -154,9 +150,9 @@
   }
 
   .active-value__text {
+    @mixin text-truncate;
+
     margin-right: 0.8rem;
-    overflow: hidden;
-    text-overflow: ellipsis;
   }
 
   &[aria-expanded='true'] {
@@ -179,9 +175,7 @@
 
 .active-value__text {
   div {
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
+    @mixin text-truncate;
 
     span {
       display: inline !important;
@@ -198,12 +192,11 @@
 }
 
 .value-item {
+  @mixin text-base 800;
+
   padding-top: 0.5rem !important;
   padding-bottom: 0.5rem !important;
   display: flex !important;
-  font-size: 1.5rem;
-  font-weight: 800;
-  line-height: 1.6rem;
   color: var(--pneumatic-color-black100) !important;
   align-items: center;
 

--- a/frontend/src/public/components/UI/Select/Select.css
+++ b/frontend/src/public/components/UI/Select/Select.css
@@ -45,6 +45,14 @@
   }
 }
 
+.dropdown-menu_wide {
+  width: 52.8rem;
+
+  @media (--mobile) {
+    width: 100%;
+  }
+}
+
 .dropdown-menu__scrollbar {
   margin-right: 0 !important;
   padding-right: 0 !important;

--- a/frontend/src/public/layout/TasksLayout/TasksLayout.tsx
+++ b/frontend/src/public/layout/TasksLayout/TasksLayout.tsx
@@ -177,6 +177,7 @@ export function TasksLayoutComponent({
             <FilterSelect
               isLoading={areFilterTemplatesLoading}
               isSearchShown
+              isWideMenu
               noValueLabel={formatMessage({ id: 'sorting.all-templates' })}
               placeholderText={formatMessage({ id: 'sorting.no-template-found' })}
               selectedOption={templateIdFilter}

--- a/frontend/src/public/layout/WorkflowsLayout/TemplateFilterSelect.tsx
+++ b/frontend/src/public/layout/WorkflowsLayout/TemplateFilterSelect.tsx
@@ -45,6 +45,7 @@ export function TemplateFilterSelect() {
         isLoading={areFilterTemplatesLoading}
         isMultiple
         isSearchShown
+        isWideMenu
         placeholderText={formatMessage({ id: 'sorting.no-template-found' })}
         searchPlaceholder={formatMessage({ id: 'sorting.search-placeholder' })}
         selectedOptions={templatesIdsFilter}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only styling and FilterSelect props with no backend or auth impact; wide menu is opt-in on two template filters.
> 
> **Overview**
> Widens the **template** filter dropdown on Tasks and Workflows by adding an optional **`isWideMenu`** prop on `FilterSelect` and a **`dropdown-menu_wide`** style (~52.8rem desktop, full width on mobile).
> 
> **`Select.css`** now uses shared font/truncate mixins for dropdown labels and the active value instead of duplicated rules. **`text-truncate`** / **`text-overflow`** mixins gain a small padding/margin offset so emoji in truncated text are less likely to be clipped without changing visible line height.
> 
> The filter search field sets **`autoComplete="one-time-code"`** and a fixed **`name`** to discourage unwanted browser autofill.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bb903fc81b3b34e2857c9801072765d5ac42d38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Increase width of template selection dropdown in Tasks and Workflows layouts
> - Adds `isWideMenu` prop to `FilterSelect` that applies a `dropdown-menu_wide` CSS class, setting dropdown width to 52.8rem (100% on mobile).
> - Enables `isWideMenu` on the template `FilterSelect` in [`TasksLayout.tsx`](https://github.com/pneumaticapp/pneumaticworkflow/pull/285/files#diff-8fc77258a36524fc7ff46d4122657aec684d1dafaf681d728227e456b0261cf3) and [`TemplateFilterSelect.tsx`](https://github.com/pneumaticapp/pneumaticworkflow/pull/285/files#diff-b4382551b99d68c2f6b6a753dcb45b98affd443e48f2488a7ad7c5230990f80e).
> - Refactors [`Select.css`](https://github.com/pneumaticapp/pneumaticworkflow/pull/285/files#diff-266d0e0cfa338a0d3b19fe8e8e4c04fdc23e2e37aa4a560cd980e3c42bc09171) to use shared typography and text-truncate mixins, and fixes emoji clipping in `text-truncate` and `text-overflow` mixins by adding small vertical padding with offsetting negative margins.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7ecaea8.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->