### PR TITLE
48210 hotfix(tasks): preserve markdown line breaks

### DIFF
--- a/frontend/src/public/components/RichText/__tests__/RichText.test.tsx
+++ b/frontend/src/public/components/RichText/__tests__/RichText.test.tsx
@@ -87,6 +87,19 @@ describe('RichText', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  it('renders single line breaks in markdown mode', () => {
+    const props: IRichTextProps = {
+      text: 'Line 1\nLine 2',
+      isMarkdownMode: true,
+    };
+
+    const { container } = render(<RichText {...props} />);
+
+    expect(container.querySelector('br')).not.toBeNull();
+    expect(container.textContent).toContain('Line 1');
+    expect(container.textContent).toContain('Line 2');
+  });
+
   it('does not append trailing space to paragraphs separated by blank lines', () => {
     const props: IRichTextProps = {
       text: 'Paragraph one\n\nParagraph two\n\n',

--- a/frontend/src/public/components/RichText/utils/createRichTextMarkdownIt.ts
+++ b/frontend/src/public/components/RichText/utils/createRichTextMarkdownIt.ts
@@ -39,6 +39,7 @@ export const createRichTextMarkdownIt = ({
   const md = MarkdownIt({
     html: true,
     linkify: false,
+    breaks: true,
   });
 
   md.disable(['link', 'image']);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small display-only change to markdown parsing with a focused test; no auth, data, or API impact.
> 
> **Overview**
> **RichText** markdown rendering now treats single newlines as hard line breaks instead of collapsing them into one line.
> 
> `createRichTextMarkdownIt` enables MarkdownIt’s **`breaks: true`** option so text like `Line 1\nLine 2` outputs a `<br>` between lines. A unit test asserts that behavior in markdown mode; existing tests for double-newline paragraphs are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4fa463a74f6727997a5f02c4cfc2ce8cb1705b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve single line breaks in markdown rendering for rich text
> Enables the `breaks: true` option in [createRichTextMarkdownIt.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/287/files#diff-c63946234bf69618aa731fcb31042d2e942b32a2590ed8e117d5e239ae47fad2), causing single newlines in markdown to render as `<br>` elements instead of being ignored. A corresponding test verifies the new behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f4fa463.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->