### PR TITLE
40893 backend [templates] Update due date and performers list according to template data when task is restarted

### DIFF
--- a/backend/src/processes/models/workflows/task.py
+++ b/backend/src/processes/models/workflows/task.py
@@ -336,7 +336,7 @@ class Task(
         if new_raw_performers:
             RawPerformer.objects.bulk_create(new_raw_performers)
         if deleted_raw_performer_api_names:
-            RawPerformer.objects.filter(
+            self.raw_performers.filter(
                 api_name__in=deleted_raw_performer_api_names,
             ).delete()
 

--- a/backend/src/processes/services/tasks/task_version.py
+++ b/backend/src/processes/services/tasks/task_version.py
@@ -578,3 +578,7 @@ class TaskUpdateVersionService(
                     is_completed=False,
                     date_completed=None,
                 )
+        elif self.instance.is_completed:
+            # Sync raw data so performers and due date are current on restart
+            self.instance.update_raw_performers_from_task_template(data)
+            self._update_raw_due_date(data=data.get('raw_due_date'))

--- a/backend/src/processes/tests/test_services/test_tasks/test_task_version_service.py
+++ b/backend/src/processes/tests/test_services/test_tasks/test_task_version_service.py
@@ -582,9 +582,11 @@ class TestTaskUpdateVersionService:
         )
 
         # assert
-        update_raw_performers_mock.assert_not_called()
+        update_raw_performers_mock.assert_called_once_with(data)
         update_performers_mock.assert_not_called()
-        update_raw_due_date_mock.assert_not_called()
+        update_raw_due_date_mock.assert_called_once_with(
+            data=data['raw_due_date'],
+        )
         set_due_date_from_template.assert_not_called()
         add_raw_performer_mock.assert_not_called()
 
@@ -681,8 +683,10 @@ class TestTaskUpdateVersionService:
         )
 
         # assert
-        update_raw_performers_mock.assert_not_called()
-        update_raw_due_date_mock.assert_not_called()
+        update_raw_performers_mock.assert_called_once_with(data)
+        update_raw_due_date_mock.assert_called_once_with(
+            data=data['raw_due_date'],
+        )
         set_due_date_from_template.assert_not_called()
         add_raw_performer_mock.assert_not_called()
 
@@ -3294,3 +3298,159 @@ def test_update_from_version__no_fieldsets__skip(mocker):
 
     # assert
     update_fieldsets_mock.assert_not_called()
+
+
+def test_update_from_version__completed_task__adds_performer__ok():
+    """
+
+    Integration: update_from_version on a completed task
+    adds new raw_performers and syncs raw_due_date from template
+    data, so they are current when the task is restarted.
+
+    """
+
+    # arrange
+    user = create_test_owner()
+    user_2 = create_test_not_admin(account=user.account)
+    workflow = create_test_workflow(
+        user=user,
+        tasks_count=2,
+        active_task_number=2,
+    )
+    task = workflow.tasks.get(number=1)
+    assert task.is_completed
+    existing_api_name = task.raw_performers.order_by(
+        'id',
+    ).values_list(
+        'api_name', flat=True,
+    ).first()
+    assert existing_api_name is not None
+    new_performer_api_name = 'raw-performer-new'
+    new_due_date_api_name = 'raw-due-date-new'
+
+    service = TaskUpdateVersionService(
+        user=user,
+        instance=task,
+        auth_type=AuthTokenType.USER,
+        is_superuser=False,
+    )
+    data = {
+        'api_name': task.api_name,
+        'name': task.name,
+        'description': task.description or '',
+        'clear_description': task.description or '',
+        'number': task.number,
+        'require_completion_by_all': False,
+        'skip_for_starter': False,
+        'revert_task': None,
+        'parents': [],
+        'raw_performers': [
+            {
+                'type': PerformerType.USER,
+                'user_id': user.id,
+                'api_name': existing_api_name,
+            },
+            {
+                'type': PerformerType.USER,
+                'user_id': user_2.id,
+                'api_name': new_performer_api_name,
+            },
+        ],
+        'raw_due_date': {
+            'api_name': new_due_date_api_name,
+            'rule': DueDateRule.AFTER_WORKFLOW_STARTED,
+            'duration': '2 00:00:00',
+            'duration_months': 0,
+            'source_id': None,
+        },
+    }
+
+    # act
+    service.update_from_version(
+        data=data,
+        version=1,
+        workflow=workflow,
+    )
+
+    # assert
+    assert task.raw_performers.count() == 2
+    assert task.raw_performers.filter(
+        api_name=new_performer_api_name,
+        user_id=user_2.id,
+    ).exists()
+
+    raw_due_date = RawDueDate.objects.get(task=task)
+    assert raw_due_date.api_name == new_due_date_api_name
+    assert raw_due_date.rule == DueDateRule.AFTER_WORKFLOW_STARTED
+    assert raw_due_date.duration == timedelta(days=2)
+
+    assert task.is_completed
+
+
+def test_update_from_version__completed_task__removes_performer__ok():
+    """
+
+    Integration: update_from_version on a completed task
+    removes orphaned raw_performers when template no longer
+    includes them.
+
+    """
+
+    # arrange
+    user = create_test_owner()
+    workflow = create_test_workflow(
+        user=user,
+        tasks_count=2,
+        active_task_number=2,
+    )
+    task = workflow.tasks.get(number=1)
+    assert task.is_completed
+    assert task.raw_performers.count() == 1
+    removed_api_name = task.raw_performers.first().api_name
+
+    service = TaskUpdateVersionService(
+        user=user,
+        instance=task,
+        auth_type=AuthTokenType.USER,
+        is_superuser=False,
+    )
+    new_api_name = 'raw-performer-replaced'
+    data = {
+        'api_name': task.api_name,
+        'name': task.name,
+        'description': task.description or '',
+        'clear_description': task.description or '',
+        'number': task.number,
+        'require_completion_by_all': False,
+        'skip_for_starter': False,
+        'revert_task': None,
+        'parents': [],
+        'raw_performers': [
+            {
+                'type': PerformerType.USER,
+                'user_id': user.id,
+                'api_name': new_api_name,
+            },
+        ],
+        'raw_due_date': None,
+    }
+
+    # act
+    service.update_from_version(
+        data=data,
+        version=1,
+        workflow=workflow,
+    )
+
+    # assert
+    assert task.raw_performers.count() == 1
+    assert not task.raw_performers.filter(
+        api_name=removed_api_name,
+    ).exists()
+    assert task.raw_performers.filter(
+        api_name=new_api_name,
+    ).exists()
+
+    assert not RawDueDate.objects.filter(task=task).exists()
+
+    assert task.is_completed


### PR DESCRIPTION
# Problem

When a workflow template is updated (e.g., performers are added/removed or due dates are changed), completed tasks don't receive these updates. If such a task is later restarted via "Return to", it runs with outdated performer lists and due dates instead of reflecting the latest template configuration.

# Fix / Solution

Added a new `elif self.instance.is_completed` branch in `TaskUpdateVersionService.update_from_version()` that syncs `raw_performers` and `raw_due_date` from the template data for completed tasks. This ensures that when a completed task is restarted, it uses the current template configuration.

Unlike the `is_pending` branch, the `is_completed` branch does **not** reset `TaskPerformer.is_completed` / `date_completed` fields, since those belong to the runtime state and should only be reset when the task actually restarts.

# Release notes

When a workflow template is updated, completed tasks now correctly receive performer and due date changes. Previously, restarting such tasks via "Return to" would use stale data.

# Changes

**API:**
- `backend/src/processes/services/tasks/task_version.py` — added `elif is_completed` branch to sync raw data

**Web-client:**
No changes.

# Test cases

**API:**

| Authorization | Test case | Expected result |
|---|---|---|
| Account owner | Template update → completed task gets new performer in raw_performers | New performer appears in task.raw_performers, task stays completed |
| Account owner | Template update → completed task has performer removed from template | Orphaned performer removed from task.raw_performers, task stays completed |
| Account owner | Template update → completed task gets new raw_due_date | raw_due_date synced with template data, task stays completed |
| Account owner | Template update → completed task, raw_due_date set to None | Previous raw_due_date deleted, task stays completed |
| Account owner | Template update → pending task (existing behavior) | raw_performers synced, TaskPerformer.is_completed reset, raw_due_date synced |
| Account owner | Template update → active task (existing behavior) | Performers updated at runtime, due date recalculated |

**Web-client:**
No changes.


Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update due date and performers when a completed task is restarted from a template
> - Adds a new branch in `TaskUpdateVersionService.update_from_version` ([task_version.py](https://github.com/pneumaticapp/pneumaticworkflow/pull/313/files#diff-a8bf6a2996986aebf8838028b99ed3643203d0e0bbcb1b7317ed4f681c9fd5d4)) to handle completed tasks, synchronizing raw performers and raw due date from template data on restart.
> - Fixes a scoping bug in `Task.update_raw_performers_from_task_template` ([task.py](https://github.com/pneumaticapp/pneumaticworkflow/pull/313/files#diff-0e6c1271b6796fca57f1a98b0224b046a202667d7165b0da96d74a4fa88a2018)) where performer deletion used a global queryset instead of `self.raw_performers`, causing unintended removal of matching performers on other tasks.
> - Risk: Completed tasks now have their performers and due dates mutated on version sync, which is new behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 406b28a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->