### PR TITLE
48392 frontend [ workflows ] handle missing legacy outputs

### DIFF
--- a/frontend/src/public/components/Workflows/WorkflowLog/WorkflowLogEvents/WorkflowLogTaskComplete/WorkflowLogTaskComplete.tsx
+++ b/frontend/src/public/components/Workflows/WorkflowLog/WorkflowLogEvents/WorkflowLogTaskComplete/WorkflowLogTaskComplete.tsx
@@ -28,7 +28,8 @@ export function WorkflowLogTaskComplete({
   const { formatMessage } = useIntl();
 
   const renderOutputValues = () => {
-    const hasOutputValue = isArrayWithItems(currentTask?.output.filter(Boolean)) || isArrayWithItems(currentTask?.fieldsets);
+    const outputs = currentTask?.output?.filter(Boolean) ?? [];
+    const hasOutputValue = isArrayWithItems(outputs) || isArrayWithItems(currentTask?.fieldsets);
 
     if (!hasOutputValue) {
       return null;
@@ -38,7 +39,7 @@ export function WorkflowLogTaskComplete({
       <KickoffOutputs
         containerClassName={styles['outputs-container']}
         viewMode={EKickoffOutputsViewModes.Short}
-        outputs={currentTask?.output.filter(Boolean)}
+        outputs={outputs}
         fieldsets={currentTask?.fieldsets || []}
         isOnlyAttachmentsShown={isOnlyAttachmentsShown}
       />

--- a/frontend/src/public/components/Workflows/WorkflowLog/WorkflowLogEvents/WorkflowLogTaskComplete/__tests__/WorkflowLogTaskComplete.test.tsx
+++ b/frontend/src/public/components/Workflows/WorkflowLog/WorkflowLogEvents/WorkflowLogTaskComplete/__tests__/WorkflowLogTaskComplete.test.tsx
@@ -117,6 +117,21 @@ describe('WorkflowLogTaskComplete', () => {
       expect(screen.queryByTestId('kickoff-outputs')).not.toBeInTheDocument();
     });
 
+    it('does not crash when a legacy task has no output', () => {
+      const task = makeTask();
+      delete (task as Partial<IWorkflowLogTask>).output;
+
+      renderWithIntl(
+        React.createElement(WorkflowLogTaskComplete, {
+          userId: 1,
+          created: '2024-01-01',
+          currentTask: task,
+        }),
+      );
+
+      expect(screen.queryByTestId('kickoff-outputs')).not.toBeInTheDocument();
+    });
+
     it('passes both outputs and fieldsets from currentTask to KickoffOutputs', () => {
       const outputField = makeField({ apiName: 'out-1', value: 'output-val' });
       const task = makeTask({


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix crash in `WorkflowLogTaskComplete.renderOutputValues` when task `output` is undefined
When a legacy workflow task has no `output` property, `renderOutputValues` previously threw at render time. The fix adds a safe chain and fallback (`currentTask?.output?.filter(Boolean) ?? []`) so the component renders without error and skips `KickoffOutputs` unless fieldsets are present. A test case covering the missing-output scenario is added in [WorkflowLogTaskComplete.test.tsx](https://github.com/pneumaticapp/pneumaticworkflow/pull/304/files#diff-1e9aade3bdfdd0591985060ee5027e1536dd8656b85eb2e7068cdd668c6947cf).

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1aaaeea.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->