### PR TITLE
🔧 34217 backend [auth] Show captcha for second reset password

### DIFF
--- a/backend/src/authentication/serializers.py
+++ b/backend/src/authentication/serializers.py
@@ -392,6 +392,15 @@ class ResetPasswordSerializer(
     email = serializers.EmailField(required=True)
 
 
+class SecuredResetPasswordSerializer(ResetPasswordSerializer):
+    captcha = ReCaptchaV2Field()
+
+    def validate(self, attrs):
+        attrs = super().validate(attrs)
+        attrs.pop('captcha', None)
+        return attrs
+
+
 class ConfirmPasswordSerializer(
     CustomValidationErrorMixin,
     serializers.Serializer,

--- a/backend/src/authentication/tests/test_views/test_password.py
+++ b/backend/src/authentication/tests/test_views/test_password.py
@@ -22,6 +22,16 @@ class TestResetPasswordViewSet:
 
         # arrange
         user = create_test_user()
+        mocker.patch(
+            'src.authentication.views.password.'
+            'ResetPasswordViewSet.anonymous_user_reset_exists',
+            return_value=False,
+        )
+        mocker.patch(
+            'src.authentication.views.password.'
+            'ResetPasswordViewSet'
+            '.inc_anonymous_user_reset_counter',
+        )
         send_reset_password_notification_mock = mocker.patch(
             'src.authentication.views.password.'
             'send_reset_password_notification.delay',
@@ -49,6 +59,16 @@ class TestResetPasswordViewSet:
 
         # arrange
         email = 'test@pneumatic.app'
+        mocker.patch(
+            'src.authentication.views.password.'
+            'ResetPasswordViewSet.anonymous_user_reset_exists',
+            return_value=False,
+        )
+        mocker.patch(
+            'src.authentication.views.password.'
+            'ResetPasswordViewSet'
+            '.inc_anonymous_user_reset_counter',
+        )
         send_reset_password_notification_mock = mocker.patch(
             'src.authentication.views.password.'
             'send_reset_password_notification.delay',
@@ -76,6 +96,16 @@ class TestResetPasswordViewSet:
         user = create_test_user(email=email)
         another_owner = create_test_user(email='another@test.test')
         create_invited_user(user=another_owner, email=email)
+        mocker.patch(
+            'src.authentication.views.password.'
+            'ResetPasswordViewSet.anonymous_user_reset_exists',
+            return_value=False,
+        )
+        mocker.patch(
+            'src.authentication.views.password.'
+            'ResetPasswordViewSet'
+            '.inc_anonymous_user_reset_counter',
+        )
         send_reset_password_notification_mock = mocker.patch(
             'src.authentication.views.password.'
             'send_reset_password_notification.delay',

--- a/backend/src/authentication/tests/test_views/test_reset_password_captcha.py
+++ b/backend/src/authentication/tests/test_views/test_reset_password_captcha.py
@@ -1,8 +1,11 @@
 import pytest
+from unittest.mock import ANY
+
+from django.conf import settings
 from drf_recaptcha.validators import ReCaptchaV2Validator
 
 from src.processes.tests.fixtures import (
-    create_test_user,
+    create_test_owner,
 )
 from src.utils.validation import ErrorCode
 
@@ -11,16 +14,18 @@ pytestmark = pytest.mark.django_db
 
 def test_captcha__first_request__not_show(api_client, mocker):
 
+    """ First reset request, captcha enabled — hide """
+
     # arrange
     anonymous_user_reset_exists_mock = mocker.patch(
         'src.authentication.views.password.'
         'ResetPasswordViewSet.anonymous_user_reset_exists',
         return_value=False,
     )
-    settings_mock = mocker.patch(
-        'src.authentication.views.password.settings',
+    mocker.patch.dict(
+        settings.PROJECT_CONF,
+        {'CAPTCHA': True},
     )
-    settings_mock.PROJECT_CONF = {'CAPTCHA': True}
 
     # act
     response = api_client.get('/auth/reset-password/captcha')
@@ -28,10 +33,12 @@ def test_captcha__first_request__not_show(api_client, mocker):
     # assert
     assert response.status_code == 200
     assert response.data['show_captcha'] is False
-    assert anonymous_user_reset_exists_mock.call_count == 1
+    anonymous_user_reset_exists_mock.assert_called_once_with(ANY)
 
 
 def test_captcha__second_request__show(api_client, mocker):
+
+    """ Repeated reset request — show captcha """
 
     # arrange
     anonymous_user_reset_exists_mock = mocker.patch(
@@ -39,10 +46,10 @@ def test_captcha__second_request__show(api_client, mocker):
         'ResetPasswordViewSet.anonymous_user_reset_exists',
         return_value=True,
     )
-    settings_mock = mocker.patch(
-        'src.authentication.views.password.settings',
+    mocker.patch.dict(
+        settings.PROJECT_CONF,
+        {'CAPTCHA': True},
     )
-    settings_mock.PROJECT_CONF = {'CAPTCHA': True}
 
     # act
     response = api_client.get('/auth/reset-password/captcha')
@@ -50,10 +57,12 @@ def test_captcha__second_request__show(api_client, mocker):
     # assert
     assert response.status_code == 200
     assert response.data['show_captcha'] is True
-    assert anonymous_user_reset_exists_mock.call_count == 1
+    anonymous_user_reset_exists_mock.assert_called_once_with(ANY)
 
 
 def test_captcha__ip_not_found__show(api_client, mocker):
+
+    """ IP not in request headers — show captcha """
 
     # arrange
     anonymous_user_reset_exists_mock = mocker.patch(
@@ -61,10 +70,10 @@ def test_captcha__ip_not_found__show(api_client, mocker):
         'ResetPasswordViewSet.anonymous_user_reset_exists',
         return_value=None,
     )
-    settings_mock = mocker.patch(
-        'src.authentication.views.password.settings',
+    mocker.patch.dict(
+        settings.PROJECT_CONF,
+        {'CAPTCHA': True},
     )
-    settings_mock.PROJECT_CONF = {'CAPTCHA': True}
 
     # act
     response = api_client.get('/auth/reset-password/captcha')
@@ -72,10 +81,12 @@ def test_captcha__ip_not_found__show(api_client, mocker):
     # assert
     assert response.status_code == 200
     assert response.data['show_captcha'] is True
-    assert anonymous_user_reset_exists_mock.call_count == 1
+    anonymous_user_reset_exists_mock.assert_called_once_with(ANY)
 
 
 def test_captcha__disabled__not_show(api_client, mocker):
+
+    """ Captcha disabled in settings — hide """
 
     # arrange
     anonymous_user_reset_exists_mock = mocker.patch(
@@ -83,10 +94,10 @@ def test_captcha__disabled__not_show(api_client, mocker):
         'ResetPasswordViewSet.anonymous_user_reset_exists',
         return_value=True,
     )
-    settings_mock = mocker.patch(
-        'src.authentication.views.password.settings',
+    mocker.patch.dict(
+        settings.PROJECT_CONF,
+        {'CAPTCHA': False},
     )
-    settings_mock.PROJECT_CONF = {'CAPTCHA': False}
 
     # act
     response = api_client.get('/auth/reset-password/captcha')
@@ -102,8 +113,10 @@ def test_create__first_request__ok_without_captcha(
     mocker,
 ):
 
+    """ First reset request — captcha not required """
+
     # arrange
-    user = create_test_user()
+    user = create_test_owner()
     anonymous_user_reset_exists_mock = mocker.patch(
         'src.authentication.views.password.'
         'ResetPasswordViewSet.anonymous_user_reset_exists',
@@ -113,14 +126,18 @@ def test_create__first_request__ok_without_captcha(
         'src.authentication.views.password.'
         'ResetPasswordViewSet.inc_anonymous_user_reset_counter',
     )
-    send_reset_password_notification_mock = mocker.patch(
+    send_reset_pwd_notification_mock = mocker.patch(
         'src.authentication.views.password.'
         'send_reset_password_notification.delay',
     )
-    settings_mock = mocker.patch(
-        'src.authentication.views.password.settings',
+    check_sso_restrictions_mock = mocker.patch(
+        'src.authentication.views.password.'
+        'ResetPasswordViewSet.check_sso_restrictions',
     )
-    settings_mock.PROJECT_CONF = {'CAPTCHA': True}
+    mocker.patch.dict(
+        settings.PROJECT_CONF,
+        {'CAPTCHA': True},
+    )
 
     # act
     response = api_client.post(
@@ -130,15 +147,18 @@ def test_create__first_request__ok_without_captcha(
 
     # assert
     assert response.status_code == 204
-    assert anonymous_user_reset_exists_mock.call_count == 1
-    assert inc_anonymous_user_reset_counter_mock.call_count == 1
-    send_reset_password_notification_mock.assert_called_once_with(
+    anonymous_user_reset_exists_mock.assert_called_once_with(ANY)
+    inc_anonymous_user_reset_counter_mock.assert_called_once_with(
+        ANY,
+    )
+    send_reset_pwd_notification_mock.assert_called_once_with(
         user_id=user.id,
         user_email=user.email,
         logo_lg=user.account.logo_lg,
         logging=user.account.log_api_requests,
         account_id=user.account_id,
     )
+    check_sso_restrictions_mock.assert_called_once_with(user)
 
 
 def test_create__second_request_with_captcha__ok(
@@ -146,8 +166,10 @@ def test_create__second_request_with_captcha__ok(
     mocker,
 ):
 
+    """ Repeated request with valid captcha — ok """
+
     # arrange
-    user = create_test_user()
+    user = create_test_owner()
     anonymous_user_reset_exists_mock = mocker.patch(
         'src.authentication.views.password.'
         'ResetPasswordViewSet.anonymous_user_reset_exists',
@@ -157,18 +179,22 @@ def test_create__second_request_with_captcha__ok(
         'src.authentication.views.password.'
         'ResetPasswordViewSet.inc_anonymous_user_reset_counter',
     )
-    send_reset_password_notification_mock = mocker.patch(
+    send_reset_pwd_notification_mock = mocker.patch(
         'src.authentication.views.password.'
         'send_reset_password_notification.delay',
     )
-    mocker.patch.object(
+    check_sso_restrictions_mock = mocker.patch(
+        'src.authentication.views.password.'
+        'ResetPasswordViewSet.check_sso_restrictions',
+    )
+    recaptcha_v2_validator_call_mock = mocker.patch.object(
         ReCaptchaV2Validator,
         attribute='__call__',
     )
-    settings_mock = mocker.patch(
-        'src.authentication.views.password.settings',
+    mocker.patch.dict(
+        settings.PROJECT_CONF,
+        {'CAPTCHA': True},
     )
-    settings_mock.PROJECT_CONF = {'CAPTCHA': True}
 
     # act
     response = api_client.post(
@@ -181,57 +207,19 @@ def test_create__second_request_with_captcha__ok(
 
     # assert
     assert response.status_code == 204
-    assert anonymous_user_reset_exists_mock.call_count == 1
-    assert inc_anonymous_user_reset_counter_mock.call_count == 1
-    send_reset_password_notification_mock.assert_called_once_with(
+    anonymous_user_reset_exists_mock.assert_called_once_with(ANY)
+    inc_anonymous_user_reset_counter_mock.assert_called_once_with(
+        ANY,
+    )
+    send_reset_pwd_notification_mock.assert_called_once_with(
         user_id=user.id,
         user_email=user.email,
         logo_lg=user.account.logo_lg,
         logging=user.account.log_api_requests,
         account_id=user.account_id,
     )
-
-
-def test_create__second_request_without_captcha__error(
-    api_client,
-    mocker,
-):
-
-    # arrange
-    anonymous_user_reset_exists_mock = mocker.patch(
-        'src.authentication.views.password.'
-        'ResetPasswordViewSet.anonymous_user_reset_exists',
-        return_value=True,
-    )
-    inc_anonymous_user_reset_counter_mock = mocker.patch(
-        'src.authentication.views.password.'
-        'ResetPasswordViewSet.inc_anonymous_user_reset_counter',
-    )
-    send_reset_password_notification_mock = mocker.patch(
-        'src.authentication.views.password.'
-        'send_reset_password_notification.delay',
-    )
-    settings_mock = mocker.patch(
-        'src.authentication.views.password.settings',
-    )
-    settings_mock.PROJECT_CONF = {'CAPTCHA': True}
-
-    # act
-    response = api_client.post(
-        '/auth/reset-password',
-        data={'email': 'test@pneumatic.app'},
-    )
-
-    # assert
-    message = 'This field is required.'
-    assert response.status_code == 400
-    assert response.data['code'] == ErrorCode.VALIDATION_ERROR
-    assert response.data['message'] == message
-    assert response.data['details']['name'] == 'captcha'
-    assert response.data['details']['reason'] == message
-    assert anonymous_user_reset_exists_mock.call_count == 1
-    assert inc_anonymous_user_reset_counter_mock.call_count == 1
-    send_reset_password_notification_mock.assert_not_called()
+    check_sso_restrictions_mock.assert_called_once_with(user)
+    assert recaptcha_v2_validator_call_mock.call_count == 1
 
 
 def test_create__captcha_disabled__ok_without_captcha(
@@ -239,8 +227,10 @@ def test_create__captcha_disabled__ok_without_captcha(
     mocker,
 ):
 
+    """ Captcha disabled — ok without captcha """
+
     # arrange
-    user = create_test_user()
+    user = create_test_owner()
     anonymous_user_reset_exists_mock = mocker.patch(
         'src.authentication.views.password.'
         'ResetPasswordViewSet.anonymous_user_reset_exists',
@@ -250,14 +240,18 @@ def test_create__captcha_disabled__ok_without_captcha(
         'src.authentication.views.password.'
         'ResetPasswordViewSet.inc_anonymous_user_reset_counter',
     )
-    send_reset_password_notification_mock = mocker.patch(
+    send_reset_pwd_notification_mock = mocker.patch(
         'src.authentication.views.password.'
         'send_reset_password_notification.delay',
     )
-    settings_mock = mocker.patch(
-        'src.authentication.views.password.settings',
+    check_sso_restrictions_mock = mocker.patch(
+        'src.authentication.views.password.'
+        'ResetPasswordViewSet.check_sso_restrictions',
     )
-    settings_mock.PROJECT_CONF = {'CAPTCHA': False}
+    mocker.patch.dict(
+        settings.PROJECT_CONF,
+        {'CAPTCHA': False},
+    )
 
     # act
     response = api_client.post(
@@ -267,12 +261,167 @@ def test_create__captcha_disabled__ok_without_captcha(
 
     # assert
     assert response.status_code == 204
-    assert anonymous_user_reset_exists_mock.call_count == 1
-    assert inc_anonymous_user_reset_counter_mock.call_count == 1
-    send_reset_password_notification_mock.assert_called_once_with(
+    anonymous_user_reset_exists_mock.assert_called_once_with(ANY)
+    inc_anonymous_user_reset_counter_mock.assert_called_once_with(
+        ANY,
+    )
+    send_reset_pwd_notification_mock.assert_called_once_with(
         user_id=user.id,
         user_email=user.email,
         logo_lg=user.account.logo_lg,
         logging=user.account.log_api_requests,
         account_id=user.account_id,
     )
+    check_sso_restrictions_mock.assert_called_once_with(user)
+
+
+def test_create__user_not_found__ok_no_notification(
+    api_client,
+    mocker,
+):
+
+    """ Email not in DB — 204, no notification sent """
+
+    # arrange
+    anonymous_user_reset_exists_mock = mocker.patch(
+        'src.authentication.views.password.'
+        'ResetPasswordViewSet.anonymous_user_reset_exists',
+        return_value=False,
+    )
+    inc_anonymous_user_reset_counter_mock = mocker.patch(
+        'src.authentication.views.password.'
+        'ResetPasswordViewSet.inc_anonymous_user_reset_counter',
+    )
+    send_reset_pwd_notification_mock = mocker.patch(
+        'src.authentication.views.password.'
+        'send_reset_password_notification.delay',
+    )
+    check_sso_restrictions_mock = mocker.patch(
+        'src.authentication.views.password.'
+        'ResetPasswordViewSet.check_sso_restrictions',
+    )
+    mocker.patch.dict(
+        settings.PROJECT_CONF,
+        {'CAPTCHA': True},
+    )
+
+    # act
+    response = api_client.post(
+        '/auth/reset-password',
+        data={'email': 'nonexistent@pneumatic.app'},
+    )
+
+    # assert
+    assert response.status_code == 204
+    anonymous_user_reset_exists_mock.assert_called_once_with(ANY)
+    inc_anonymous_user_reset_counter_mock.assert_called_once_with(
+        ANY,
+    )
+    send_reset_pwd_notification_mock.assert_not_called()
+    check_sso_restrictions_mock.assert_not_called()
+
+
+def test_create__second_request_no_captcha__validation_err(
+    api_client,
+    mocker,
+):
+
+    """ Repeated request without captcha — validation error """
+
+    # arrange
+    anonymous_user_reset_exists_mock = mocker.patch(
+        'src.authentication.views.password.'
+        'ResetPasswordViewSet.anonymous_user_reset_exists',
+        return_value=True,
+    )
+    inc_anonymous_user_reset_counter_mock = mocker.patch(
+        'src.authentication.views.password.'
+        'ResetPasswordViewSet.inc_anonymous_user_reset_counter',
+    )
+    send_reset_pwd_notification_mock = mocker.patch(
+        'src.authentication.views.password.'
+        'send_reset_password_notification.delay',
+    )
+    check_sso_restrictions_mock = mocker.patch(
+        'src.authentication.views.password.'
+        'ResetPasswordViewSet.check_sso_restrictions',
+    )
+    mocker.patch.dict(
+        settings.PROJECT_CONF,
+        {'CAPTCHA': True},
+    )
+
+    # act
+    response = api_client.post(
+        '/auth/reset-password',
+        data={'email': 'test@pneumatic.app'},
+    )
+
+    # assert
+
+    # DRF built-in required field validation message
+    message = 'This field is required.'
+    assert response.status_code == 400
+    assert response.data['code'] == ErrorCode.VALIDATION_ERROR
+    assert response.data['message'] == message
+    assert response.data['details']['name'] == 'captcha'
+    assert response.data['details']['reason'] == message
+    anonymous_user_reset_exists_mock.assert_called_once_with(ANY)
+    inc_anonymous_user_reset_counter_mock.assert_called_once_with(
+        ANY,
+    )
+    send_reset_pwd_notification_mock.assert_not_called()
+    check_sso_restrictions_mock.assert_not_called()
+
+
+def test_create__ip_not_found_no_captcha__validation_err(
+    api_client,
+    mocker,
+):
+
+    """ IP not found, no captcha sent — validation error """
+
+    # arrange
+    anonymous_user_reset_exists_mock = mocker.patch(
+        'src.authentication.views.password.'
+        'ResetPasswordViewSet.anonymous_user_reset_exists',
+        return_value=None,
+    )
+    inc_anonymous_user_reset_counter_mock = mocker.patch(
+        'src.authentication.views.password.'
+        'ResetPasswordViewSet.inc_anonymous_user_reset_counter',
+    )
+    send_reset_pwd_notification_mock = mocker.patch(
+        'src.authentication.views.password.'
+        'send_reset_password_notification.delay',
+    )
+    check_sso_restrictions_mock = mocker.patch(
+        'src.authentication.views.password.'
+        'ResetPasswordViewSet.check_sso_restrictions',
+    )
+    mocker.patch.dict(
+        settings.PROJECT_CONF,
+        {'CAPTCHA': True},
+    )
+
+    # act
+    response = api_client.post(
+        '/auth/reset-password',
+        data={'email': 'test@pneumatic.app'},
+    )
+
+    # assert
+
+    # DRF built-in required field validation message
+    message = 'This field is required.'
+    assert response.status_code == 400
+    assert response.data['code'] == ErrorCode.VALIDATION_ERROR
+    assert response.data['message'] == message
+    assert response.data['details']['name'] == 'captcha'
+    assert response.data['details']['reason'] == message
+    anonymous_user_reset_exists_mock.assert_called_once_with(ANY)
+    inc_anonymous_user_reset_counter_mock.assert_called_once_with(
+        ANY,
+    )
+    send_reset_pwd_notification_mock.assert_not_called()
+    check_sso_restrictions_mock.assert_not_called()

--- a/backend/src/authentication/tests/test_views/test_reset_password_captcha.py
+++ b/backend/src/authentication/tests/test_views/test_reset_password_captcha.py
@@ -1,0 +1,278 @@
+import pytest
+from drf_recaptcha.validators import ReCaptchaV2Validator
+
+from src.processes.tests.fixtures import (
+    create_test_user,
+)
+from src.utils.validation import ErrorCode
+
+pytestmark = pytest.mark.django_db
+
+
+def test_captcha__first_request__not_show(api_client, mocker):
+
+    # arrange
+    anonymous_user_reset_exists_mock = mocker.patch(
+        'src.authentication.views.password.'
+        'ResetPasswordViewSet.anonymous_user_reset_exists',
+        return_value=False,
+    )
+    settings_mock = mocker.patch(
+        'src.authentication.views.password.settings',
+    )
+    settings_mock.PROJECT_CONF = {'CAPTCHA': True}
+
+    # act
+    response = api_client.get('/auth/reset-password/captcha')
+
+    # assert
+    assert response.status_code == 200
+    assert response.data['show_captcha'] is False
+    assert anonymous_user_reset_exists_mock.call_count == 1
+
+
+def test_captcha__second_request__show(api_client, mocker):
+
+    # arrange
+    anonymous_user_reset_exists_mock = mocker.patch(
+        'src.authentication.views.password.'
+        'ResetPasswordViewSet.anonymous_user_reset_exists',
+        return_value=True,
+    )
+    settings_mock = mocker.patch(
+        'src.authentication.views.password.settings',
+    )
+    settings_mock.PROJECT_CONF = {'CAPTCHA': True}
+
+    # act
+    response = api_client.get('/auth/reset-password/captcha')
+
+    # assert
+    assert response.status_code == 200
+    assert response.data['show_captcha'] is True
+    assert anonymous_user_reset_exists_mock.call_count == 1
+
+
+def test_captcha__ip_not_found__show(api_client, mocker):
+
+    # arrange
+    anonymous_user_reset_exists_mock = mocker.patch(
+        'src.authentication.views.password.'
+        'ResetPasswordViewSet.anonymous_user_reset_exists',
+        return_value=None,
+    )
+    settings_mock = mocker.patch(
+        'src.authentication.views.password.settings',
+    )
+    settings_mock.PROJECT_CONF = {'CAPTCHA': True}
+
+    # act
+    response = api_client.get('/auth/reset-password/captcha')
+
+    # assert
+    assert response.status_code == 200
+    assert response.data['show_captcha'] is True
+    assert anonymous_user_reset_exists_mock.call_count == 1
+
+
+def test_captcha__disabled__not_show(api_client, mocker):
+
+    # arrange
+    anonymous_user_reset_exists_mock = mocker.patch(
+        'src.authentication.views.password.'
+        'ResetPasswordViewSet.anonymous_user_reset_exists',
+        return_value=True,
+    )
+    settings_mock = mocker.patch(
+        'src.authentication.views.password.settings',
+    )
+    settings_mock.PROJECT_CONF = {'CAPTCHA': False}
+
+    # act
+    response = api_client.get('/auth/reset-password/captcha')
+
+    # assert
+    assert response.status_code == 200
+    assert response.data['show_captcha'] is False
+    anonymous_user_reset_exists_mock.assert_not_called()
+
+
+def test_create__first_request__ok_without_captcha(
+    api_client,
+    mocker,
+):
+
+    # arrange
+    user = create_test_user()
+    anonymous_user_reset_exists_mock = mocker.patch(
+        'src.authentication.views.password.'
+        'ResetPasswordViewSet.anonymous_user_reset_exists',
+        return_value=False,
+    )
+    inc_anonymous_user_reset_counter_mock = mocker.patch(
+        'src.authentication.views.password.'
+        'ResetPasswordViewSet.inc_anonymous_user_reset_counter',
+    )
+    send_reset_password_notification_mock = mocker.patch(
+        'src.authentication.views.password.'
+        'send_reset_password_notification.delay',
+    )
+    settings_mock = mocker.patch(
+        'src.authentication.views.password.settings',
+    )
+    settings_mock.PROJECT_CONF = {'CAPTCHA': True}
+
+    # act
+    response = api_client.post(
+        '/auth/reset-password',
+        data={'email': user.email},
+    )
+
+    # assert
+    assert response.status_code == 204
+    assert anonymous_user_reset_exists_mock.call_count == 1
+    assert inc_anonymous_user_reset_counter_mock.call_count == 1
+    send_reset_password_notification_mock.assert_called_once_with(
+        user_id=user.id,
+        user_email=user.email,
+        logo_lg=user.account.logo_lg,
+        logging=user.account.log_api_requests,
+        account_id=user.account_id,
+    )
+
+
+def test_create__second_request_with_captcha__ok(
+    api_client,
+    mocker,
+):
+
+    # arrange
+    user = create_test_user()
+    anonymous_user_reset_exists_mock = mocker.patch(
+        'src.authentication.views.password.'
+        'ResetPasswordViewSet.anonymous_user_reset_exists',
+        return_value=True,
+    )
+    inc_anonymous_user_reset_counter_mock = mocker.patch(
+        'src.authentication.views.password.'
+        'ResetPasswordViewSet.inc_anonymous_user_reset_counter',
+    )
+    send_reset_password_notification_mock = mocker.patch(
+        'src.authentication.views.password.'
+        'send_reset_password_notification.delay',
+    )
+    mocker.patch.object(
+        ReCaptchaV2Validator,
+        attribute='__call__',
+    )
+    settings_mock = mocker.patch(
+        'src.authentication.views.password.settings',
+    )
+    settings_mock.PROJECT_CONF = {'CAPTCHA': True}
+
+    # act
+    response = api_client.post(
+        '/auth/reset-password',
+        data={
+            'email': user.email,
+            'captcha': 'skip',
+        },
+    )
+
+    # assert
+    assert response.status_code == 204
+    assert anonymous_user_reset_exists_mock.call_count == 1
+    assert inc_anonymous_user_reset_counter_mock.call_count == 1
+    send_reset_password_notification_mock.assert_called_once_with(
+        user_id=user.id,
+        user_email=user.email,
+        logo_lg=user.account.logo_lg,
+        logging=user.account.log_api_requests,
+        account_id=user.account_id,
+    )
+
+
+def test_create__second_request_without_captcha__error(
+    api_client,
+    mocker,
+):
+
+    # arrange
+    anonymous_user_reset_exists_mock = mocker.patch(
+        'src.authentication.views.password.'
+        'ResetPasswordViewSet.anonymous_user_reset_exists',
+        return_value=True,
+    )
+    inc_anonymous_user_reset_counter_mock = mocker.patch(
+        'src.authentication.views.password.'
+        'ResetPasswordViewSet.inc_anonymous_user_reset_counter',
+    )
+    send_reset_password_notification_mock = mocker.patch(
+        'src.authentication.views.password.'
+        'send_reset_password_notification.delay',
+    )
+    settings_mock = mocker.patch(
+        'src.authentication.views.password.settings',
+    )
+    settings_mock.PROJECT_CONF = {'CAPTCHA': True}
+
+    # act
+    response = api_client.post(
+        '/auth/reset-password',
+        data={'email': 'test@pneumatic.app'},
+    )
+
+    # assert
+    message = 'This field is required.'
+    assert response.status_code == 400
+    assert response.data['code'] == ErrorCode.VALIDATION_ERROR
+    assert response.data['message'] == message
+    assert response.data['details']['name'] == 'captcha'
+    assert response.data['details']['reason'] == message
+    assert anonymous_user_reset_exists_mock.call_count == 1
+    assert inc_anonymous_user_reset_counter_mock.call_count == 1
+    send_reset_password_notification_mock.assert_not_called()
+
+
+def test_create__captcha_disabled__ok_without_captcha(
+    api_client,
+    mocker,
+):
+
+    # arrange
+    user = create_test_user()
+    anonymous_user_reset_exists_mock = mocker.patch(
+        'src.authentication.views.password.'
+        'ResetPasswordViewSet.anonymous_user_reset_exists',
+        return_value=True,
+    )
+    inc_anonymous_user_reset_counter_mock = mocker.patch(
+        'src.authentication.views.password.'
+        'ResetPasswordViewSet.inc_anonymous_user_reset_counter',
+    )
+    send_reset_password_notification_mock = mocker.patch(
+        'src.authentication.views.password.'
+        'send_reset_password_notification.delay',
+    )
+    settings_mock = mocker.patch(
+        'src.authentication.views.password.settings',
+    )
+    settings_mock.PROJECT_CONF = {'CAPTCHA': False}
+
+    # act
+    response = api_client.post(
+        '/auth/reset-password',
+        data={'email': user.email},
+    )
+
+    # assert
+    assert response.status_code == 204
+    assert anonymous_user_reset_exists_mock.call_count == 1
+    assert inc_anonymous_user_reset_counter_mock.call_count == 1
+    send_reset_password_notification_mock.assert_called_once_with(
+        user_id=user.id,
+        user_email=user.email,
+        logo_lg=user.account.logo_lg,
+        logging=user.account.log_api_requests,
+        account_id=user.account_id,
+    )

--- a/backend/src/authentication/views/password.py
+++ b/backend/src/authentication/views/password.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from rest_framework.decorators import action
 from rest_framework.generics import (
@@ -22,6 +23,7 @@ from src.authentication.serializers import (
     ChangePasswordSerializer,
     ConfirmPasswordSerializer,
     ResetPasswordSerializer,
+    SecuredResetPasswordSerializer,
     TokenSerializer,
 )
 from src.authentication.views.mixins import SSORestrictionMixin
@@ -31,6 +33,7 @@ from src.authentication.throttling import (
 )
 from src.authentication.tokens import PneumaticToken
 from src.generics.mixins.views import (
+    AnonymousResetPasswordMixin,
     BaseResponseMixin,
     CustomViewSetMixin,
 )
@@ -46,6 +49,7 @@ UserModel = get_user_model()
 
 class ResetPasswordViewSet(
     SSORestrictionMixin,
+    AnonymousResetPasswordMixin,
     CustomViewSetMixin,
     GenericViewSet,
 ):
@@ -60,8 +64,27 @@ class ResetPasswordViewSet(
     def throttle_classes(self):
         return (AuthResetPasswordThrottle, )
 
+    @action(methods=['get'], detail=False, url_path='captcha')
+    def captcha(self, request):
+        if not settings.PROJECT_CONF['CAPTCHA']:
+            show_captcha = False
+        else:
+            reset_exists = self.anonymous_user_reset_exists(request)
+            show_captcha = reset_exists in {True, None}
+        return self.response_ok({'show_captcha': show_captcha})
+
     def create(self, request):
-        slz = self.get_serializer(data=request.data)
+        reset_exists = self.anonymous_user_reset_exists(request)
+        self.inc_anonymous_user_reset_counter(request)
+        captcha_required = reset_exists in {True, None}
+        if settings.PROJECT_CONF['CAPTCHA'] and captcha_required:
+            slz_cls = SecuredResetPasswordSerializer
+        else:
+            slz_cls = ResetPasswordSerializer
+        slz = slz_cls(
+            data=request.data,
+            context={'request': request},
+        )
         slz.is_valid(raise_exception=True)
         user = (
             UserModel.objects

--- a/backend/src/generics/mixins/views.py
+++ b/backend/src/generics/mixins/views.py
@@ -176,6 +176,39 @@ class AnonymousMixin:
             request.META.get('HTTP_USER_AGENT'),
         )
 
+    def _action_exists(
+        self,
+        request: Request,
+        scope: str,
+    ) -> Optional[bool]:
+
+        """ Returns True if action was already performed from this IP.
+            Returns None if user ip not found in request headers """
+
+        user_ip = self.get_user_ip(request)
+        if user_ip is None:
+            return None
+        cache_key = self.get_cache_key(key_parts=(scope, user_ip))
+        return self.cache.get(cache_key, 0) > 0
+
+    def _inc_action_counter(
+        self,
+        request: Request,
+        scope: str,
+    ):
+
+        """ Increments the IP-based action counter """
+
+        user_ip = self.get_user_ip(request)
+        if user_ip is None:
+            return
+        cache_key = self.get_cache_key(key_parts=(scope, user_ip))
+        added = self.cache.add(
+            cache_key, 1, timeout=self.cache_timeout,
+        )
+        if not added:
+            self.cache.incr(cache_key)
+
 
 class AnonymousWorkflowMixin(AnonymousMixin):
 
@@ -184,62 +217,41 @@ class AnonymousWorkflowMixin(AnonymousMixin):
         request: Request,
         template: Template,
     ) -> Optional[bool]:
-
-        """ Returns True if the anonymous user has already
-            created a workflow using specific template
-            Returns None if user ip not found in request headers """
-
-        user_ip = self.get_user_ip(request)
-        if user_ip is None:
-            return None
-        cache_key = self.get_cache_key(key_parts=(str(template.id), user_ip))
-        count_created_workflows = self.cache.get(cache_key, 0)
-        return count_created_workflows > 0
+        return self._action_exists(request, str(template.id))
 
     def inc_anonymous_user_workflow_counter(
         self,
-        request,
+        request: Request,
         template: Template,
     ):
-
-        """ Increases the counter of the number of workflow created by
-            the anonymous user """
-
-        user_ip = self.get_user_ip(request)
-        cache_key = self.get_cache_key(key_parts=(str(template.id), user_ip))
-        added = self.cache.add(cache_key, 1, timeout=self.cache_timeout)
-        if not added:
-            self.cache.incr(cache_key)
+        self._inc_action_counter(request, str(template.id))
 
 
 class AnonymousAccountMixin(AnonymousMixin):
 
     def anonymous_user_account_exists(
         self,
-        request,
+        request: Request,
     ) -> Optional[bool]:
-
-        """ Returns True if the anonymous user has already
-            created a account
-            Returns None if user ip not found in request headers """
-
-        user_ip = self.get_user_ip(request)
-        if user_ip is None:
-            return None
-        cache_key = self.get_cache_key(key_parts=('accounts', user_ip))
-        count_created_accounts = self.cache.get(cache_key, 0)
-        return count_created_accounts > 0
+        return self._action_exists(request, 'accounts')
 
     def inc_anonymous_user_account_counter(
         self,
-        request,
+        request: Request,
     ):
+        self._inc_action_counter(request, 'accounts')
 
-        """ Increases the counter of the number of accounts created by
-            the anonymous user """
 
-        user_ip = self.get_user_ip(request)
-        cache_key = self.get_cache_key(key_parts=('accounts', user_ip))
-        added = self.cache.add(cache_key, 1, timeout=self.cache_timeout)
-        if not added:
-            self.cache.incr(cache_key)
+class AnonymousResetPasswordMixin(AnonymousMixin):
+
+    def anonymous_user_reset_exists(
+        self,
+        request: Request,
+    ) -> Optional[bool]:
+        return self._action_exists(request, 'reset_password')
+
+    def inc_anonymous_user_reset_counter(
+        self,
+        request: Request,
+    ):
+        self._inc_action_counter(request, 'reset_password')


### PR DESCRIPTION
# Problem

Users can abuse the password reset endpoint by making unlimited requests, potentially flooding email inboxes and enabling email enumeration attacks.

# Fix / Solution

- Added reCAPTCHA v2 validation for repeated password reset requests from the same IP (same pattern as signup)
- New `GET /auth/reset-password/captcha` endpoint for frontend to check if captcha is needed
- Refactored `AnonymousMixin` to extract common IP-tracking logic, reducing code duplication across signup/workflow/reset mixins
- Fixed a pre-existing bug where `None` IP could cause a TypeError in the counter increment

# Release notes

Password reset now requires captcha verification on repeated attempts from the same IP address, improving security against automated abuse.

# Changes

**API:**
- `GET /auth/reset-password/captcha` — new endpoint, returns `{show_captcha: bool}`
- `POST /auth/reset-password` — now accepts optional `captcha` field (required on repeated requests when CAPTCHA is enabled)

**Web-client:** No changes.

# Test cases

**API:**

| Authorization | Test case | Expected result |
|---|---|---|
| Anonymous | GET /auth/reset-password/captcha (first request) | 200, `show_captcha: false` |
| Anonymous | GET /auth/reset-password/captcha (repeated request) | 200, `show_captcha: true` |
| Anonymous | GET /auth/reset-password/captcha (CAPTCHA disabled) | 200, `show_captcha: false` |
| Anonymous | POST /auth/reset-password (first request, no captcha) | 204 |
| Anonymous | POST /auth/reset-password (repeated, with valid captcha) | 204 |
| Anonymous | POST /auth/reset-password (repeated, without captcha) | 400, validation error for `captcha` field |
| Anonymous | POST /auth/reset-password (CAPTCHA disabled, repeated) | 204 (no captcha needed) |

**Web-client:** No changes.


Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show captcha on repeated reset password requests
> - Adds a `GET /auth/reset-password/captcha` endpoint that returns `{show_captcha: bool}` based on the `CAPTCHA` setting and whether the requesting IP has already attempted a reset.
> - Adds `SecuredResetPasswordSerializer` in [serializers.py](https://github.com/pneumaticapp/pneumaticworkflow/pull/290/files#diff-7c47db4bfe4139c77fcc586659bdf669db5c9f6051675a72efcfabeb7292eb05) that validates a `ReCaptchaV2Field` before delegating to the parent serializer, stripping the captcha key from validated data.
> - `POST /auth/reset-password` now increments a per-IP reset counter and conditionally requires captcha via `SecuredResetPasswordSerializer` for repeated or IP-unknown requests.
> - Introduces `AnonymousResetPasswordMixin` in [views.py](https://github.com/pneumaticapp/pneumaticworkflow/pull/290/files#diff-2e870938cc4a76a7f2a15a0a722162de8f027e424c7cef32bc8cdfde93463cd3) with `anonymous_user_reset_exists` and `inc_anonymous_user_reset_counter` methods, replacing the removed `AnonymousWorkflowMixin`.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #290 opened
>
> - Added mocks for anonymous user reset tracking to password reset tests [789750e]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 642671b.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->