### PR TITLE
🔧 48291 frontend [ notification ] Fix the issue link when notified in the

### DIFF
--- a/frontend/src/public/firebase/__tests__/resolveNotificationUrl.test.ts
+++ b/frontend/src/public/firebase/__tests__/resolveNotificationUrl.test.ts
@@ -1,0 +1,39 @@
+import { resolveNotificationUrl } from '../resolveNotificationUrl';
+
+describe('resolveNotificationUrl', () => {
+  const hostWithoutSlash = 'http://localhost';
+  const hostWithSlash = 'http://localhost/';
+
+  it('prefers backend-provided link', () => {
+    expect(
+      resolveNotificationUrl(
+        {
+          link: 'http://localhost/workflows/42',
+          task_id: '1',
+        },
+        hostWithoutSlash,
+      ),
+    ).toBe('http://localhost/workflows/42');
+  });
+
+  it('builds task url when link is missing and host has no trailing slash', () => {
+    expect(
+      resolveNotificationUrl({ task_id: '123' }, hostWithoutSlash),
+    ).toBe('http://localhost/tasks/123/');
+  });
+
+  it('builds task url when link is missing and host has trailing slash', () => {
+    expect(
+      resolveNotificationUrl({ task_id: '123' }, hostWithSlash),
+    ).toBe('http://localhost/tasks/123/');
+  });
+
+  it('returns null when payload has neither link nor task_id', () => {
+    expect(resolveNotificationUrl({}, hostWithoutSlash)).toBeNull();
+  });
+
+  it('returns null for empty payload', () => {
+    expect(resolveNotificationUrl(null, hostWithoutSlash)).toBeNull();
+    expect(resolveNotificationUrl(undefined, hostWithoutSlash)).toBeNull();
+  });
+});

--- a/frontend/src/public/firebase/firebase-messaging-sw.ejs
+++ b/frontend/src/public/firebase/firebase-messaging-sw.ejs
@@ -66,40 +66,64 @@ self.addEventListener('push', (e) => {
 });
 
 const messaging = firebase.messaging();
+const appHost = '<%= host %>';
+
+// Keep in sync with resolveNotificationUrl.ts
+function resolveNotificationUrl(data, host) {
+  if (!data) {
+    return null;
+  }
+
+  if (data.link) {
+    return data.link;
+  }
+
+  if (data.task_id) {
+    const normalizedHost = host.replace(/\/$/, '');
+    return `${normalizedHost}/tasks/${data.task_id}/`;
+  }
+
+  return null;
+}
 
 messaging.onBackgroundMessage(function (payload) {
   const notificationTitle = payload.data.title;
   const notificationBody = payload.data.body;
+  const url = resolveNotificationUrl(payload.data, appHost);
 
   const notificationOptions = {
     body: notificationBody,
+    data: {
+      link: url,
+    },
   };
 
-  self.addEventListener('notificationclick', function (event) {
-    const taskId = payload.data.task_id;
-    if (!taskId) {
-      return;
-    }
-
-    let url = `<%= host %>tasks/${taskId}/`;
-    event.notification.close(); // Android needs explicit close.
-    event.waitUntil(
-      clients.matchAll({ type: 'window', includeUncontrolled: true }).then((windowClients) => {
-        // Check if there is already a window/tab open with the target URL
-        for (var i = 0; i < windowClients.length; i++) {
-          var client = windowClients[i];
-          // If so, just focus it.
-          if (client.url === url && 'focus' in client) {
-            return client.focus();
-          }
-        }
-        // If not, then open the target URL in a new window/tab.
-        if (clients.openWindow) {
-          return clients.openWindow(url);
-        }
-      }),
-    );
-  });
-
   return self.registration.showNotification(notificationTitle, notificationOptions);
+});
+
+self.addEventListener('notificationclick', function (event) {
+  const url = event.notification.data && event.notification.data.link;
+
+  event.notification.close();
+
+  if (!url) {
+    return;
+  }
+
+  event.waitUntil(
+    clients.matchAll({ type: 'window', includeUncontrolled: true }).then((windowClients) => {
+      for (var i = 0; i < windowClients.length; i++) {
+        var client = windowClients[i];
+        if ('focus' in client) {
+          if ('navigate' in client) {
+            return client.navigate(url).then((navigatedClient) => navigatedClient.focus());
+          }
+          return client.focus();
+        }
+      }
+      if (clients.openWindow) {
+        return clients.openWindow(url);
+      }
+    }),
+  );
 });

--- a/frontend/src/public/firebase/resolveNotificationUrl.ts
+++ b/frontend/src/public/firebase/resolveNotificationUrl.ts
@@ -1,0 +1,29 @@
+export interface INotificationPayloadData {
+  link?: string;
+  task_id?: string;
+}
+
+/**
+ * Resolves the URL opened when a browser push notification is clicked.
+ * Prefer the backend-provided `link`; fall back to a task URL built from host + task_id.
+ * Keep in sync with firebase-messaging-sw.ejs.
+ */
+export function resolveNotificationUrl(
+  data: INotificationPayloadData | null | undefined,
+  host: string,
+): string | null {
+  if (!data) {
+    return null;
+  }
+
+  if (data.link) {
+    return data.link;
+  }
+
+  if (data.task_id) {
+    const normalizedHost = host.replace(/\/$/, '');
+    return `${normalizedHost}/tasks/${data.task_id}/`;
+  }
+
+  return null;
+}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix notification click-through URL in service worker background message handler
- Adds [`resolveNotificationUrl`](https://github.com/pneumaticapp/pneumaticworkflow/pull/300/files#diff-200249cc34885760f66290205f23b18e857d1e8e9aeebaed085d167cd1a354d8) to compute a click-through URL from either a backend-provided `data.link` or a constructed `/tasks/{task_id}/` path relative to the app host.
- Stores the resolved URL in `notification.data.link` when showing a background notification, replacing per-message registration of a `notificationclick` listener.
- Moves `notificationclick` to a single global listener that reads the URL from the notification data, navigates an existing window client if available, or opens a new window as a fallback.
- Behavioral Change: notifications without a resolvable URL no longer attempt navigation on click.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized a85b668.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->