### PR TITLE
48346 fix(workflows): remove unused TaskFieldException import

### DIFF
--- a/backend/src/processes/views/workflow.py
+++ b/backend/src/processes/views/workflow.py
@@ -60,7 +60,6 @@ from src.processes.services.exceptions import (
     CommentServiceException,
     WorkflowActionServiceException,
 )
-from src.processes.services.tasks.exceptions import TaskFieldException
 from src.processes.services.workflow_action import WorkflowActionService
 from src.utils.validation import raise_validation_error
 from src.webhooks.enums import HookEvent


### PR DESCRIPTION
## Problem

Jenkins build #605 fails on ruff F401 lint — unused `TaskFieldException` import in `workflow.py` after PR #299 squash merge removed the `task-complete` endpoint.

## Fix

Remove the unused import line.

## Release notes

N/A (lint fix only)

## Changes

### API
- Removed unused import `TaskFieldException` from `workflow.py`

### Web-client
N/A

## Test cases

### API
- Jenkins build passes ruff lint check

### Web-client
N/A

Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused `TaskFieldException` import from workflow view
> Removes a dead import in [workflow.py](https://github.com/pneumaticapp/pneumaticworkflow/pull/311/files#diff-22da56a1ec6b0ff63a35c77ef949cdf5be3664e0f7eb0979b3add6eed7827f9f) with no functional impact.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c76a899.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->