### PR TITLE
 48413 frontend [ errors ] Fix the banner color of the fieldset error

### DIFF
--- a/frontend/src/public/api/__tests__/commonRequest.test.ts
+++ b/frontend/src/public/api/__tests__/commonRequest.test.ts
@@ -130,5 +130,15 @@ describe('error interceptor logic (unit)', () => {
     expect(error.data).toEqual({ detail: 'Some technical error from Django' });
     expect(error.status).toBe(500);
   });
+
+  it('parses JSON string into object instead of wrapping in { error } (responseType empty regression)', () => {
+    const jsonString = '{"code":"validation_error","message":"Cannot delete a fieldset template that is used in templates.","details":{}}';
+
+    const error = createApiError(jsonString, 400);
+
+    expect(error.message).toBe('Cannot delete a fieldset template that is used in templates.');
+    expect(error.status).toBe(400);
+    expect((error.data as Record<string, unknown>).code).toBe('validation_error');
+  });
 });
 

--- a/frontend/src/public/api/utils/createApiError.ts
+++ b/frontend/src/public/api/utils/createApiError.ts
@@ -1,6 +1,15 @@
 import { ApiError } from '../commonRequest';
 
 export function createApiError(responseData: unknown, status?: number): ApiError {
-  const payload = typeof responseData === 'string' ? { error: responseData } : responseData ?? {};
+  let payload: unknown;
+  if (typeof responseData === 'string') {
+    try {
+      payload = JSON.parse(responseData);
+    } catch {
+      payload = { error: responseData };
+    }
+  } else {
+    payload = responseData ?? {};
+  }
   return new ApiError('', payload, status);
 }

--- a/frontend/src/public/components/UI/Notifications/NotificationManager.tsx
+++ b/frontend/src/public/components/UI/Notifications/NotificationManager.tsx
@@ -19,31 +19,11 @@ const DEFAULT_NOTIFY: INotification = {
   customClassName: '',
 };
 
-/*
-  TODO: Refactor this to mapper outside NotificationManager
-  https://trello.com/c/E6sXxjT1/1262-handle-notification-colors-properly
-*/
-
-const alertErrorMessages = [
-  'Something Went Wrong',
-  'The transaction was declined. Please use a different card or contact your bank.',
-];
-
 class NotificationManagerCreator extends EventEmitter {
   private listNotify: INotification[] = [];
 
   public create = (notify: INotification) => {
-    if (notify.priority) {
-      if (notify.message && alertErrorMessages.includes(notify.message.toString())) {
-        this.listNotify.unshift({ ...notify, type: 'error' });
-      } else {
-        this.listNotify.unshift(notify);
-      }
-    } else if (notify.message && alertErrorMessages.includes(notify.message.toString())) {
-      this.listNotify.push({ ...notify, type: 'error' });
-    } else {
-      this.listNotify.push(notify);
-    }
+    this.listNotify.push(notify);
     this.emitChange();
   };
 

--- a/frontend/src/public/components/UI/Notifications/__tests__/NotificationManager.test.ts
+++ b/frontend/src/public/components/UI/Notifications/__tests__/NotificationManager.test.ts
@@ -1,4 +1,5 @@
 import { NotificationManager } from '../NotificationManager';
+import { INotification } from '../../../../types';
 
 describe('NotificationManager', () => {
   describe('notifyApiError', () => {
@@ -108,6 +109,61 @@ describe('NotificationManager', () => {
 
       expect(warningSpy).toHaveBeenCalledWith({ message: 'file-service.file-not-found' });
       warningSpy.mockRestore();
+    });
+  });
+
+  describe('create() preserves notification type without override', () => {
+    let changeHandler: jest.Mock;
+    let createdId: string;
+
+    beforeEach(() => {
+      changeHandler = jest.fn();
+      NotificationManager.addChangeListener(changeHandler);
+    });
+
+    afterEach(() => {
+      NotificationManager.removeChangeListener(changeHandler);
+      NotificationManager.remove({ id: createdId } as INotification);
+    });
+
+    it('preserves type=warning for "Something Went Wrong" message (alertErrorMessages regression)', () => {
+      createdId = 'test-1';
+      NotificationManager.create({
+        id: createdId,
+        type: 'warning',
+        title: null,
+        message: 'Something Went Wrong',
+        timeOut: 5000,
+        customClassName: '',
+      });
+
+      expect(changeHandler).toHaveBeenCalledTimes(1);
+      const notifications = changeHandler.mock.calls[0][0];
+      expect(notifications).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: 'test-1', type: 'warning', message: 'Something Went Wrong' }),
+        ]),
+      );
+    });
+
+    it('preserves type=warning for payment declined message (alertErrorMessages regression)', () => {
+      createdId = 'test-2';
+      NotificationManager.create({
+        id: createdId,
+        type: 'warning',
+        title: null,
+        message: 'The transaction was declined. Please use a different card or contact your bank.',
+        timeOut: 5000,
+        customClassName: '',
+      });
+
+      expect(changeHandler).toHaveBeenCalledTimes(1);
+      const notifications = changeHandler.mock.calls[0][0];
+      expect(notifications).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: 'test-2', type: 'warning' }),
+        ]),
+      );
     });
   });
 });

--- a/frontend/src/public/redux/fieldsets/__tests__/saga.test.ts
+++ b/frontend/src/public/redux/fieldsets/__tests__/saga.test.ts
@@ -38,7 +38,7 @@ jest.mock('../../../utils/history', () => ({
 }));
 
 jest.mock('../../../components/UI/Notifications', () => ({
-  NotificationManager: { warning: jest.fn() },
+  NotificationManager: { notifyApiError: jest.fn(), warning: jest.fn() },
 }));
 
 jest.mock('../../../utils/logger', () => ({

--- a/frontend/src/public/redux/fieldsets/saga.ts
+++ b/frontend/src/public/redux/fieldsets/saga.ts
@@ -73,7 +73,7 @@ export function* loadFieldsetsSaga({ payload }: ReturnType<typeof loadFieldsets>
   } catch (error) {
     if (isRequestCanceled(error)) return;
     yield put(loadFieldsetsFailed());
-    NotificationManager.warning({ message: getErrorMessage(error) });
+    NotificationManager.notifyApiError(error, { message: getErrorMessage(error) });
     logger.error('failed to load fieldsets', error);
 
     if (error?.status === 404) {
@@ -94,7 +94,7 @@ export function* loadCurrentFieldsetSaga({ payload: { id } }: PayloadAction<{ id
     if (isRequestCanceled(error)) return;
     yield put(loadCurrentFieldsetFailed());
     history.push(getFieldsetsRoute());
-    NotificationManager.warning({ message: getErrorMessage(error) });
+    NotificationManager.notifyApiError(error, { message: getErrorMessage(error) });
     logger.error('failed to load current fieldset', error);
   } finally {
     abortController.abort();
@@ -107,7 +107,7 @@ function* createFieldsetSaga({ payload }: PayloadAction<ICreateFieldsetParams>) 
     yield put(loadCurrentFieldsetSuccess(createdFieldset));
     history.push(getFieldsetDetailRoute(createdFieldset.id));
   } catch (error) {
-    NotificationManager.warning({ message: getErrorMessage(error) });
+    NotificationManager.notifyApiError(error, { message: getErrorMessage(error) });
     logger.error('failed to create fieldset', error);
   }
 }
@@ -120,7 +120,7 @@ export function* updateFieldsetSaga({ payload }: PayloadAction<IUpdateFieldsetPa
     yield put(setCurrentFieldset(updatedFieldset));
   } catch (error) {
     if (isRequestCanceled(error)) return;
-    NotificationManager.warning({ message: getErrorMessage(error) });
+    NotificationManager.notifyApiError(error, { message: getErrorMessage(error) });
     logger.error('failed to update fieldset', error);
     yield put(loadCurrentFieldset({ id: payload.id }));
   } finally {
@@ -135,7 +135,7 @@ export function* deleteFieldsetSaga({ payload: { id, onSuccess } }: PayloadActio
     onSuccess?.();
   } catch (error) {
     yield put(loadFieldsetsFailed());
-    NotificationManager.warning({ message: getErrorMessage(error) });
+    NotificationManager.notifyApiError(error, { message: getErrorMessage(error) });
     logger.error('failed to delete fieldset', error);
   }
 }
@@ -170,7 +170,7 @@ function* loadFieldsetsCatalogSaga() {
   } catch (error) {
     if (isRequestCanceled(error)) return;
     yield put(loadFieldsetsCatalogFailed());
-    NotificationManager.warning({ message: getErrorMessage(error) });
+    NotificationManager.notifyApiError(error, { message: getErrorMessage(error) });
     logger.error('failed to load fieldsets catalog', error);
   } finally {
     abortController.abort();

--- a/frontend/src/public/types/notifications.ts
+++ b/frontend/src/public/types/notifications.ts
@@ -10,7 +10,6 @@ export interface INotification {
   message: React.ReactNode | null;
   timeOut: number;
   customClassName: string;
-  priority?: boolean;
   onCancelClick?: Function;
   onClick?: Function;
   onSubmitClick?: Function;


### PR DESCRIPTION
## 1. Release notes

Fixed error notifications when deleting fieldsets: notifications now display the actual server error message with correct banner color (yellow for client errors, red for server errors).

## 2. Description (problem)

When attempting to delete a fieldset bound to a template, instead of the specific backend message ("Cannot delete a fieldset template that is used in templates."), the UI displayed:
- Text: "Oops, looks like something went wrong..." (fallback)
- Color: red (instead of yellow for 400 errors)

**Where:** Fieldsets page → delete a fieldset bound to a template → notification in the top banner.

**Root causes (three):**
1. Fieldset sagas called `NotificationManager.warning()` directly — notification type was always `warning`, ignoring HTTP status.
2. `NotificationManager.create()` contained an `alertErrorMessages` array that overrode `warning` → `error` type for texts "Something Went Wrong" and "The transaction was declined...", coloring 400 errors red.
3. `createApiError` with `responseType: 'empty'` did not parse JSON strings from response bodies — the backend message was lost, and `getErrorMessage()` returned the fallback.

## 3. Context

- Task: #48413 — fix fieldset error banner color and display real error text to the user.
- Related: bug introduced by task #45407 (incremental clone naming), which added `responseType: 'empty'` for DELETE requests.
- Page: Fieldsets (left menu → Fieldsets → detail page → Delete button).

## 4. Solution

1. **Sagas:** replaced `NotificationManager.warning()` with `NotificationManager.notifyApiError()` — banner type is now determined by HTTP status (4xx → yellow, 5xx → red).
2. **NotificationManager:** removed `alertErrorMessages` array and type-override logic in `create()` — type is no longer overridden based on message text.
3. **createApiError:** added `JSON.parse` for string responses — JSON strings (arriving with `responseType: 'empty'`) are now parsed into objects, and the backend `message` field is correctly extracted.

## 5. Implementation details

### Fieldset sagas (`saga.ts`)
- **Before:** `NotificationManager.warning({ message: getErrorMessage(error) })` — always yellow banner.
- **After:** `NotificationManager.notifyApiError(error, { message: getErrorMessage(error) })` — color by HTTP status.
- Change affects 6 catch blocks: load, loadCurrent, create, update, delete, loadCatalog.

### NotificationManager (`NotificationManager.tsx`)
- **Before:** `create()` checked `alertErrorMessages.includes(notify.message)` and overrode to `type: 'error'`.
- **After:** `create()` simply pushes `notify` without modification.
- Removed: `alertErrorMessages` array (conflicted with `notifyApiError` by overriding type based on text), `priority` logic and `priority` field from `INotification` (dead code — unused anywhere).

### createApiError (`createApiError.ts`)
- **Before:** `typeof responseData === 'string' ? { error: responseData } : responseData ?? {}` — JSON string was wrapped in `{ error: '...' }`.
- **After:** string → `JSON.parse` → if successful, use the object (extract `message`, `code`). If JSON.parse fails (HTML/text) → `{ error: responseData }` as before.

## 6. What to test

### 6.1 Preconditions

- Dev branch with backend supporting fieldsets.
- At least one fieldset bound to a template (cannot be deleted).
- At least one fieldset not bound to any template (can be deleted).

### 6.2 Positive scenarios

| Scenario | Description | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| :--- | :--- | :--- | :--- | :--- | :--- |
| **Delete unbound fieldset** | Fieldsets → select a fieldset without templates → Delete → confirm. Expected: fieldset deleted, green success banner or redirect to list. | [ ] | [ ] | [ ] | [ ] |
| **Create fieldset** | Fieldsets → Create → fill name → Save. Expected: fieldset created, redirect to detail page. | [ ] | [ ] | [ ] | [ ] |

### 6.3 Negative scenarios

| Scenario | Description | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| :--- | :--- | :--- | :--- | :--- | :--- |
| **Delete bound fieldset** | Fieldsets → select a fieldset bound to a template → Delete → confirm. Expected: **yellow** banner with text "Cannot delete a fieldset template that is used in templates." | [ ] | [ ] | [ ] | [ ] |
| **Server error 500** | Simulate (DevTools → throttle/block API). Expected: **red** banner with error message. | [ ] | [ ] | [ ] | [ ] |

### 6.4 Verification points

- **UI:** banner color — yellow for 400 errors, red for 500 errors.
- **UI:** banner text — actual server message, not "Oops, looks like something went wrong...".
- **DevTools → Network:** on DELETE fieldset error — Response body contains JSON with `message` field.

### 6.6 What was NOT tested

- Payment errors ("The transaction was declined...") — no access to payment sandbox.
- Other APIs with `responseType: 'empty'` (deleteTemplate, deleteWorkflow, etc.) — behavior is identical, fix is in the shared `createApiError` function.

## 7. Unit tests

Added/updated tests in three files:

- **`NotificationManager.test.ts`** — 2 new tests: `create()` does not override `type: 'warning'` for messages from the former `alertErrorMessages` ("Something Went Wrong", payment declined).
- **`commonRequest.test.ts`** — 1 new test: `createApiError` parses JSON string into object instead of wrapping in `{ error: ... }`.
- **`saga.test.ts`** — updated `NotificationManager` mock: added `notifyApiError`.

## 8. Commits

- `3617e5a6` — fix(fieldset errors): use notifyApiError in sagas, remove alertErrorMessages override, parse JSON for empty responseType


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix fieldset error notification banner color by using `notifyApiError` instead of `warning`
> - All six fieldset sagas now call `NotificationManager.notifyApiError(error, ...)` on failure instead of always emitting a `warning` notification, so the banner color reflects the actual error type.
> - `createApiError` now attempts `JSON.parse` on string response payloads and uses the parsed object rather than wrapping the string as `{ error: ... }`, enabling correct error type detection downstream.
> - `NotificationManager.create` no longer overrides the notification type based on message content; the provided type is preserved as-is.
> - The `priority` field is removed from `INotification` and the related insertion-order logic in `NotificationManager` is dropped.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 3617e5a. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->