### PR TITLE
48391 frontend [ notifications ] Refill list after deletion

### DIFF
--- a/frontend/src/public/redux/notifications/__tests__/saga.test.ts
+++ b/frontend/src/public/redux/notifications/__tests__/saga.test.ts
@@ -1,4 +1,13 @@
-import { call, put, select } from 'redux-saga/effects';
+import { channel as createChannel } from 'redux-saga';
+import {
+  ActionChannelEffect,
+  ActionPattern,
+  actionChannel,
+  call,
+  put,
+  select,
+  take,
+} from 'redux-saga/effects';
 
 import { getNotifications, TGetNotificationsResponse } from '../../../api/getNotifications';
 import { removeNotificationItem as removeNotificationItemApi } from '../../../api/removeNotificationItem';
@@ -7,9 +16,11 @@ import { IStoreNotification } from '../../../types/redux';
 import { getNotificationsStore } from '../../selectors/notifications';
 import {
   changeNotificationsList,
+  ENotificationsActions,
   removeNotificationItem,
+  TRemoveNotificationItem,
 } from '../actions';
-import { handleRemoveNotification } from '../saga';
+import { handleRemoveNotification, watchRemoveNotification } from '../saga';
 
 const makeNotification = (id: number): TNotificationsListItem => ({
   id,
@@ -32,6 +43,7 @@ describe('notifications saga', () => {
   it('loads an older notification after deleting a visible notification', () => {
     const notification = makeNotification(1);
     const olderNotification = makeNotification(2);
+    const realtimeNotification = makeNotification(3);
     const saga = handleRemoveNotification(
       removeNotificationItem({ notificationId: notification.id }),
     ) as unknown as Generator<unknown, void, IStoreNotification | TGetNotificationsResponse>;
@@ -51,11 +63,27 @@ describe('notifications saga', () => {
       count: 1,
     }).value).toEqual(select(getNotificationsStore));
     expect(saga.next(makeNotificationsStore({
-      totalItemsCount: 1,
+      items: [realtimeNotification],
+      totalItemsCount: 2,
     })).value).toEqual(put(changeNotificationsList({
-      items: [olderNotification],
-      count: 1,
+      items: [realtimeNotification, olderNotification],
+      count: 2,
     })));
     expect(saga.next().done).toBe(true);
+  });
+
+  it('queues rapid notification removals', () => {
+    const action = removeNotificationItem({ notificationId: 1 });
+    const channel = createChannel<TRemoveNotificationItem>() as unknown as ActionPattern<ActionChannelEffect>;
+    const saga = watchRemoveNotification() as unknown as Generator<
+      unknown,
+      void,
+      ActionPattern<ActionChannelEffect> | TRemoveNotificationItem
+    >;
+
+    expect(saga.next().value).toEqual(actionChannel(ENotificationsActions.RemoveNotificationItem));
+    expect(saga.next(channel).value).toEqual(take(channel));
+    expect(saga.next(action).value).toEqual(call(handleRemoveNotification, action));
+    expect(saga.next().value).toEqual(take(channel));
   });
 });

--- a/frontend/src/public/redux/notifications/__tests__/saga.test.ts
+++ b/frontend/src/public/redux/notifications/__tests__/saga.test.ts
@@ -1,0 +1,61 @@
+import { call, put, select } from 'redux-saga/effects';
+
+import { getNotifications, TGetNotificationsResponse } from '../../../api/getNotifications';
+import { removeNotificationItem as removeNotificationItemApi } from '../../../api/removeNotificationItem';
+import { TNotificationsListItem } from '../../../types';
+import { IStoreNotification } from '../../../types/redux';
+import { getNotificationsStore } from '../../selectors/notifications';
+import {
+  changeNotificationsList,
+  removeNotificationItem,
+} from '../actions';
+import { handleRemoveNotification } from '../saga';
+
+const makeNotification = (id: number): TNotificationsListItem => ({
+  id,
+  status: 'read',
+} as TNotificationsListItem);
+
+const makeNotificationsStore = (
+  overrides: Partial<IStoreNotification> = {},
+): IStoreNotification => ({
+  items: [],
+  totalItemsCount: 0,
+  unreadItemsCount: 0,
+  isNotificationsListOpen: true,
+  hasNewNotifications: false,
+  isLoading: false,
+  ...overrides,
+});
+
+describe('notifications saga', () => {
+  it('loads an older notification after deleting a visible notification', () => {
+    const notification = makeNotification(1);
+    const olderNotification = makeNotification(2);
+    const saga = handleRemoveNotification(
+      removeNotificationItem({ notificationId: notification.id }),
+    ) as unknown as Generator<unknown, void, IStoreNotification | TGetNotificationsResponse>;
+
+    expect(saga.next().value).toEqual(select(getNotificationsStore));
+    expect(saga.next(makeNotificationsStore({
+      items: [notification],
+      totalItemsCount: 2,
+    })).value).toEqual(put(changeNotificationsList({ items: [], count: 1 })));
+    expect(saga.next().value).toEqual(call(removeNotificationItemApi, { notificationId: notification.id }));
+    expect(saga.next().value).toEqual(select(getNotificationsStore));
+    expect(saga.next(makeNotificationsStore({
+      totalItemsCount: 1,
+    })).value).toEqual(call(getNotifications, { offset: 0, limit: 1 }));
+    expect(saga.next({
+      results: [olderNotification],
+      count: 1,
+    }).value).toEqual(select(getNotificationsStore));
+    expect(saga.next(makeNotificationsStore({
+      totalItemsCount: 1,
+    })).value).toEqual(put(changeNotificationsList({
+      items: [olderNotification],
+      count: 1,
+    })));
+    expect(saga.next().done).toBe(true);
+  });
+});

--- a/frontend/src/public/redux/notifications/saga.ts
+++ b/frontend/src/public/redux/notifications/saga.ts
@@ -1,5 +1,3 @@
-/* eslint-disable */
-/* prettier-ignore */
 import { all, call, fork, put, select, takeEvery } from 'redux-saga/effects';
 import uniqBy from 'lodash.uniqby';
 
@@ -11,6 +9,7 @@ import { isArrayWithItems } from '../../utils/helpers';
 import { TRemoveNotificationItem } from '../actions';
 import { getNotificationsStore } from '../selectors/notifications';
 import { TNotificationsListItem } from '../../types';
+import { IStoreNotification } from '../../types/redux';
 
 import {
   ENotificationsActions,
@@ -25,7 +24,7 @@ import { getUnreadNotificationsCount } from '../../api/getUnreadNotificationsCou
 import { NotificationManager } from '../../components/UI/Notifications';
 
 function* fetchNotificationsAsRead() {
-  const { items: notificationsList, unreadItemsCount }: ReturnType<typeof getNotificationsStore> = yield select(
+  const { items: notificationsList, unreadItemsCount }: IStoreNotification = yield select(
     getNotificationsStore,
   );
   const newNotificationsIds = notificationsList.filter(({ status }) => status === 'new').map(({ id }) => id);
@@ -39,7 +38,7 @@ function* fetchNotificationsAsRead() {
 }
 
 function* markAllNotificationsAsRead() {
-  const { items: notificationsList }: ReturnType<typeof getNotificationsStore> = yield select(getNotificationsStore);
+  const { items: notificationsList }: IStoreNotification = yield select(getNotificationsStore);
 
   const normalizedNotfications: TNotificationsListItem[] = notificationsList.map((notification) => {
     return { ...notification, status: 'read' };
@@ -49,7 +48,7 @@ function* markAllNotificationsAsRead() {
 }
 
 function* fetchNotifications({ payload: { offset } = { offset: 0 } }: TLoadNotifications) {
-  const { items: currentItems }: ReturnType<typeof getNotificationsStore> = yield select(getNotificationsStore);
+  const { items: currentItems }: IStoreNotification = yield select(getNotificationsStore);
   const isEmptyList = offset === 0;
 
   try {
@@ -72,22 +71,25 @@ function* fetchNotifications({ payload: { offset } = { offset: 0 } }: TLoadNotif
   }
 }
 
-function* handleRemoveNotification({ payload: { notificationId } }: TRemoveNotificationItem) {
-  const { items, totalItemsCount, unreadItemsCount }: ReturnType<typeof getNotificationsStore> = yield select(
+export function* handleRemoveNotification({ payload: { notificationId } }: TRemoveNotificationItem) {
+  const { items, totalItemsCount, unreadItemsCount }: IStoreNotification = yield select(
     getNotificationsStore,
   );
-  const newItems = items.filter(({ id }) => id !== notificationId);
   const deletingItem = items.find(({ id }) => id === notificationId);
-  if (!deletingItem || items.length === newItems.length) {
+
+  if (!deletingItem) {
     return;
   }
 
-  const newNotificationsList = {
-    items: newItems,
-    count: totalItemsCount - 1,
-  };
+  const targetItemsCount = items.length;
+  const remainingTotalItemsCount = Math.max(0, totalItemsCount - 1);
+  const newItems = items.filter(({ id }) => id !== notificationId);
 
-  yield put(changeNotificationsList(newNotificationsList));
+  yield put(changeNotificationsList({
+    items: newItems,
+    count: remainingTotalItemsCount,
+  }));
+
   if (deletingItem.status === 'new') {
     yield put(changeUnreadNotificationsCount(Math.max(0, unreadItemsCount - 1)));
   }
@@ -97,6 +99,38 @@ function* handleRemoveNotification({ payload: { notificationId } }: TRemoveNotif
   } catch (error) {
     NotificationManager.notifyApiError(error, {
       title: 'notifications.failed-to-remove-notification',
+      message: getErrorMessage(error),
+    });
+    return;
+  }
+
+  const { items: currentItems }: IStoreNotification = yield select(getNotificationsStore);
+  const refillItemsCount = Math.min(
+    targetItemsCount - currentItems.length,
+    remainingTotalItemsCount - currentItems.length,
+  );
+
+  if (refillItemsCount <= 0) {
+    return;
+  }
+
+  try {
+    const {
+      results: olderItems,
+      count: updatedTotalItemsCount,
+    }: TGetNotificationsResponse = yield call(getNotifications, {
+      offset: currentItems.length,
+      limit: refillItemsCount,
+    });
+    const { items: latestItems }: IStoreNotification = yield select(getNotificationsStore);
+
+    yield put(changeNotificationsList({
+      items: uniqBy([...latestItems, ...olderItems], 'id'),
+      count: updatedTotalItemsCount,
+    }));
+  } catch (error) {
+    NotificationManager.notifyApiError(error, {
+      title: 'notifications.fetch-error',
       message: getErrorMessage(error),
     });
   }

--- a/frontend/src/public/redux/notifications/saga.ts
+++ b/frontend/src/public/redux/notifications/saga.ts
@@ -1,4 +1,15 @@
-import { all, call, fork, put, select, takeEvery } from 'redux-saga/effects';
+import {
+  ActionChannelEffect,
+  ActionPattern,
+  actionChannel,
+  all,
+  call,
+  fork,
+  put,
+  select,
+  take,
+  takeEvery,
+} from 'redux-saga/effects';
 import uniqBy from 'lodash.uniqby';
 
 import { getNotifications, TGetNotificationsResponse } from '../../api/getNotifications';
@@ -122,11 +133,17 @@ export function* handleRemoveNotification({ payload: { notificationId } }: TRemo
       offset: currentItems.length,
       limit: refillItemsCount,
     });
-    const { items: latestItems }: IStoreNotification = yield select(getNotificationsStore);
+    const {
+      items: latestItems,
+      totalItemsCount: latestTotalItemsCount,
+    }: IStoreNotification = yield select(getNotificationsStore);
+    const safeTotalItemsCount = latestTotalItemsCount === remainingTotalItemsCount
+      ? updatedTotalItemsCount
+      : latestTotalItemsCount;
 
     yield put(changeNotificationsList({
       items: uniqBy([...latestItems, ...olderItems], 'id'),
-      count: updatedTotalItemsCount,
+      count: safeTotalItemsCount,
     }));
   } catch (error) {
     NotificationManager.notifyApiError(error, {
@@ -154,8 +171,15 @@ export function* watchMarkNotificationsAsRead() {
   yield takeEvery(ENotificationsActions.MarkNotificationsAsRead, markAllNotificationsAsRead);
 }
 
-function* watchRemoveNotification() {
-  yield takeEvery(ENotificationsActions.RemoveNotificationItem, handleRemoveNotification);
+export function* watchRemoveNotification() {
+  const removeNotificationChannel: ActionPattern<ActionChannelEffect> = yield actionChannel(
+    ENotificationsActions.RemoveNotificationItem,
+  );
+
+  while (true) {
+    const action: TRemoveNotificationItem = yield take(removeNotificationChannel);
+    yield call(handleRemoveNotification, action);
+  }
 }
 
 function* watchChangeList() {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Refill notifications list after deletion and serialize removal actions
- `handleRemoveNotification` now optimistically removes the deleted item and updates the total and unread counts before calling the API, then fetches older notifications to fill the gap left by the removed item.
- `watchRemoveNotification` replaces `takeEvery` with an `actionChannel`-based loop, so rapid deletions are queued and processed serially instead of concurrently.
- On API failure, the saga notifies the user and stops without attempting a refill.
- New tests in [saga.test.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/305/files#diff-7ce27520acbabbf3c853488508db8706f4f7a6616a9a53df14c2407df8d0377a) cover optimistic removal, refill behavior, and action queuing.
- Behavioral Change: concurrent `RemoveNotificationItem` dispatches are now serialized; in-flight deletions no longer race.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 126b0aa.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->