### PR TITLE
🔧 48177 frontend [ ui ] Images are compressed in the comments

### DIFF
--- a/frontend/src/public/components/RichEditor/plugins/PasteAttachmentPlugin/PasteAttachmentPlugin.tsx
+++ b/frontend/src/public/components/RichEditor/plugins/PasteAttachmentPlugin/PasteAttachmentPlugin.tsx
@@ -1,12 +1,17 @@
 import { useEffect } from 'react';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
-import { COMMAND_PRIORITY_EDITOR, PASTE_COMMAND } from 'lexical';
+import { COMMAND_PRIORITY_HIGH, PASTE_COMMAND } from 'lexical';
 import { getFilesFromClipboard } from './getFilesFromClipboard';
 
 export interface IPasteAttachmentPluginProps {
   onPasteFiles: (files: File[]) => Promise<void>;
 }
 
+/**
+ * Handles file paste (e.g. screenshots) before Lexical's default PASTE_COMMAND
+ * handler (COMMAND_PRIORITY_EDITOR), which otherwise swallows files via
+ * unused DRAG_DROP_PASTE or falls through to HTML paste when text types exist.
+ */
 export function PasteAttachmentPlugin({
   onPasteFiles,
 }: IPasteAttachmentPluginProps): null {
@@ -19,10 +24,11 @@ export function PasteAttachmentPlugin({
         const files = getFilesFromClipboard(event);
         if (files.length === 0) return false;
 
+        event.preventDefault();
         onPasteFiles(files).catch(() => undefined);
         return true;
       },
-      COMMAND_PRIORITY_EDITOR,
+      COMMAND_PRIORITY_HIGH,
     );
   }, [editor, onPasteFiles]);
 

--- a/frontend/src/public/components/RichEditor/plugins/PasteAttachmentPlugin/__tests__/PasteAttachmentPlugin.test.tsx
+++ b/frontend/src/public/components/RichEditor/plugins/PasteAttachmentPlugin/__tests__/PasteAttachmentPlugin.test.tsx
@@ -19,6 +19,7 @@ const initialConfig = {
 function createPasteEventWithFiles(files: File[]): ClipboardEvent {
   const fileList = Object.assign([...files], { length: files.length }) as unknown as FileList;
   return {
+    preventDefault: jest.fn(),
     clipboardData: {
       files: fileList,
       items: [],
@@ -97,5 +98,28 @@ describe('PasteAttachmentPlugin', () => {
     editorRef.current!.dispatchCommand(PASTE_COMMAND, event);
 
     expect(onPasteFiles).toHaveBeenCalledWith([file1, file2]);
+  });
+
+  it('calls preventDefault when files are pasted', async () => {
+    const onPasteFiles = jest.fn().mockResolvedValue(undefined);
+    const editorRef = React.createRef<LexicalEditor | null>() as MutableRefObject<LexicalEditor | null>;
+
+    render(
+      <LexicalComposer initialConfig={initialConfig}>
+        <SetEditorRefPlugin editorRef={editorRef} />
+        <PasteAttachmentPlugin onPasteFiles={onPasteFiles} />
+      </LexicalComposer>,
+    );
+
+    await waitFor(() => {
+      expect(editorRef.current).not.toBeNull();
+    });
+
+    const file = new File(['content'], 'pasted.png', { type: 'image/png' });
+    const event = createPasteEventWithFiles([file]);
+
+    editorRef.current!.dispatchCommand(PASTE_COMMAND, event);
+
+    expect(event.preventDefault).toHaveBeenCalled();
   });
 });

--- a/frontend/src/public/components/RichText/RichText.css
+++ b/frontend/src/public/components/RichText/RichText.css
@@ -108,6 +108,7 @@
   img {
     display: block;
     width: auto;
+    max-width: 100%;
     max-height: 50rem;
     cursor: pointer;
   }
@@ -117,6 +118,14 @@
   ul,
   ol {
     margin: 2rem 0;
+  }
+
+  > *:first-child {
+    margin-top: 0;
+  }
+
+  > *:last-child {
+    margin-bottom: 0;
   }
 
   li + li {

--- a/frontend/src/public/components/Workflows/WorkflowLog/WorkflowLogEvents/WorkflowLogTaskComment/WorkflowLogTaskComment.css
+++ b/frontend/src/public/components/Workflows/WorkflowLog/WorkflowLogEvents/WorkflowLogTaskComment/WorkflowLogTaskComment.css
@@ -2,6 +2,7 @@
   display: flex;
 
   &__avatar {
+    flex-shrink: 0;
     margin-right: 1.6rem;
 
     @media (--mobile) {
@@ -11,6 +12,7 @@
 
   &__body {
     flex-grow: 1;
+    min-width: 0;
   }
 
   &__info {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI and editor paste-order changes only; no auth, data, or API changes.
> 
> **Overview**
> Fixes **workflow comment images looking squashed** and improves **pasting screenshots/files** into the rich comment editor.
> 
> **Rich text / comments:** Images in rendered comment content now get `max-width: 100%` while keeping natural width, and top/bottom margins on the first/last block are trimmed so spacing does not exaggerate layout issues. In the workflow log comment row, the avatar no longer shrinks in the flex row and the comment body gets `min-width: 0` so wide content (including images) can shrink inside the flex layout instead of overflowing or compressing oddly.
> 
> **Paste attachments:** `PasteAttachmentPlugin` registers `PASTE_COMMAND` at **`COMMAND_PRIORITY_HIGH`** (above Lexical’s default editor handler) and calls **`preventDefault`** when clipboard files are present, so file pastes are handled by `onPasteFiles` instead of being swallowed or turned into HTML paste. Tests cover `preventDefault` on file paste.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fddacb20ded78be8ecf868bb416102826f98fcdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix image compression and layout issues in comments
> - Raises `PASTE_COMMAND` priority to `COMMAND_PRIORITY_HIGH` and adds `event.preventDefault()` in [`PasteAttachmentPlugin`](https://github.com/pneumaticapp/pneumaticworkflow/pull/292/files#diff-97da202982ca06e085d84d96f4aec328c8b34fa90d0330bf822e4d61d0f1982b) so file pastes are handled before lower-priority handlers (preventing image compression from default browser paste behavior).
> - Adds `max-width: 100%` to images in [RichText.css](https://github.com/pneumaticapp/pneumaticworkflow/pull/292/files#diff-9790c7e47b9ed09c01a58f4fe339e2749f6823fc7ea517fba2427d962cd0cabf) so images no longer overflow horizontally inside markdown content, and removes extra top/bottom margins from first/last children.
> - Fixes flex layout in [WorkflowLogTaskComment.css](https://github.com/pneumaticapp/pneumaticworkflow/pull/292/files#diff-539cdf78ea3465c9959f0545654adb8dfce487ff560e6052f730461a17782e98) so the avatar does not shrink and the comment body can shrink with proper overflow handling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fddacb2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->