### PR TITLE
🔧 48347 backend [ templates ] Deplicate the fieldset with a dropdown field produce a 500 error

### DIFF
--- a/backend/src/processes/services/fieldsets/fieldset.py
+++ b/backend/src/processes/services/fieldsets/fieldset.py
@@ -6,7 +6,10 @@ from django.db import transaction
 
 from src.generics.base.service import BaseModelService
 from src.processes.enums import LabelPosition, FieldSetLayout
-from src.processes.models.templates.fields import FieldTemplate
+from src.processes.models.templates.fields import (
+    FieldTemplate,
+    FieldTemplateSelection,
+)
 from src.processes.models.templates.fieldset import (
     FieldsetTemplate,
     FieldsetTemplateRule,
@@ -262,6 +265,10 @@ class FieldSetTemplateService(BaseModelService):
             )
             fields_map[field_data['api_name']] = new_api_name
             field_data['api_name'] = new_api_name
+            for selection_data in field_data.get('selections', []):
+                selection_data['api_name'] = create_api_name(
+                    FieldTemplateSelection.api_name_prefix,
+                )
             updated_fields_data.append(field_data)
         fieldset_data['fields'] = updated_fields_data
 

--- a/backend/src/processes/tests/fixtures.py
+++ b/backend/src/processes/tests/fixtures.py
@@ -51,7 +51,8 @@ from src.processes.models.templates.fieldset import (
     FieldsetTemplate,
     FieldsetTemplateRule,
 )
-from src.processes.models.templates.fields import FieldTemplate
+from src.processes.models.templates.fields import FieldTemplate, \
+    FieldTemplateSelection
 from src.processes.models.templates.kickoff import Kickoff
 from src.processes.models.templates.owner import TemplateOwner
 from src.processes.models.templates.preset import (
@@ -912,7 +913,7 @@ def create_test_shared_fieldset(
         FieldsetTemplateRule.objects.create(
             fieldset=fieldset,
             account=account,
-            api_name=f'{fieldset.api_name}-rule-1',
+            api_name=f'{fieldset.api_name}-shared-rule-1',
             type=rule_type,
             value=rule_value,
         )
@@ -926,7 +927,7 @@ def create_test_shared_fieldset(
         type=field_type,
         fieldset=fieldset,
         order=1,
-        api_name=f'{fieldset.api_name}-field-1',
+        api_name=f'{fieldset.api_name}-shared-field-1',
         account=account,
     )
     return fieldset
@@ -980,7 +981,7 @@ def create_test_fieldset_template(
         )
 
     for shared_field in shared_fieldset.fields.all():
-        FieldTemplate.objects.create(
+        field = FieldTemplate.objects.create(
             name=shared_field.name,
             type=shared_field.type,
             fieldset=fieldset,
@@ -989,6 +990,13 @@ def create_test_fieldset_template(
             api_name=f'{fieldset.api_name}-field-1',
             account=account,
         )
+        for shared_selection in shared_field.selections.all():
+            FieldTemplateSelection.objects.create(
+                value=shared_selection.value,
+                field_template=field,
+                template=template,
+                api_name=f'{field.api_name}-selection-1',
+            )
     return fieldset
 
 

--- a/backend/src/processes/tests/test_services/test_fieldsets/test_fieldset_template_service.py
+++ b/backend/src/processes/tests/test_services/test_fieldsets/test_fieldset_template_service.py
@@ -11,7 +11,10 @@ from src.processes.models.templates.fieldset import (
     FieldsetTemplate,
     FieldsetTemplateRule,
 )
-from src.processes.models.templates.fields import FieldTemplate
+from src.processes.models.templates.fields import (
+    FieldTemplate,
+    FieldTemplateSelection,
+)
 from src.processes.services.exceptions import (
     FieldsetTemplateInUseException,
     FieldsetTemplateSharedIdMissing,
@@ -1379,15 +1382,29 @@ def test__replace_api_names__fields_and_rules__ok(mocker):
     old_field_api = 'old-field-1'
     shared_fieldset_data = {
         'api_name': 'old-fs',
-        'fields': [{'api_name': old_field_api, 'name': 'F 1'}],
+        'fields': [
+            {
+                'api_name': old_field_api,
+                'name': 'F 1',
+                'selections': [
+                    {'api_name': 'old-selection-1', 'value': 'Option A'},
+                ],
+            },
+        ],
         'rules': [{'api_name': 'old-rule-1', 'fields': [old_field_api]}],
     }
     new_fs_api = 'new-fs-1'
     new_field_api = 'new-field-1'
+    new_selection_api = 'new-selection-1'
     new_rule_api = 'new-rule-1'
     create_api_name_mock = mocker.patch(
         'src.processes.services.fieldsets.fieldset.create_api_name',
-        side_effect=[new_fs_api, new_field_api, new_rule_api],
+        side_effect=[
+            new_fs_api,
+            new_field_api,
+            new_selection_api,
+            new_rule_api,
+        ],
     )
 
     # act
@@ -1398,13 +1415,18 @@ def test__replace_api_names__fields_and_rules__ok(mocker):
     # assert
     assert result['api_name'] == new_fs_api
     assert result['fields'][0]['api_name'] == new_field_api
+    assert result['fields'][0]['selections'][0]['api_name'] == (
+        new_selection_api
+    )
+    assert result['fields'][0]['selections'][0]['value'] == 'Option A'
     assert result['rules'][0]['api_name'] == new_rule_api
     assert result['rules'][0]['fields'][0] == new_field_api
-    assert create_api_name_mock.call_count == 3
+    assert create_api_name_mock.call_count == 4
     create_api_name_mock.assert_has_calls(
         [
             mocker.call(FieldsetTemplate.api_name_prefix),
             mocker.call(FieldTemplate.api_name_prefix),
+            mocker.call(FieldTemplateSelection.api_name_prefix),
             mocker.call(FieldsetTemplateRule.api_name_prefix),
         ],
         any_order=True,

--- a/backend/src/processes/tests/test_views/test_templates/test_create/test_template.py
+++ b/backend/src/processes/tests/test_views/test_templates/test_create/test_template.py
@@ -4569,3 +4569,93 @@ def test_create__draft_fieldset_from_another_account__excluded(
     assert draft['tasks'][0]['fieldsets'] == []
     assert response.data['kickoff']['fieldsets'] == []
     assert response.data['tasks'][0]['fieldsets'] == []
+
+
+def test_create__two_kickoff_fieldsets_from_same_shared_with_selections__ok(
+    mocker,
+    api_client,
+):
+    """Two inherited fieldsets from one shared fieldset with checkbox
+    selections must get unique selection api_names within the template."""
+
+    # arrange
+    account = create_test_account()
+    user = create_test_user(account=account)
+    api_client.token_authenticate(user)
+    mocker.patch(
+        'src.processes.services.templates.'
+        'integrations.TemplateIntegrationsService.'
+        'create_integrations_for_template',
+    )
+    mocker.patch(
+        'src.processes.views.template.'
+        'AnalyticService.templates_created',
+    )
+    mocker.patch(
+        'src.processes.views.template.'
+        'AnalyticService.templates_kickoff_created',
+    )
+    shared_fieldset = create_test_shared_fieldset(account=account)
+    shared_fieldset.fields.all().delete()
+    shared_field = FieldTemplate.objects.create(
+        fieldset=shared_fieldset,
+        account=account,
+        name='Checkbox field',
+        type=FieldType.CHECKBOX,
+        order=1,
+        api_name='checkbox-field',
+    )
+    FieldTemplateSelection.objects.create(
+        field_template=shared_field,
+        value='Option A',
+        api_name='selection-6059b7',
+    )
+    request_data = {
+        'name': 'Template with duplicated shared fieldset',
+        'owners': [
+            {
+                'type': OwnerType.USER,
+                'source_id': user.id,
+                'role': OwnerRole.OWNER,
+            },
+        ],
+        'is_active': True,
+        'kickoff': {
+            'fieldsets': [
+                {
+                    'shared_fieldset_id': shared_fieldset.id,
+                },
+                {
+                    'shared_fieldset_id': shared_fieldset.id,
+                },
+            ],
+        },
+        'tasks': [
+            {
+                'number': 1,
+                'name': 'First step',
+                'raw_performers': [
+                    {
+                        'type': PerformerType.USER,
+                        'source_id': user.id,
+                    },
+                ],
+            },
+        ],
+    }
+
+    # act
+    response = api_client.post(
+        path='/templates',
+        data=request_data,
+    )
+
+    # assert
+    assert response.status_code == 200
+    fieldsets = response.data['kickoff']['fieldsets']
+    assert len(fieldsets) == 2
+    selection_1 = fieldsets[0]['fields'][0]['selections'][0]
+    selection_2 = fieldsets[1]['fields'][0]['selections'][0]
+    assert selection_1['value'] == 'Option A'
+    assert selection_2['value'] == 'Option A'
+    assert selection_1['api_name'] != selection_2['api_name']

--- a/backend/src/processes/tests/test_views/test_templates/test_update/test_fieldsets.py
+++ b/backend/src/processes/tests/test_views/test_templates/test_update/test_fieldsets.py
@@ -3,12 +3,15 @@ import pytest
 from src.processes.enums import (
     FieldSetLayout,
     FieldSetRuleType,
+    FieldType,
     LabelPosition,
     OwnerRole,
     OwnerType,
     PerformerType,
 )
+from src.processes.models.templates.fields import FieldTemplateSelection
 from src.processes.models.templates.fieldset import FieldsetTemplate
+from src.processes.serializers.templates.template import TemplateSerializer
 from src.processes.tests.fixtures import (
     create_test_account,
     create_test_fieldset_template,
@@ -151,7 +154,7 @@ def test_update__create_kickoff_fieldset_only_required_data__ok(
     assert rule_data['fields'] == [field.api_name]
 
 
-def test_update__kickoff_fieldset_all_fieldset_data__ok(
+def test_update__create_kickoff_fieldset_all_fieldset_data__ok(
     mocker,
     api_client,
 ):
@@ -253,7 +256,7 @@ def test_update__kickoff_fieldset_all_fieldset_data__ok(
     assert fieldset_data['fields'] == []
 
 
-def test_update__kickoff_create_two_fieldsets__ok(
+def test_update__create_kickoff_two_different_fieldsets__ok(
     mocker,
     api_client,
 ):
@@ -345,7 +348,101 @@ def test_update__kickoff_create_two_fieldsets__ok(
     ).count() == 1
 
 
-def test_update__kickoff_replace_fieldset__ok(
+def test_update__create_kickoff_two_similar_fieldsets__ok(
+    mocker,
+    api_client,
+):
+
+    # arrange
+    account = create_test_account()
+    user = create_test_owner(account=account)
+    template = create_test_template(user, is_active=True, tasks_count=1)
+    kickoff = template.kickoff_instance
+    task = template.tasks.first()
+    shared_fieldset = create_test_shared_fieldset(account=account)
+    mocker.patch(
+        'src.processes.services.templates.'
+        'integrations.TemplateIntegrationsService.'
+        'create_integrations_for_template',
+    )
+    mocker.patch(
+        'src.processes.services.templates.'
+        'integrations.TemplateIntegrationsService.template_updated',
+    )
+    mocker.patch(
+        'src.processes.views.template.AnalyticService.templates_updated',
+    )
+    mocker.patch(
+        'src.processes.views.template.'
+        'AnalyticService.templates_kickoff_updated',
+    )
+    api_client.token_authenticate(user)
+
+    # act
+    response = api_client.put(
+        path=f'/templates/{template.id}',
+        data={
+            'id': template.id,
+            'is_active': True,
+            'name': 'Updated template',
+            'owners': [
+                {
+                    'type': OwnerType.USER,
+                    'source_id': user.id,
+                    'role': OwnerRole.OWNER,
+                },
+            ],
+            'kickoff': {
+                'id': kickoff.id,
+                'fieldsets': [
+                    {
+                        'shared_fieldset_id': shared_fieldset.id,
+                        'order': 0,
+                    },
+                    {
+                        'shared_fieldset_id': shared_fieldset.id,
+                        'order': 1,
+                    },
+                ],
+            },
+            'tasks': [
+                {
+                    'id': task.id,
+                    'api_name': task.api_name,
+                    'number': task.number,
+                    'name': task.name,
+                    'raw_performers': [
+                        {
+                            'type': PerformerType.USER,
+                            'source_id': user.id,
+                        },
+                    ],
+                },
+            ],
+        },
+    )
+
+    # assert
+    assert response.status_code == 200
+    fieldsets = response.data['kickoff']['fieldsets']
+    assert len(fieldsets) == 2
+    kickoff_fieldset_1 = fieldsets[0]
+    kickoff_fieldset_2 = fieldsets[1]
+    assert kickoff_fieldset_1['shared_fieldset_id'] == shared_fieldset.id
+    assert kickoff_fieldset_2['shared_fieldset_id'] == shared_fieldset.id
+    assert kickoff_fieldset_1['api_name'] != kickoff_fieldset_2['api_name']
+    db_fieldset_1 = kickoff.fieldsets.get(
+        shared_fieldset_id=shared_fieldset.id,
+        order=0,
+    )
+    db_fieldset_2 = kickoff.fieldsets.get(
+        shared_fieldset_id=shared_fieldset.id,
+        order=1,
+    )
+    assert db_fieldset_1.api_name != db_fieldset_2.api_name
+
+
+def test_update__replace_kickoff_fieldset__ok(
     mocker,
     api_client,
 ):
@@ -437,7 +534,7 @@ def test_update__kickoff_replace_fieldset__ok(
     ).count() == 1
 
 
-def test_update__kickoff_remove_fieldset__ok(
+def test_update__remove_kickoff_fieldset__ok(
     mocker,
     api_client,
 ):
@@ -514,6 +611,248 @@ def test_update__kickoff_remove_fieldset__ok(
     assert response.data['kickoff']['fieldsets'] == []
     assert not kickoff.fieldsets.filter(id=fieldset.id).exists()
 
+
+@pytest.mark.parametrize('is_active', (True, False))
+def test_update__update_kickoff__fieldset_all_fields__ok(
+    mocker,
+    is_active,
+    api_client,
+):
+    # arrange
+    account = create_test_account()
+    user = create_test_owner(account=account)
+    template = create_test_template(user, is_active=is_active, tasks_count=1)
+    kickoff = template.kickoff_instance
+    task = template.tasks.first()
+    shared_fieldset = create_test_shared_fieldset(account=account)
+    fieldset = create_test_fieldset_template(
+        account=account,
+        template=template,
+        kickoff=kickoff,
+        shared_fieldset=shared_fieldset,
+        order=0,
+        title='Old title',
+        description='Old desc',
+        api_name='fs-kickoff-update',
+    )
+    fieldset_id = fieldset.id
+    new_order = 2
+    new_title = 'New title'
+    new_description = 'New desc'
+    mocker.patch(
+        'src.processes.services.templates.'
+        'integrations.TemplateIntegrationsService.'
+        'create_integrations_for_template',
+    )
+    mocker.patch(
+        'src.processes.services.templates.'
+        'integrations.TemplateIntegrationsService.template_updated',
+    )
+    mocker.patch(
+        'src.processes.views.template.AnalyticService.templates_updated',
+    )
+    mocker.patch(
+        'src.processes.views.template.'
+        'AnalyticService.templates_kickoff_updated',
+    )
+    api_client.token_authenticate(user)
+
+    # act
+    response = api_client.put(
+        path=f'/templates/{template.id}',
+        data={
+            'id': template.id,
+            'is_active': is_active,
+            'name': 'Updated template',
+            'owners': [
+                {
+                    'type': OwnerType.USER,
+                    'source_id': user.id,
+                    'role': OwnerRole.OWNER,
+                },
+            ],
+            'kickoff': {
+                'id': kickoff.id,
+                'fieldsets': [
+                    {
+                        'shared_fieldset_id': shared_fieldset.id,
+                        'api_name': fieldset.api_name,
+                        'order': new_order,
+                        'title': new_title,
+                        'description': new_description,
+                    },
+                ],
+            },
+            'tasks': [
+                {
+                    'id': task.id,
+                    'api_name': task.api_name,
+                    'number': task.number,
+                    'name': task.name,
+                    'raw_performers': [
+                        {
+                            'type': PerformerType.USER,
+                            'source_id': user.id,
+                        },
+                    ],
+                },
+            ],
+        },
+    )
+
+    # assert
+    assert response.status_code == 200
+    fieldsets = response.data['kickoff']['fieldsets']
+    assert len(fieldsets) == 1
+    kickoff_fieldset_1 = fieldsets[0]
+    assert kickoff_fieldset_1['api_name'] == fieldset.api_name
+    assert kickoff_fieldset_1['order'] == new_order
+    assert kickoff_fieldset_1['title'] == new_title
+    assert kickoff_fieldset_1['description'] == new_description
+    assert kickoff_fieldset_1['name'] == fieldset.name
+    assert kickoff_fieldset_1['layout'] == fieldset.layout
+    assert kickoff_fieldset_1['label_position'] == fieldset.label_position
+    if is_active:
+        fieldset.refresh_from_db()
+        assert fieldset.id == fieldset_id
+        assert fieldset.api_name == 'fs-kickoff-update'
+        assert fieldset.order == new_order
+        assert fieldset.title == new_title
+        assert fieldset.description == new_description
+        assert fieldset.name == shared_fieldset.name
+        assert fieldset.layout == shared_fieldset.layout
+        assert fieldset.label_position == shared_fieldset.label_position
+
+
+@pytest.mark.parametrize('is_active', (True, False))
+def test_update_kickoff_update_template__not_change_fieldset(
+    mocker,
+    is_active,
+    api_client,
+):
+
+    # arrange
+    account = create_test_account()
+    user = create_test_owner(account=account)
+    template = create_test_template(user, is_active=is_active, tasks_count=1)
+    kickoff = template.kickoff_instance
+    task = template.tasks.first()
+    shared_fieldset = create_test_shared_fieldset(account=account)
+    shared_field = shared_fieldset.fields.first()
+    shared_field.type = FieldType.RADIO
+    shared_field.save(update_fields=['type'])
+    FieldTemplateSelection.objects.create(
+        value='Option 1',
+        field_template=shared_field,
+        template=template,
+        api_name=f'{shared_field.api_name}-shared-selection-1',
+    )
+    fieldset = create_test_fieldset_template(
+        account=account,
+        template=template,
+        kickoff=kickoff,
+        shared_fieldset=shared_fieldset,
+        order=0,
+        title='Old title',
+        api_name='fs-kickoff-fields',
+    )
+    field = fieldset.fields.first()
+    selection = field.selections.all().first()
+
+    new_title = 'New title'
+    mocker.patch(
+        'src.processes.services.templates.'
+        'integrations.TemplateIntegrationsService.'
+        'create_integrations_for_template',
+    )
+    mocker.patch(
+        'src.processes.services.templates.'
+        'integrations.TemplateIntegrationsService.template_updated',
+    )
+    mocker.patch(
+        'src.processes.views.template.AnalyticService.templates_updated',
+    )
+    mocker.patch(
+        'src.processes.views.template.'
+        'AnalyticService.templates_kickoff_updated',
+    )
+    api_client.token_authenticate(user)
+
+    # act
+    response = api_client.put(
+        path=f'/templates/{template.id}',
+        data={
+            'id': template.id,
+            'is_active': is_active,
+            'name': 'Updated template',
+            'owners': [
+                {
+                    'type': OwnerType.USER,
+                    'source_id': user.id,
+                    'role': OwnerRole.OWNER,
+                },
+            ],
+            'kickoff': {
+                'id': kickoff.id,
+                'fieldsets': [
+                    {
+                        'shared_fieldset_id': shared_fieldset.id,
+                        'api_name': fieldset.api_name,
+                        'order': fieldset.order,
+                        'title': new_title,
+                        'description': fieldset.description,
+                        'fields': [
+                            {
+                                'name': field.name,
+                                'api_name': field.api_name,
+                                'type': field.type,
+                                'order': field.order,
+                                'selections': [
+                                    {
+                                        'value': selection.value,
+                                        'api_name': selection.api_name,
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+            'tasks': [
+                {
+                    'id': task.id,
+                    'api_name': task.api_name,
+                    'number': task.number,
+                    'name': task.name,
+                    'raw_performers': [
+                        {
+                            'type': PerformerType.USER,
+                            'source_id': user.id,
+                        },
+                    ],
+                },
+            ],
+        },
+    )
+
+    # assert
+    assert response.status_code == 200
+    fieldsets = response.data['kickoff']['fieldsets']
+    assert len(fieldsets) == 1
+
+    kickoff_fieldset_1 = fieldsets[0]
+    assert kickoff_fieldset_1['api_name'] == fieldset.api_name
+    assert kickoff_fieldset_1['title'] == new_title
+
+    fields = kickoff_fieldset_1['fields']
+    assert len(fields) == 1
+    field_1 = fields[0]
+    assert field_1['api_name'] == field.api_name
+
+    selections = field_1['selections']
+    assert len(selections) == 1
+    selection_1 = selections[0]
+    assert selection_1['api_name'] == selection.api_name
 
 # Task fieldsets
 
@@ -647,7 +986,7 @@ def test_update__create_task_fieldset_only_required_data__ok(
     assert rule_data['fields'] == [field.api_name]
 
 
-def test_update__task_fieldset_all_fieldset_data__ok(
+def test_update__create_task_fieldset_all_fieldset_data__ok(
     mocker,
     api_client,
 ):
@@ -749,7 +1088,7 @@ def test_update__task_fieldset_all_fieldset_data__ok(
     assert fieldset_data['fields'] == []
 
 
-def test_update__task_create_two_fieldsets__ok(
+def test_update__create_task_two_fieldsets__ok(
     mocker,
     api_client,
 ):
@@ -841,7 +1180,101 @@ def test_update__task_create_two_fieldsets__ok(
     ).count() == 1
 
 
-def test_update__task_replace_fieldset__ok(
+def test_update__create_task_two_similar_fieldsets__ok(
+    mocker,
+    api_client,
+):
+
+    # arrange
+    account = create_test_account()
+    user = create_test_owner(account=account)
+    template = create_test_template(user, is_active=True, tasks_count=1)
+    task = template.tasks.first()
+    kickoff = template.kickoff_instance
+    shared_fieldset = create_test_shared_fieldset(account=account)
+    mocker.patch(
+        'src.processes.services.templates.'
+        'integrations.TemplateIntegrationsService.'
+        'create_integrations_for_template',
+    )
+    mocker.patch(
+        'src.processes.services.templates.'
+        'integrations.TemplateIntegrationsService.template_updated',
+    )
+    mocker.patch(
+        'src.processes.views.template.AnalyticService.templates_updated',
+    )
+    mocker.patch(
+        'src.processes.views.template.'
+        'AnalyticService.templates_kickoff_updated',
+    )
+    api_client.token_authenticate(user)
+
+    # act
+    response = api_client.put(
+        path=f'/templates/{template.id}',
+        data={
+            'id': template.id,
+            'is_active': True,
+            'name': 'Updated template',
+            'owners': [
+                {
+                    'type': OwnerType.USER,
+                    'source_id': user.id,
+                    'role': OwnerRole.OWNER,
+                },
+            ],
+            'kickoff': {
+                'id': kickoff.id,
+            },
+            'tasks': [
+                {
+                    'id': task.id,
+                    'api_name': task.api_name,
+                    'number': task.number,
+                    'name': task.name,
+                    'raw_performers': [
+                        {
+                            'type': PerformerType.USER,
+                            'source_id': user.id,
+                        },
+                    ],
+                    'fieldsets': [
+                        {
+                            'shared_fieldset_id': shared_fieldset.id,
+                            'order': 0,
+                        },
+                        {
+                            'shared_fieldset_id': shared_fieldset.id,
+                            'order': 1,
+                        },
+                    ],
+                },
+            ],
+        },
+    )
+
+    # assert
+    assert response.status_code == 200
+    fieldsets = response.data['tasks'][0]['fieldsets']
+    assert len(fieldsets) == 2
+    task_fieldset_1 = fieldsets[0]
+    task_fieldset_2 = fieldsets[1]
+    assert task_fieldset_1['shared_fieldset_id'] == shared_fieldset.id
+    assert task_fieldset_2['shared_fieldset_id'] == shared_fieldset.id
+    assert task_fieldset_1['api_name'] != task_fieldset_2['api_name']
+    db_fieldset_1 = task.fieldsets.get(
+        shared_fieldset_id=shared_fieldset.id,
+        order=0,
+    )
+    db_fieldset_2 = task.fieldsets.get(
+        shared_fieldset_id=shared_fieldset.id,
+        order=1,
+    )
+    assert db_fieldset_1.api_name != db_fieldset_2.api_name
+
+
+def test_update__replace_task_fieldset__ok(
     mocker,
     api_client,
 ):
@@ -933,7 +1366,7 @@ def test_update__task_replace_fieldset__ok(
     ).count() == 1
 
 
-def test_update__tasks_remove_fieldset__ok(
+def test_update__remove_tasks_fieldset__ok(
     mocker,
     api_client,
 ):
@@ -1081,3 +1514,565 @@ def test_update__task_with_empty_fieldsets__no_create_fieldsets(
     # assert
     assert response.status_code == 200
     assert task.fieldsets.count() == 0
+
+
+@pytest.mark.parametrize('is_active', (True, False))
+def test_update__update_task__fieldset_all_fields__ok(
+    mocker,
+    is_active,
+    api_client,
+):
+    # arrange
+    account = create_test_account()
+    user = create_test_owner(account=account)
+    template = create_test_template(user, is_active=is_active, tasks_count=1)
+    kickoff = template.kickoff_instance
+    task = template.tasks.get(number=1)
+    shared_fieldset = create_test_shared_fieldset(account=account)
+    fieldset = create_test_fieldset_template(
+        account=account,
+        template=template,
+        task=task,
+        shared_fieldset=shared_fieldset,
+        order=0,
+        title='Old title',
+        description='Old desc',
+        api_name='fs-task-update',
+    )
+    fieldset_id = fieldset.id
+    new_order = 2
+    new_title = 'New title'
+    new_description = 'New desc'
+    mocker.patch(
+        'src.processes.services.templates.'
+        'integrations.TemplateIntegrationsService.'
+        'create_integrations_for_template',
+    )
+    mocker.patch(
+        'src.processes.services.templates.'
+        'integrations.TemplateIntegrationsService.template_updated',
+    )
+    mocker.patch(
+        'src.processes.views.template.AnalyticService.templates_updated',
+    )
+    mocker.patch(
+        'src.processes.views.template.'
+        'AnalyticService.templates_kickoff_updated',
+    )
+    api_client.token_authenticate(user)
+
+    # act
+    response = api_client.put(
+        path=f'/templates/{template.id}',
+        data={
+            'id': template.id,
+            'is_active': is_active,
+            'name': 'Updated template',
+            'owners': [
+                {
+                    'type': OwnerType.USER,
+                    'source_id': user.id,
+                    'role': OwnerRole.OWNER,
+                },
+            ],
+            'kickoff': {
+                'id': kickoff.id,
+            },
+            'tasks': [
+                {
+                    'id': task.id,
+                    'api_name': task.api_name,
+                    'number': task.number,
+                    'name': task.name,
+                    'raw_performers': [
+                        {
+                            'type': PerformerType.USER,
+                            'source_id': user.id,
+                        },
+                    ],
+                    'fieldsets': [
+                        {
+                            'shared_fieldset_id': shared_fieldset.id,
+                            'api_name': fieldset.api_name,
+                            'order': new_order,
+                            'title': new_title,
+                            'description': new_description,
+                        },
+                    ],
+                },
+            ],
+        },
+    )
+
+    # assert
+    assert response.status_code == 200
+    fieldsets = response.data['tasks'][0]['fieldsets']
+    assert len(fieldsets) == 1
+    task_fieldset_1 = fieldsets[0]
+    assert task_fieldset_1['api_name'] == fieldset.api_name
+    assert task_fieldset_1['order'] == new_order
+    assert task_fieldset_1['title'] == new_title
+    assert task_fieldset_1['description'] == new_description
+    assert task_fieldset_1['name'] == fieldset.name
+    assert task_fieldset_1['layout'] == fieldset.layout
+    assert task_fieldset_1['label_position'] == fieldset.label_position
+    if is_active:
+        fieldset.refresh_from_db()
+        assert fieldset.id == fieldset_id
+        assert fieldset.api_name == 'fs-task-update'
+        assert fieldset.order == new_order
+        assert fieldset.title == new_title
+        assert fieldset.description == new_description
+        assert fieldset.name == shared_fieldset.name
+        assert fieldset.layout == shared_fieldset.layout
+        assert fieldset.label_position == shared_fieldset.label_position
+
+
+@pytest.mark.parametrize('is_active', (True, False))
+def test_update__update_task_fieldset_all_fields__ok(
+    mocker,
+    is_active,
+    api_client,
+):
+    # arrange
+    account = create_test_account()
+    user = create_test_owner(account=account)
+    template = create_test_template(user, is_active=is_active, tasks_count=1)
+    kickoff = template.kickoff_instance
+    task = template.tasks.get(number=1)
+    shared_fieldset = create_test_shared_fieldset(account=account)
+    fieldset = create_test_fieldset_template(
+        account=account,
+        template=template,
+        task=task,
+        shared_fieldset=shared_fieldset,
+        order=0,
+        title='Old title',
+        description='Old desc',
+        api_name='fs-task-update',
+    )
+    fieldset_id = fieldset.id
+    new_order = 2
+    new_title = 'New title'
+    new_description = 'New desc'
+    mocker.patch(
+        'src.processes.services.templates.'
+        'integrations.TemplateIntegrationsService.'
+        'create_integrations_for_template',
+    )
+    mocker.patch(
+        'src.processes.services.templates.'
+        'integrations.TemplateIntegrationsService.template_updated',
+    )
+    mocker.patch(
+        'src.processes.views.template.AnalyticService.templates_updated',
+    )
+    mocker.patch(
+        'src.processes.views.template.'
+        'AnalyticService.templates_kickoff_updated',
+    )
+    api_client.token_authenticate(user)
+
+    # act
+    response = api_client.put(
+        path=f'/templates/{template.id}',
+        data={
+            'id': template.id,
+            'is_active': is_active,
+            'name': 'Updated template',
+            'owners': [
+                {
+                    'type': OwnerType.USER,
+                    'source_id': user.id,
+                    'role': OwnerRole.OWNER,
+                },
+            ],
+            'kickoff': {
+                'id': kickoff.id,
+            },
+            'tasks': [
+                {
+                    'id': task.id,
+                    'api_name': task.api_name,
+                    'number': task.number,
+                    'name': task.name,
+                    'raw_performers': [
+                        {
+                            'type': PerformerType.USER,
+                            'source_id': user.id,
+                        },
+                    ],
+                    'fieldsets': [
+                        {
+                            'shared_fieldset_id': shared_fieldset.id,
+                            'api_name': fieldset.api_name,
+                            'order': new_order,
+                            'title': new_title,
+                            'description': new_description,
+                        },
+                    ],
+                },
+            ],
+        },
+    )
+
+    # assert
+    assert response.status_code == 200
+    fieldsets = response.data['tasks'][0]['fieldsets']
+    assert len(fieldsets) == 1
+    task_fieldset_1 = fieldsets[0]
+    assert task_fieldset_1['api_name'] == fieldset.api_name
+    assert task_fieldset_1['order'] == new_order
+    assert task_fieldset_1['title'] == new_title
+    assert task_fieldset_1['description'] == new_description
+    assert task_fieldset_1['name'] == fieldset.name
+    assert task_fieldset_1['layout'] == fieldset.layout
+    assert task_fieldset_1['label_position'] == fieldset.label_position
+    if is_active:
+        fieldset.refresh_from_db()
+        assert fieldset.id == fieldset_id
+        assert fieldset.api_name == 'fs-task-update'
+        assert fieldset.order == new_order
+        assert fieldset.title == new_title
+        assert fieldset.description == new_description
+        assert fieldset.name == shared_fieldset.name
+        assert fieldset.layout == shared_fieldset.layout
+        assert fieldset.label_position == shared_fieldset.label_position
+
+
+@pytest.mark.parametrize('is_active', (True, False))
+def test_update_task_update_template__not_change_fieldset(
+    mocker,
+    is_active,
+    api_client,
+):
+
+    # arrange
+    account = create_test_account()
+    user = create_test_owner(account=account)
+    template = create_test_template(user, is_active=is_active, tasks_count=1)
+    kickoff = template.kickoff_instance
+    task = template.tasks.get(number=1)
+    shared_fieldset = create_test_shared_fieldset(account=account)
+    shared_field = shared_fieldset.fields.first()
+    shared_field.type = FieldType.RADIO
+    shared_field.save(update_fields=['type'])
+    FieldTemplateSelection.objects.create(
+        value='Option 1',
+        field_template=shared_field,
+        template=template,
+        api_name=f'{shared_field.api_name}-shared-selection-1',
+    )
+    fieldset = create_test_fieldset_template(
+        account=account,
+        template=template,
+        task=task,
+        shared_fieldset=shared_fieldset,
+        order=0,
+        title='Old title',
+        api_name='fieldset-1',
+    )
+    field = fieldset.fields.first()
+    selection = field.selections.all().first()
+
+    slz = TemplateSerializer(
+        instance=template,
+        context={
+            'user': user,
+            'account': user.account,
+        },
+    )
+    slz.initial_data = slz.data
+    slz.save_as_draft()
+
+    mocker.patch(
+        'src.processes.services.templates.'
+        'integrations.TemplateIntegrationsService.'
+        'create_integrations_for_template',
+    )
+    mocker.patch(
+        'src.processes.services.templates.'
+        'integrations.TemplateIntegrationsService.template_updated',
+    )
+    mocker.patch(
+        'src.processes.views.template.AnalyticService.templates_updated',
+    )
+    mocker.patch(
+        'src.processes.views.template.'
+        'AnalyticService.templates_kickoff_updated',
+    )
+    api_client.token_authenticate(user)
+
+    # act
+    response = api_client.put(
+        path=f'/templates/{template.id}',
+        data={
+            'id': template.id,
+            'is_active': False,
+            'name': 'Updated template',
+            'owners': [
+                {
+                    'type': OwnerType.USER,
+                    'source_id': user.id,
+                    'role': OwnerRole.OWNER,
+                },
+            ],
+            'kickoff': {
+                'id': kickoff.id,
+            },
+            'tasks': [
+                {
+                    'id': task.id,
+                    'api_name': task.api_name,
+                    'number': task.number,
+                    'name': task.name,
+                    'raw_performers': [
+                        {
+                            'type': PerformerType.USER,
+                            'source_id': user.id,
+                        },
+                    ],
+                    'fieldsets': [
+                        {
+                            'shared_fieldset_id': shared_fieldset.id,
+                            'api_name': fieldset.api_name,
+                            'order': fieldset.order,
+                            'title': fieldset.title,
+                            'description': fieldset.description,
+                            'fields': [
+                                {
+                                    'name': field.name,
+                                    'api_name': field.api_name,
+                                    'type': field.type,
+                                    'order': field.order,
+                                    'selections': [
+                                        {
+                                            'value': selection.value,
+                                            'api_name': selection.api_name,
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                    'fields': [
+                        {
+                            'name': 'New field',
+                            'api_name': 'field-123',
+                            'type': FieldType.NUMBER,
+                            'order': 2,
+                        },
+                    ],
+                },
+            ],
+        },
+    )
+
+    # assert
+    assert response.status_code == 200
+    fieldsets = response.data['tasks'][0]['fieldsets']
+    assert len(fieldsets) == 1
+
+    task_fieldset_1 = fieldsets[0]
+    assert task_fieldset_1['api_name'] == fieldset.api_name
+    assert task_fieldset_1['title'] == fieldset.title
+
+    fields = task_fieldset_1['fields']
+    assert len(fields) == 1
+    field_1 = fields[0]
+    assert field_1['api_name'] == field.api_name
+
+    selections = field_1['selections']
+    assert len(selections) == 1
+    selection_1 = selections[0]
+    assert selection_1['api_name'] == selection.api_name
+
+
+# Mixed task and kickoff
+
+
+def test_update__create_kickoff_and_task_different_fieldsets__ok(
+    mocker,
+    api_client,
+):
+
+    # arrange
+    account = create_test_account()
+    user = create_test_owner(account=account)
+    template = create_test_template(user, is_active=True, tasks_count=1)
+    kickoff = template.kickoff_instance
+    task = template.tasks.first()
+    shared_1 = create_test_shared_fieldset(account=account)
+    shared_2 = create_test_shared_fieldset(account=account)
+    mocker.patch(
+        'src.processes.services.templates.'
+        'integrations.TemplateIntegrationsService.'
+        'create_integrations_for_template',
+    )
+    mocker.patch(
+        'src.processes.services.templates.'
+        'integrations.TemplateIntegrationsService.template_updated',
+    )
+    mocker.patch(
+        'src.processes.views.template.AnalyticService.templates_updated',
+    )
+    mocker.patch(
+        'src.processes.views.template.'
+        'AnalyticService.templates_kickoff_updated',
+    )
+    api_client.token_authenticate(user)
+
+    # act
+    response = api_client.put(
+        path=f'/templates/{template.id}',
+        data={
+            'id': template.id,
+            'is_active': True,
+            'name': 'Updated template',
+            'owners': [
+                {
+                    'type': OwnerType.USER,
+                    'source_id': user.id,
+                    'role': OwnerRole.OWNER,
+                },
+            ],
+            'kickoff': {
+                'id': kickoff.id,
+                'fieldsets': [
+                    {
+                        'shared_fieldset_id': shared_1.id,
+                    },
+                ],
+            },
+            'tasks': [
+                {
+                    'id': task.id,
+                    'api_name': task.api_name,
+                    'number': task.number,
+                    'name': task.name,
+                    'raw_performers': [
+                        {
+                            'type': PerformerType.USER,
+                            'source_id': user.id,
+                        },
+                    ],
+                    'fieldsets': [
+                        {
+                            'shared_fieldset_id': shared_2.id,
+                        },
+                    ],
+                },
+            ],
+        },
+    )
+
+    # assert
+    assert response.status_code == 200
+    kickoff_fieldsets = response.data['kickoff']['fieldsets']
+    task_fieldsets = response.data['tasks'][0]['fieldsets']
+    assert len(kickoff_fieldsets) == 1
+    assert len(task_fieldsets) == 1
+    kickoff_fieldset_1 = kickoff_fieldsets[0]
+    task_fieldset_1 = task_fieldsets[0]
+    assert kickoff_fieldset_1['shared_fieldset_id'] == shared_1.id
+    assert task_fieldset_1['shared_fieldset_id'] == shared_2.id
+    assert kickoff.fieldsets.filter(
+        shared_fieldset_id=shared_1.id,
+    ).count() == 1
+    assert task.fieldsets.filter(
+        shared_fieldset_id=shared_2.id,
+    ).count() == 1
+
+
+def test_update__create_kickoff_and_task_similar_fieldsets__ok(
+    mocker,
+    api_client,
+):
+
+    # arrange
+    account = create_test_account()
+    user = create_test_owner(account=account)
+    template = create_test_template(user, is_active=True, tasks_count=1)
+    kickoff = template.kickoff_instance
+    task = template.tasks.first()
+    shared_fieldset = create_test_shared_fieldset(account=account)
+    mocker.patch(
+        'src.processes.services.templates.'
+        'integrations.TemplateIntegrationsService.'
+        'create_integrations_for_template',
+    )
+    mocker.patch(
+        'src.processes.services.templates.'
+        'integrations.TemplateIntegrationsService.template_updated',
+    )
+    mocker.patch(
+        'src.processes.views.template.AnalyticService.templates_updated',
+    )
+    mocker.patch(
+        'src.processes.views.template.'
+        'AnalyticService.templates_kickoff_updated',
+    )
+    api_client.token_authenticate(user)
+
+    # act
+    response = api_client.put(
+        path=f'/templates/{template.id}',
+        data={
+            'id': template.id,
+            'is_active': True,
+            'name': 'Updated template',
+            'owners': [
+                {
+                    'type': OwnerType.USER,
+                    'source_id': user.id,
+                    'role': OwnerRole.OWNER,
+                },
+            ],
+            'kickoff': {
+                'id': kickoff.id,
+                'fieldsets': [
+                    {
+                        'shared_fieldset_id': shared_fieldset.id,
+                    },
+                ],
+            },
+            'tasks': [
+                {
+                    'id': task.id,
+                    'api_name': task.api_name,
+                    'number': task.number,
+                    'name': task.name,
+                    'raw_performers': [
+                        {
+                            'type': PerformerType.USER,
+                            'source_id': user.id,
+                        },
+                    ],
+                    'fieldsets': [
+                        {
+                            'shared_fieldset_id': shared_fieldset.id,
+                        },
+                    ],
+                },
+            ],
+        },
+    )
+
+    # assert
+    assert response.status_code == 200
+    kickoff_fieldsets = response.data['kickoff']['fieldsets']
+    task_fieldsets = response.data['tasks'][0]['fieldsets']
+    assert len(kickoff_fieldsets) == 1
+    assert len(task_fieldsets) == 1
+    kickoff_fieldset_1 = kickoff_fieldsets[0]
+    task_fieldset_1 = task_fieldsets[0]
+    assert kickoff_fieldset_1['shared_fieldset_id'] == shared_fieldset.id
+    assert task_fieldset_1['shared_fieldset_id'] == shared_fieldset.id
+    assert kickoff_fieldset_1['api_name'] != task_fieldset_1['api_name']
+    kickoff_fieldset = kickoff.fieldsets.get(
+        shared_fieldset_id=shared_fieldset.id,
+    )
+    task_fieldset = task.fieldsets.get(
+        shared_fieldset_id=shared_fieldset.id,
+    )
+    assert kickoff_fieldset.api_name != task_fieldset.api_name


### PR DESCRIPTION
# Problem

Users can reuse the same shared field group on a template more than once — for example, the same checkbox options on kickoff twice, or the same group on kickoff and on a step. If that shared group includes choice options (checkbox, dropdown, or similar), saving the template failed with a server error. As a result, templates that legitimately need the same shared field group in several places could not be created or updated.

# Fix / Solution

When a shared fieldset is copied onto a template (create/update) or cloned, generate new unique `api_name` values not only for the fieldset, fields, and rules, but also for each field selection. This keeps selection identifiers unique within a template when the same shared fieldset is attached more than once.

# Release notes

Fixed a server error when attaching the same shared fieldset with choice options (e.g. checkbox selections) more than once to a template. Each attached copy now gets its own unique selection identifiers.

# Changes

## API

**`/templates`**

- `POST /templates` — when kickoff/task `fieldsets` attach the same shared fieldset with selections more than once, each copy gets unique selection `api_name`s (no IntegrityError)
- `PUT /templates/{id}` — same behavior when adding/replacing fieldsets from a shared source that has selections
- `POST /templates/{id}/clone` — cloning a template that inherited shared fieldsets with selections continues to produce unique selection `api_name`s

**`/fieldsets`**

- `POST /fieldsets/{id}/clone` — cloning a shared fieldset with selections regenerates selection `api_name`s (same `_replace_api_names` path)

No new endpoints, request/response schema changes, or status codes.

## Web-client

No web-client changes in this branch.

# Test cases

## API

### `POST /templates`

| Authorization | Test case | Expected result |
| --- | --- | --- |
| User token (account member with create rights) | Create an active template with one kickoff fieldset from a shared fieldset that has a checkbox field and one selection | **200**; kickoff has 1 fieldset; field type checkbox; selection value preserved; selection `api_name` present |
| User token | Create a template with **two** kickoff fieldsets both referencing the **same** shared fieldset (checkbox + one selection) | **200**; two kickoff fieldsets; both selections have value `Option A` (or configured value); `api_name` of the two selections are **different** |
| User token | Create a template with one kickoff fieldset and one task fieldset from the **same** shared fieldset with selections | **200**; both fieldsets created; selection `api_name`s differ between kickoff and task copies |
| User token | Create template with only required fields and one shared fieldset without selections | **200**; defaults for optional template fields; fieldset attached as before |
| None | `POST /templates` without authentication | **401** |
| Non-admin / insufficient plan / expired subscription (per existing template create permissions) | Authenticated user fails permission checks | **403** |
| User token | Attach `shared_fieldset_id` that is not shared / from another account on an active template | **400**; validation error on `fieldsets` (existing behavior) |

### `PUT /templates/{id}`

| Authorization | Test case | Expected result |
| --- | --- | --- |
| Template owner / user with update rights | Update template: add two kickoff fieldsets from the same shared fieldset with checkbox selections | **200**; two fieldsets; selection values match; selection `api_name`s are unique |
| Template owner | Update template: replace existing fieldsets with two copies of the same shared fieldset with selections | **200**; response reflects new fieldsets; no server error |
| Template owner | Update with only required template fields + one shared fieldset (no selections) | **200**; optional fields keep expected defaults / unchanged where not sent |
| None | `PUT /templates/{id}` without authentication | **401** |
| Authenticated user without template access / permission | Update another account’s or forbidden template | **403** or **404** per existing rules |

### `POST /fieldsets/{id}/clone`

| Authorization | Test case | Expected result |
| --- | --- | --- |
| Admin / owner | Clone a shared fieldset whose field has selections (checkbox/dropdown) | **201**; clone name has ` - clone` suffix; fields and selections copied; selection `api_name`s differ from the source |
| None | Clone without authentication | **401** |
| Non-admin | Clone as non-admin | **403** |
| Admin / owner | Clone non-existent or non-shared / other-account fieldset | **404** |

### `POST /templates/{id}/clone`

| Authorization | Test case | Expected result |
| --- | --- | --- |
| Template owner | Clone a template that already has two kickoff fieldsets from the same shared fieldset with selections | **200**; cloned template has two fieldsets; selection values preserved; all selection `api_name`s unique within the new template |
| None | Clone without authentication | **401** |

## Web-client

| Browser | Device | Authorization | Test scenario | Expected result |
| --- | --- | --- | --- | --- |
| Chrome | Desktop browser | Logged-in user with template edit rights | Open template editor → attach the same shared fieldset (with checkbox/dropdown options) twice on kickoff → save | Template saves successfully; both groups appear with the same option labels; no server error toast |
| Chrome | Desktop browser | Logged-in user | Attach the same shared fieldset with options once on kickoff and once on a task → save | Template saves; options visible in both places |
| Chrome | Desktop browser | Logged-in admin | Library → clone a shared fieldset that has choice options → open the clone | Clone opens; options present; can be attached to a template without errors |
| Chrome | Desktop browser | Logged-in user | Regression: attach two different shared fieldsets (each with options) once → save | Saves as before; no regression |
| Chrome | Desktop browser | Logged-in user | Network failure / slow save while attaching duplicated shared fieldset | Error handling unchanged vs other template save failures; retry succeeds after fix is deployed |


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix 500 error when duplicating a fieldset template containing a dropdown field
> - When cloning a fieldset, `FieldSetTemplateService._replace_api_names` now generates unique `api_name` values for each selection inside each field using `FieldTemplateSelection.api_name_prefix`, preventing the 500 error on duplication.
> - Adds test coverage for cloning fieldsets that share the same source, verifying selections get distinct `api_name` values across both kickoff and task fieldset contexts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dd5784a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->