### PR TITLE
🔧 48208 frontend [ websocket ] Fix the processing of messages by groups

### DIFF
--- a/frontend/src/public/redux/groups/saga.ts
+++ b/frontend/src/public/redux/groups/saga.ts
@@ -69,7 +69,16 @@ function* createGroupSaga({ payload }: PayloadAction<IGroup>) {
   }
 }
 
-function* updateGroupSaga({ payload }: PayloadAction<IGroup>) {
+function* restoreGroupFromServer(groupId: number) {
+  try {
+    const group: IGroup = yield getGroup(groupId as unknown as Pick<IGroup, 'id'>);
+    yield put(updateGroupSuccess(group));
+  } catch (error) {
+    logger.error('failed to restore group after update error', error);
+  }
+}
+
+function* updateGroupSaga({ payload, type }: PayloadAction<IGroup>) {
   try {
     const group: IGroup = yield updateGroupApi(payload);
 
@@ -78,6 +87,10 @@ function* updateGroupSaga({ payload }: PayloadAction<IGroup>) {
     NotificationManager.warning({ message: getErrorMessage(error) });
     logger.error('failed to update group', error);
     yield put(updateGroupFailed());
+
+    if (type === updateUsersGroup.type) {
+      yield restoreGroupFromServer(payload.id);
+    }
   }
 }
 

--- a/frontend/src/public/redux/groups/slice.ts
+++ b/frontend/src/public/redux/groups/slice.ts
@@ -136,8 +136,13 @@ const groupsSlice = createSlice({
       .addCase(updateGroup, (state) => {
         state.isLoading = true;
       })
-      .addCase(updateUsersGroup, (state) => {
-        state.isLoading = true;
+      .addCase(updateUsersGroup, (state, action: PayloadAction<IGroup>) => {
+        const group = action.payload;
+        state.list = state.list.map((item) => (item.id === group.id ? group : item));
+
+        if (state.currentGroup.data?.id === group.id) {
+          state.currentGroup.data = group;
+        }
       })
       .addCase(deleteGroup, (state) => {
         state.isLoading = true;

--- a/frontend/src/public/redux/realtime/types.ts
+++ b/frontend/src/public/redux/realtime/types.ts
@@ -221,7 +221,7 @@ export interface IWsGroupData {
   name: string;
   photo: string | null;
   type: EUserGroupType;
-  users: IWsGroupUser[];
+  users: number[];
 }
 
 // ======================= utils
@@ -247,9 +247,6 @@ export interface IWsTaskPerformer {
   isCompleted: boolean;
   dateCompletedTsp: number | null;
 }
-
-export interface IWsGroupUser extends IWsUserData {}
-
 
 // ======================= notification data types
 

--- a/frontend/src/public/redux/realtime/utils/__tests__/mapGroupFromWs.test.ts
+++ b/frontend/src/public/redux/realtime/utils/__tests__/mapGroupFromWs.test.ts
@@ -1,0 +1,35 @@
+import { EUserGroupType } from '../../../team/types';
+import { mapWsGroupToGroup } from '../mapGroupFromWs';
+
+describe('mapWsGroupToGroup', () => {
+  it('keeps user ids as-is when WS payload sends PrimaryKeyRelatedField list', () => {
+    const result = mapWsGroupToGroup({
+      id: 10,
+      name: 'Engineering',
+      photo: null,
+      type: EUserGroupType.Regular,
+      users: [1, 2, 3],
+    });
+
+    expect(result).toEqual({
+      id: 10,
+      name: 'Engineering',
+      photo: null,
+      type: EUserGroupType.Regular,
+      users: [1, 2, 3],
+    });
+  });
+
+  it('does not map users through .id (avoids undefined/null after backend serializer change)', () => {
+    const result = mapWsGroupToGroup({
+      id: 1,
+      name: 'Ops',
+      photo: 'https://example.com/photo.png',
+      type: EUserGroupType.Regular,
+      users: [42],
+    });
+
+    expect(result.users).toEqual([42]);
+    expect(result.users.every((id) => typeof id === 'number')).toBe(true);
+  });
+});

--- a/frontend/src/public/redux/realtime/utils/mapGroupFromWs.ts
+++ b/frontend/src/public/redux/realtime/utils/mapGroupFromWs.ts
@@ -3,7 +3,10 @@ import type { IWsGroupData } from '../types';
 
 export function mapWsGroupToGroup(group: IWsGroupData): IGroup {
   return {
-    ...group,
-    users: group.users.map((user) => user.id)
+    id: group.id,
+    name: group.name,
+    photo: group.photo,
+    type: group.type,
+    users: group.users,
   };
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes real-time group sync and optimistic membership updates; incorrect mapping or rollback could show wrong group members until refresh, but scope is limited to groups/team UI state.
> 
> **Overview**
> Aligns frontend group handling with WebSocket payloads that send **user IDs as `number[]`** (PrimaryKeyRelatedField) instead of user objects.
> 
> **WebSocket mapping:** `IWsGroupData.users` is typed as `number[]`, and `mapWsGroupToGroup` passes `users` through without mapping `.id`, which had produced broken membership after a backend serializer change. Unit tests cover this behavior.
> 
> **Redux:** `updateUsersGroup` now **optimistically** updates the group in `list` and `currentGroup` instead of setting `isLoading`. On API failure for that action, `updateGroupSaga` calls **`restoreGroupFromServer`** to re-fetch the group and apply `updateGroupSuccess`, rolling back bad optimistic state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cb863b2465c760f15ebf3f226f25b279bb855f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix WebSocket group message processing to correctly handle user IDs and restore state on failure
> - Updates [`mapWsGroupToGroup`](https://github.com/pneumaticapp/pneumaticworkflow/pull/286/files#diff-a3008a0dbe56ae6df523e0f6e88d3220503f48c2bdb25824a71a869755f3bcd2) to pass users through as `number[]` directly from the WS payload, removing the broken assumption that users were objects with an `.id` field.
> - Changes the `updateUsersGroup` reducer in [`slice.ts`](https://github.com/pneumaticapp/pneumaticworkflow/pull/286/files#diff-2b035ff93d1f6ab351e88f8af2d8eece72d7f1f216910b659fe4da4e431400a4) to immediately replace the matching group in state instead of setting `isLoading = true`.
> - Adds a `restoreGroupFromServer` saga that re-fetches and restores group state from the server when an `updateUsersGroup` action fails, keeping the store in sync.
> - Behavioral Change: dispatching `updateUsersGroup` no longer triggers a loading state; the store is updated optimistically and rolled back on failure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0cb863b.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->