### PR TITLE
44522 frontend [ highlights ] Localize group performer events

### DIFF
--- a/frontend/src/public/lang/locales/ru_RU.ts
+++ b/frontend/src/public/lang/locales/ru_RU.ts
@@ -991,6 +991,8 @@ export const ruMessages = {
   'task.log-returned': 'Процесс возвращён к {taskName}',
   'task.log-delay': '{taskName} отложена до {date}',
   'task.log-delay-workflow': 'Отложено до {date}',
+  'task.log-added-performer-group': 'Добавлена группа\u00A0',
+  'task.log-removed-performer-group': 'Удалена группа\u00A0',
   'task.log-added-performer': 'Добавлен пользователь\u00A0',
   'task.log-removed-performer': 'Удален пользователь\u00A0',
   'process-highlights.button-clear': 'Очистить',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Copy-only i18n change in `ru_RU.ts`; no logic or API impact.
> 
> **Overview**
> Adds Russian locale entries for **group performer** workflow log / highlights copy, matching the existing English keys `task.log-added-performer-group` and `task.log-removed-performer-group`.
> 
> Strings read «Добавлена группа» and «Удалена группа» (with a non-breaking space before the appended group name), parallel to the existing user performer messages in `ru_RU.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09a23c8ff2ece013b39585b19b2c9311c919df41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Russian translations for performer group task log events
> Adds `task.log-added-performer-group` and `task.log-removed-performer-group` entries to the Russian locale in [ru_RU.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/296/files#diff-3313e21aeb4edafb8e8b0e64a8103f6b264a45622abee8c7c10a89bb7539ee40), covering the task log highlights when a performer group is added or removed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 09a23c8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->