### PR TITLE
 48521 frontend [ fields ] Correct data typing in the checkbox field

### DIFF
--- a/frontend/src/public/components/TemplateEdit/ExtraFields/Checkbox/ExtraFieldCheckbox.tsx
+++ b/frontend/src/public/components/TemplateEdit/ExtraFields/Checkbox/ExtraFieldCheckbox.tsx
@@ -21,14 +21,9 @@ import { IWorkflowExtraFieldProps } from '..';
 import styles from '../../KickoffRedux/KickoffRedux.css';
 import fieldStyles from './ExtraFieldCheckbox.css';
 import { useState } from 'react';
+import { normalizeCheckboxValue } from '../../../../utils/fields';
 
 const DEFAULT_OPTION_INPUT_WIDTH = 120;
-
-function normalizeCheckboxValue(value: unknown): string[] {
-  if (Array.isArray(value)) return value;
-  if (typeof value === 'string' && value !== '') return value.split(', ');
-  return [];
-}
 
 export function ExtraFieldCheckbox({
   field,

--- a/frontend/src/public/components/TemplateEdit/ExtraFields/utils/ExtraFieldsHelper.ts
+++ b/frontend/src/public/components/TemplateEdit/ExtraFields/utils/ExtraFieldsHelper.ts
@@ -2,6 +2,7 @@
 import { EExtraFieldType, IExtraField, TExtraFieldValue } from '../../../../types/template';
 import { getEndOfDayTsp } from '../../../../utils/dateTime';
 import { parseMarkdownToFiles } from '../../../../utils/parseMarkdownFiles';
+import { normalizeCheckboxValue } from '../../../../utils/fields';
 
 type TFieldDispatchRecord = {
   [key in EExtraFieldType]: (field: IExtraField) => IExtraField | null;
@@ -108,7 +109,8 @@ export class ExtraFieldsHelper {
       return { ...field, value: this.getFieldValue(field.value, '', field.apiName) };
     },
     [EExtraFieldType.Checkbox]: (field: IExtraField) => {
-      return { ...field, value: this.getFieldValue(field.value, [], field.apiName) };
+      const rawValue = this.getFieldValue(field.value, [], field.apiName);
+      return { ...field, value: normalizeCheckboxValue(rawValue) };
     },
     [EExtraFieldType.Radio]: (field: IExtraField) => {
       if (!field.selections || field.selections.length === 0) {

--- a/frontend/src/public/components/Workflows/WorkflowModal/WorkflowModal.tsx
+++ b/frontend/src/public/components/Workflows/WorkflowModal/WorkflowModal.tsx
@@ -11,12 +11,13 @@ import {
   IWorkflowEditData,
   IWorkflowLogItem,
 } from '../../../types/workflow';
-import { IExtraField } from '../../../types/template';
+import { EExtraFieldType, IExtraField } from '../../../types/template';
 import { IFieldsetRuntime } from '../../../types/fieldset';
 import { Avatar } from '../../UI/Avatar';
 import { EditIcon, ModalCloseIcon } from '../../icons';
 import { EditKickoffContainer } from '../../KickoffEdit';
 import { getEditKickoff } from '../../../utils/workflows';
+import { normalizeCheckboxValue } from '../../../utils/fields';
 import { getPercent } from '../../../utils/helpers';
 import { getUserFullName } from '../../../utils/users';
 import { IntlMessages } from '../../IntlMessages';
@@ -136,7 +137,14 @@ export class WorkflowModal extends React.Component<IWorkflowModalProps, IWorkflo
   }
 
   private static getFieldsetsFromProps(props: IWorkflowModalProps): IFieldsetRuntime[] {
-    return (props.workflow?.kickoff?.fieldsets || []).map((fs) => ({ ...fs, fields: [...fs.fields] }));
+    return (props.workflow?.kickoff?.fieldsets || []).map((fs) => ({
+      ...fs,
+      fields: fs.fields.map((field) =>
+        field.type === EExtraFieldType.Checkbox
+          ? { ...field, value: normalizeCheckboxValue(field.value) }
+          : field,
+      ),
+    }));
   }
 
   public componentWillUnmount() {

--- a/frontend/src/public/components/Workflows/WorkflowsGridPage/WorkflowCard/utils/__tests__/getClonedKickoff.test.ts
+++ b/frontend/src/public/components/Workflows/WorkflowsGridPage/WorkflowCard/utils/__tests__/getClonedKickoff.test.ts
@@ -1,5 +1,6 @@
 import { IWorkflowDetailsKickoff } from '../../../../../../types/workflow';
-import { EExtraFieldType, IKickoffClient } from '../../../../../../types/template';
+import { EExtraFieldType, IKickoffClient, IFieldsetBindingClient } from '../../../../../../types/template';
+import { IFieldsetRuntime } from '../../../../../../types/fieldset';
 import { makeFieldsetRuntime } from '../../../../../../__stubs__/fieldsets.factory';
 import { makeExtraField } from '../../../../../../__stubs__/fields.factory';
 import { getClonedKickoff } from '../getClonedKickoff';
@@ -431,6 +432,131 @@ describe('getClonedKickoff', () => {
       expect(result.fields).toHaveLength(1);
       expect(result.fields[0].value).toEqual(['a', 'c']);
       expect(result.fields[0].selections).toEqual(['a', 'c', 'd']);
+    });
+
+    it('preserves fieldsets and maps their fields when present in template', () => {
+      const workflowWithFieldsets: IWorkflowDetailsKickoff = {
+        id: 5,
+        description: '',
+        output: [],
+        fieldsets: [
+          makeFieldsetRuntime({
+            apiNameBinding: 'fs-1',
+            name: 'Fieldset 1',
+            fields: [
+              makeExtraField({
+                apiName: 'fs-field-1',
+                name: 'FS Checkbox',
+                type: EExtraFieldType.Checkbox,
+                value: 'Opt1, Opt2',
+              }),
+            ],
+          }),
+        ],
+      };
+
+      const templateKickoff: IKickoffClient = {
+        description: '',
+        fields: [],
+        fieldsets: [
+          makeFieldsetRuntime({
+            apiNameBinding: 'fs-1',
+            name: 'Fieldset 1',
+            fields: [
+              makeExtraField({
+                apiName: 'fs-field-1',
+                name: 'FS Checkbox',
+                type: EExtraFieldType.Checkbox,
+                selections: ['Opt1', 'Opt2', 'Opt3'],
+              }),
+            ],
+          }) as unknown as IFieldsetBindingClient,
+        ],
+      };
+
+      const result = getClonedKickoff(workflowWithFieldsets, templateKickoff);
+
+      expect(result.fieldsets).toHaveLength(1);
+      const clonedFieldset = result.fieldsets[0] as unknown as IFieldsetRuntime;
+      expect(clonedFieldset.fields[0].value).toEqual(['Opt1', 'Opt2']);
+    });
+
+    it('handles fieldsets with missing or mismatched apiNameBinding gracefully', () => {
+      const workflowWithFieldsets: IWorkflowDetailsKickoff = {
+        id: 6,
+        description: '',
+        output: [],
+        fieldsets: [
+          makeFieldsetRuntime({
+            apiNameBinding: undefined as unknown as string,
+            name: 'Corrupted Fieldset',
+            fields: [makeExtraField({ apiName: 'f-1', value: 'val' })],
+          }),
+        ],
+      };
+
+      const templateKickoff: IKickoffClient = {
+        description: '',
+        fields: [],
+        fieldsets: [
+          makeFieldsetRuntime({
+            apiNameBinding: 'fs-valid',
+            name: 'Valid Fieldset',
+            fields: [],
+          }) as unknown as IFieldsetBindingClient,
+        ],
+      };
+
+      const result = getClonedKickoff(workflowWithFieldsets, templateKickoff);
+
+      expect(result.fieldsets).toEqual([]);
+    });
+
+    it('correctly maps raw backend fieldsets containing apiName and id', () => {
+      const workflowWithRawBackendFieldset: IWorkflowDetailsKickoff = {
+        id: 7,
+        description: '',
+        output: [],
+        fieldsets: [
+          {
+            id: 100,
+            apiName: 'raw-backend-fs',
+            name: 'Raw Backend Fieldset',
+            fields: [
+              makeExtraField({
+                apiName: 'raw-field-1',
+                name: 'Field 1',
+                type: EExtraFieldType.String,
+                value: 'backend value',
+              }),
+            ],
+          } as unknown as IFieldsetRuntime,
+        ],
+      };
+
+      const templateKickoff: IKickoffClient = {
+        description: '',
+        fields: [],
+        fieldsets: [
+          makeFieldsetRuntime({
+            apiNameBinding: 'raw-backend-fs',
+            name: 'Template Fieldset',
+            fields: [
+              makeExtraField({
+                apiName: 'raw-field-1',
+                name: 'Field 1',
+                type: EExtraFieldType.String,
+              }),
+            ],
+          }) as unknown as IFieldsetBindingClient,
+        ],
+      };
+
+      const result = getClonedKickoff(workflowWithRawBackendFieldset, templateKickoff);
+
+      expect(result.fieldsets).toHaveLength(1);
+      const clonedFieldset = result.fieldsets[0] as unknown as IFieldsetRuntime;
+      expect(clonedFieldset.fields[0].value).toBe('backend value');
     });
   });
 });

--- a/frontend/src/public/components/Workflows/WorkflowsGridPage/WorkflowCard/utils/getClonedKickoff.ts
+++ b/frontend/src/public/components/Workflows/WorkflowsGridPage/WorkflowCard/utils/getClonedKickoff.ts
@@ -5,42 +5,67 @@ import {
   IExtraField,
   IKickoffClient,
   TExtraFieldValue,
+  IFieldsetBindingClient,
 } from '../../../../../types/template';
 import { IWorkflowDetailsKickoff } from '../../../../../types/workflow';
 import { getEditKickoff } from '../../../../../utils/workflows';
 import { normalizeSelections } from '../../../../TemplateEdit/utils/normalizeSelections';
+import { normalizeCheckboxValue } from '../../../../../utils/fields';
+import { IFieldsetField } from '../../../../../types/fieldset';
+
+function normalizeKickoffFields(
+  fields: (IExtraField | IFieldsetField)[] = [],
+  templateKickoffFields: (IExtraField | IFieldsetField)[] = [],
+): IExtraField[] {
+  return fields
+    .map((field) => {
+      const templateField = templateKickoffFields.find((templateField) => templateField.apiName === field.apiName);
+      if (!templateField) {
+        return null;
+      }
+
+      return cloneFieldSelections(field as IExtraField, templateField as IExtraField);
+    })
+    .filter(Boolean) as IExtraField[];
+}
 
 export function getClonedKickoff(
   workflowKickoff: IWorkflowDetailsKickoff,
   templateKickoff: IKickoffClient,
 ): IKickoffClient {
   const kickoff = getEditKickoff(workflowKickoff);
-  const normalizedKickoffFields = kickoff.fields
-    .map((field) => {
-      const templateField = templateKickoff.fields.find((templateField) => templateField.apiName === field.apiName);
-      if (!templateField) {
+  const finalFields = normalizeKickoffFields(kickoff.fields, templateKickoff.fields);
+
+  const finalFieldsets = (kickoff.fieldsets || [])
+    .map((fieldset) => {
+      // TODO (Technical Debt): Backend workflow fieldsets contain raw properties (id, apiName),
+      // while client-side template fieldsets expect apiNameBinding.
+      // We fall back to fieldset.apiName to safely match template fieldsets.
+      const fieldsetApiName = fieldset.apiNameBinding || (fieldset as any).apiName;
+
+      const templateFieldset = (templateKickoff.fieldsets || []).find(
+        (fieldsetFromTemplate) => fieldsetFromTemplate.apiNameBinding === fieldsetApiName,
+      );
+
+      if (!templateFieldset) {
         return null;
       }
 
-      return cloneFieldSelections(field, templateField);
+      return {
+        ...fieldset,
+        fields: normalizeKickoffFields(fieldset.fields, templateFieldset.fields),
+      };
     })
-    .filter(Boolean) as IExtraField[];
+    .filter(Boolean);
 
-  const finalFields = normalizedKickoffFields.map((field) => {
-    if (field.type !== EExtraFieldType.Checkbox) {
-      return field;
-    }
-
-    if (Array.isArray(field.value)) {
-      return field;
-    }
-
-    const arrayValue = typeof field.value === 'string' && field.value !== '' ? field.value.split(', ') : [];
-
-    return { ...field, value: arrayValue as TExtraFieldValue };
-  });
-
-  return { ...kickoff, fields: finalFields };
+  // TODO (Technical Debt): IKickoffClient.fieldsets is typed as IFieldsetBindingClient[] (template editor shape),
+  // but runtime workflow execution components expect IFieldsetRuntime[] (with IExtraField[]).
+  // Cast is required until IKickoffClient type is separated/narrowed between editor and runtime contexts.
+  return {
+    ...kickoff,
+    fields: finalFields,
+    fieldsets: finalFieldsets as unknown as IFieldsetBindingClient[],
+  };
 }
 
 function cloneFieldSelections(field: IExtraField, templateField: IExtraField): IExtraField {
@@ -51,7 +76,7 @@ function cloneFieldSelections(field: IExtraField, templateField: IExtraField): I
   let normalizedValue = field.value;
 
   if (normalizedValue) {
-    const parts = Array.isArray(normalizedValue) ? normalizedValue : (normalizedValue as string).split(', ');
+    const parts = normalizeCheckboxValue(normalizedValue);
     const filtered = parts.filter((value) => templateValues.includes(value));
 
     if (field.type === EExtraFieldType.Checkbox) {

--- a/frontend/src/public/redux/workflows/saga.ts
+++ b/frontend/src/public/redux/workflows/saga.ts
@@ -128,6 +128,7 @@ import { deleteWorkflow } from '../../api/deleteWorkflow';
 import { getTemplate } from '../../api/getTemplate';
 import { getRunnableWorkflow, loadDatasetsMap } from '../../components/TemplateEdit/utils/getRunnableWorkflow';
 import { mapTemplateFieldsetsToRuntime } from '../../utils/mapTemplateFieldsetsToRuntime';
+import { IFieldsetRuntime } from '../../types/fieldset';
 import { getClonedKickoff } from '../../components/Workflows/WorkflowsGridPage/WorkflowCard/utils/getClonedKickoff';
 import { getWorkflowsCurrentPerformerCounters } from '../../api/getWorkflowsCurrentPerformerCounters';
 import { getWorkflowsStartersCounters } from '../../api/getWorkflowsStartersCounters';
@@ -617,6 +618,8 @@ export function* cloneWorkflowSaga({
       throw new Error('no template id');
     }
 
+    // TODO (Technical Debt): Backend fieldsets in TWorkflowDetailsResponse contain raw backend properties (id, apiName),
+    // which do not match the declared client runtime model IFieldsetRuntime (which expects apiNameBinding instead of apiName, and lacks id).
     const [workflowDetails, template]: [TWorkflowDetailsResponse, ITemplateResponse] = yield all([
       getWorkflow(workflowId),
       getTemplate(templateId),
@@ -645,6 +648,9 @@ export function* cloneWorkflowSaga({
         ...runnableWorkflow,
         name: `${workflowName} (Clone)`,
         kickoff,
+        // TODO (Technical Debt): Sync cloned fieldsets into loadedFieldsets for WorkflowEditPopup modal.
+        // Cast is required due to shared IKickoffClient type usage across editor & runtime contexts.
+        loadedFieldsets: (kickoff.fieldsets || []) as unknown as IFieldsetRuntime[],
       }),
     );
   } catch (error) {

--- a/frontend/src/public/types/template.ts
+++ b/frontend/src/public/types/template.ts
@@ -237,6 +237,12 @@ export interface IKickoff {
   fieldsets: IFieldsetBinding[];
 }
 
+/** 
+ * TODO (Technical Debt): IKickoffClient is currently shared between Template Editor
+ * (where fieldsets use IFieldsetBindingClient[] with template field definitions) and Workflow
+ * Runtime / Cloning (where fieldsets hold filled values using IFieldsetRuntime[]).
+ * Future refactoring should separate or narrow editor vs runtime kickoff types to avoid type casts.
+ */
 export interface IKickoffClient extends Omit<IKickoff, 'fieldsets'> {
   fieldsets: IFieldsetBindingClient[];
 }

--- a/frontend/src/public/utils/__tests__/fields.test.ts
+++ b/frontend/src/public/utils/__tests__/fields.test.ts
@@ -1,0 +1,34 @@
+import { normalizeCheckboxValue } from '../fields';
+import { TExtraFieldValue } from '../../types/template';
+
+describe('normalizeCheckboxValue', () => {
+  it('should return the same array if an array of strings is passed', () => {
+    const input = ['Option 1', 'Option 2'];
+    expect(normalizeCheckboxValue(input)).toEqual(['Option 1', 'Option 2']);
+  });
+
+  it('should split a comma-separated string into an array of strings', () => {
+    const input = 'Option 1, Option 2';
+    expect(normalizeCheckboxValue(input)).toEqual(['Option 1', 'Option 2']);
+  });
+
+  it('should return a single item array for a string with one option', () => {
+    const input = 'Option 1';
+    expect(normalizeCheckboxValue(input)).toEqual(['Option 1']);
+  });
+
+  it('should return an empty array when an empty string is passed', () => {
+    expect(normalizeCheckboxValue('')).toEqual([]);
+    expect(normalizeCheckboxValue('   ')).toEqual([]);
+  });
+
+  it('should return an empty array for null or undefined', () => {
+    expect(normalizeCheckboxValue(null)).toEqual([]);
+    expect(normalizeCheckboxValue(undefined)).toEqual([]);
+  });
+
+  it('should return an empty array for non-string non-array values', () => {
+    expect(normalizeCheckboxValue(123 as unknown as TExtraFieldValue)).toEqual([]);
+    expect(normalizeCheckboxValue({} as unknown as TExtraFieldValue)).toEqual([]);
+  });
+});

--- a/frontend/src/public/utils/__tests__/workflows.test.ts
+++ b/frontend/src/public/utils/__tests__/workflows.test.ts
@@ -4,7 +4,7 @@ import { makeFieldsetRuntime } from '../../__stubs__/fieldsets.factory';
 import { IWorkflowDetailsKickoff } from '../../types/workflow';
 
 describe('getEditKickoff', () => {
-  it('returns fieldsets as an empty array even when the source kickoff has fieldsets', () => {
+  it('preserves fieldsets and maps their fields when source kickoff has fieldsets', () => {
     const workflowKickoff: IWorkflowDetailsKickoff = {
       id: 1,
       description: 'Kickoff description',
@@ -14,7 +14,7 @@ describe('getEditKickoff', () => {
 
     const result = getEditKickoff(workflowKickoff);
 
-    expect(result.fieldsets).toEqual([]);
+    expect(result.fieldsets).toEqual([expect.objectContaining({ apiNameBinding: 'fs-1' })]);
     expect(result.description).toBe('Kickoff description');
     expect(result.fields).toEqual(
       expect.arrayContaining([expect.objectContaining({ apiName: 'f1' })]),

--- a/frontend/src/public/utils/fields.ts
+++ b/frontend/src/public/utils/fields.ts
@@ -1,0 +1,11 @@
+import { TExtraFieldValue } from '../types/template';
+
+export function normalizeCheckboxValue(value?: TExtraFieldValue): string[] {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (typeof value === 'string' && value.trim() !== '') {
+    return value.split(', ');
+  }
+  return [];
+}

--- a/frontend/src/public/utils/mappers.ts
+++ b/frontend/src/public/utils/mappers.ts
@@ -2,6 +2,7 @@ import { IExtraField, IKickoffClient } from '../types/template';
 import { isArrayWithItems } from './helpers';
 import { IRunWorkflow } from '../components/WorkflowEditPopup/types';
 import { ExtraFieldsHelper } from '../components/TemplateEdit/ExtraFields/utils/ExtraFieldsHelper';
+import { normalizeCheckboxValue } from './fields';
 import {
   getEndOfDayTsp,
   toDateString,
@@ -107,16 +108,7 @@ export const mapOutputToCompleteTask = (output: IExtraField[]): IExtraField[] =>
       };
     }
     if (item.type === 'checkbox') {
-      let checkboxValue: string[];
-      if (Array.isArray(item.value)) {
-        checkboxValue = item.value;
-      } else if (item.value) {
-        checkboxValue = (item.value as string).split(', ');
-      } else {
-        checkboxValue = [];
-      }
-
-      return { ...item, value: checkboxValue };
+      return { ...item, value: normalizeCheckboxValue(item.value) };
     }
     return item;
   });

--- a/frontend/src/public/utils/workflows.ts
+++ b/frontend/src/public/utils/workflows.ts
@@ -1,6 +1,5 @@
 import { EDashboardActivityAction, EWorkflowLogEvent, ECommentType, IWorkflowDetailsKickoff } from '../types/workflow';
-
-import { ITemplateTaskClient, IKickoffClient, IExtraField } from '../types/template';
+import { ITemplateTaskClient, IKickoffClient, IExtraField, IFieldsetBindingClient } from '../types/template';
 
 import { isArrayWithItems, deepCopy } from './helpers';
 import { ExtraFieldsHelper } from '../components/TemplateEdit/ExtraFields/utils/ExtraFieldsHelper';
@@ -57,8 +56,18 @@ export const moveWorkflowField = (a: number, b: number, arr: IExtraField[]) => {
 export const getEditKickoff = (kickoff: IWorkflowDetailsKickoff): IKickoffClient => {
   const kickoffFields = new ExtraFieldsHelper(kickoff.output).getFieldsWithValues();
   const kickoffDescritpiton = kickoff.description || '';
+  const kickoffFieldsets = (kickoff.fieldsets || []).map((fieldset) => ({
+    ...fieldset,
+    fields: new ExtraFieldsHelper(fieldset.fields).getFieldsWithValues(),
+  }));
 
-  return { description: kickoffDescritpiton, fields: kickoffFields, fieldsets: [] };
+  return {
+    description: kickoffDescritpiton,
+    fields: kickoffFields,
+    // Safe cast: workflow runtime components & API only consume field values from 'fields'.
+    // Template-only properties (rules & sharedFieldsetId) are ignored during workflow execution.
+    fieldsets: kickoffFieldsets as unknown as IFieldsetBindingClient[],
+  };
 };
 
 export const getNormalizeFieldsOrders = (fields?: IExtraField[]): IExtraField[] => {


### PR DESCRIPTION
## 1. Release notes

- **a) Checkboxes:** Fixed an error when saving/editing a workflow kickoff form if previously filled `Checkbox` field values were not modified by the user.
- **b) Fieldsets:** Fixed loss of fieldsets during workflow cloning.

---

## 2. Description (Problem)

- **a) Checkboxes:** The error occurred exclusively when previously filled checkboxes were left unchanged. In this scenario, unchanged checkbox values arrived from the backend as a single string (e.g., `'Option 1, Option 2'`) instead of an array of strings `['Option 1', 'Option 2']`, leading to a data type mismatch and form submission failure.
- **b) Fieldsets:** Fieldsets support was completely missing from the workflow cloning pipeline — fieldsets were ignored in `getClonedKickoff` utility and were not passed into `loadedFieldsets` of the workflow launch modal. During investigation, 2 key Technical Debt items were identified:
  - **Technical Debt #1 (`template.ts:241`, `getClonedKickoff.ts:61`):** The `IKickoffClient` interface is shared between Template Editor and Runtime/Run Workflow modal. In Template Editor, fieldsets use `IFieldsetBindingClient[]`, whereas in Runtime they expect `IFieldsetRuntime[]`, causing a type collision.
  - **Technical Debt #2 (`saga.ts:621`, `getClonedKickoff.ts:41`):** Raw fieldset objects in `TWorkflowDetailsResponse` contain backend properties (`id` and `apiName`), which do not match client `IFieldsetRuntime` interface expectations (which expects `apiNameBinding` and omits `id`).

---

## 3. Context

- **a) Checkboxes:**
  - **Task Issue:** #48521
  - **Location:** Workflows section (`/workflows`) → Workflow Card (`WorkflowCard`) → Workflow edit modal (`WorkflowEditPopup`) and run modal (`WorkflowRunModal`).

- **b) Fieldsets:**
  - **Task Issue:** #48521
  - **Location:** Workflows section (`/workflows`) → Workflow Card (`WorkflowCard`) → Menu button "Clone" → Workflow run modal (`WorkflowRunModal`).

---

## 4. Solution

- **a) Checkboxes:** Extracted a dedicated helper `cloneFieldSelections` into fields utility (`fields.ts`), which normalizes backend checkbox strings into arrays and filters selections against active template options.
- **b) Fieldsets:** Enabled fieldsets mapping in `getClonedKickoff`, passed cloned fieldsets to `loadedFieldsets` in `saga.ts`, implemented `fieldset.apiNameBinding || (fieldset as any).apiName` fallback for safe backend compatibility, and documented corresponding `TODO (Technical Debt)` comments in codebase.

---

## 5. What to test

### 5.1 Preconditions
- Log into the application.
- Navigate to Workflows page (`/workflows`).
- Have workflows with previously filled unchanged checkboxes and fieldsets.

### 5.2 Positive Scenarios / Test Report

| Scenario | Description (Steps & Expected Result) | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| :--- | :--- | :--- | :--- | :--- | :--- |
| **a.1) Unchanged filled checkboxes** | 1. Open edit modal (`WorkflowEditPopup`) or clone modal (`WorkflowRunModal`) for a workflow with previously filled unchanged checkboxes.<br>Expected: Workflow saves/launches without errors, checkboxes passed as valid array. | [ ] | [ ] | [ ] | [ ] |
| **a.2) Partially filled checkboxes** | 1. Verify edit/clone modal for workflow with partially selected checkbox options.<br>Expected: Selected options saved as array, unselected options omitted. | [ ] | [ ] | [ ] | [ ] |
| **a.3) Empty (unfilled) checkboxes** | 1. Verify workflow where `Checkbox` fields are left empty.<br>Expected: Form saves/clones cleanly, sending empty array `[]`. | [ ] | [ ] | [ ] | [ ] |
| **a.4) Task Revert / Return** | 1. Perform task return on a workflow with filled checkboxes.<br>Expected: Checkbox values restore correctly maintaining array format. | [ ] | [ ] | [ ] | [ ] |
| **b.1) Fieldsets cloning** | 1. Click "Clone" on a workflow containing fieldsets.<br>Expected: All fieldsets and nested fields are cloned successfully and displayed in run modal. | [ ] | [ ] | [ ] | [ ] |

### 5.3 Negative Scenarios & Edge Cases

| Scenario | Description | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| :--- | :--- | :--- | :--- | :--- | :--- |
| **a.1) Checkbox with removed template options** | If backend string contained an option that was removed from template, it gets safely filtered out during edit/clone/revert. | [ ] | [ ] | [ ] | [ ] |
| **b.1) Removed fieldset from template** | If a fieldset was removed from template, cloning an old workflow proceeds safely without console errors. | [ ] | [ ] | [ ] | [ ] |

### 5.4 API Verification
- **a) Checkboxes:** Request payload contains valid array of strings instead of unparsed string.
- **b) Fieldsets:** Request payload contains valid fieldsets structure.

### 5.5 What was NOT tested
- Locales were not tested (not affected).

---

## 6. Unit Tests

- **a) Checkboxes:** 
  - `fields.test.ts` — added unit tests for string-to-array checkbox normalization helper.
  - `workflows.test.ts` — updated workflow helper test suite.
  - `getClonedKickoff.test.ts` — verified `Checkbox` fields normalization logic.
- **b) Fieldsets:** 
  - `getClonedKickoff.test.ts` — added unit test `correctly maps raw backend fieldsets containing apiName and id`.

---

## 7. Commits

- `fix(checkbox, fieldsets): add checkbox support in separate utility and enable fieldsets in cloning`


… separate utility and enable fieldsets in cloning

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix checkbox field data typing by normalizing values to string[] across kickoff and workflow flows
> - Introduces `normalizeCheckboxValue` in [`utils/fields.ts`](https://github.com/pneumaticapp/pneumaticworkflow/pull/315/files#diff-9ac382a9ef03783bd5525eb84949616bb7f7496185fdf5c426cbf77b3285dad1) as a shared utility that converts checkbox values (strings, comma-separated strings, or arrays) to `string[]`.
> - Replaces inline checkbox normalization in `ExtraFieldCheckbox`, `mapOutputToCompleteTask`, and `ExtraFieldsHelper` with calls to the new utility.
> - Updates `getClonedKickoff` to include fieldsets in cloned kickoffs, matching them by `apiNameBinding` and normalizing their checkbox field values.
> - Updates `getEditKickoff` to preserve and map fieldsets with normalized field values instead of always returning an empty fieldsets array.
> - `WorkflowModal.getFieldsetsFromProps` and `cloneWorkflowSaga` now pass normalized fieldset data through to the run workflow modal.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f341fee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->