### PR TITLE
11894 frontend [ profile ] Validate phone and password confirmation on the profile page

### DIFF
--- a/frontend/src/public/components/Profile/ChangePassword/ChangePassword.tsx
+++ b/frontend/src/public/components/Profile/ChangePassword/ChangePassword.tsx
@@ -42,6 +42,7 @@ export function ChangePassword({ isOpen, handleCloseModal, sendChangePassword, l
           const passwordErrors = getErrorsObject(values, {
             oldPassword: validateOldPassword,
             newPassword: validateNewPassword,
+            confirmNewPassword: validateNewPassword,
           });
 
           if (oldPassword === newPassword) {

--- a/frontend/src/public/components/Profile/ChangePassword/ChangePassword.tsx
+++ b/frontend/src/public/components/Profile/ChangePassword/ChangePassword.tsx
@@ -68,6 +68,7 @@ export function ChangePassword({ isOpen, handleCloseModal, sendChangePassword, l
               fieldSize="lg"
               title={formatMessage({ id: 'user.old-password' })}
               containerClassName={styles['field']}
+              isRequired
             />
             <FormikInputField
               autoComplete="new-password"
@@ -76,6 +77,7 @@ export function ChangePassword({ isOpen, handleCloseModal, sendChangePassword, l
               fieldSize="lg"
               title={formatMessage({ id: 'user.new-password' })}
               containerClassName={styles['field']}
+              isRequired
             />
             <FormikInputField
               autoComplete="new-password"
@@ -84,6 +86,7 @@ export function ChangePassword({ isOpen, handleCloseModal, sendChangePassword, l
               fieldSize="lg"
               title={formatMessage({ id: 'user.new-password-again' })}
               containerClassName={styles['field']}
+              isRequired
             />
           </fieldset>
           <footer className={styles['change-pass__footer']}>

--- a/frontend/src/public/components/Profile/Profile.tsx
+++ b/frontend/src/public/components/Profile/Profile.tsx
@@ -277,6 +277,7 @@ export function Profile({
               fieldSize="lg"
               title={formatMessage({ id: 'user.phone' })}
               containerClassName={styles['field']}
+              isRequired
             />
           </fieldset>
 

--- a/frontend/src/public/components/Profile/Profile.tsx
+++ b/frontend/src/public/components/Profile/Profile.tsx
@@ -16,7 +16,7 @@ import { Button } from '../UI/Buttons/Button';
 import { ESettingsTabs, TPasswordFields } from '../../types/profile';
 import { TITLES } from '../../constants/titles';
 import { IUpdateUserRequest } from '../../api/editProfile';
-import { validateName, validatePhone } from '../../utils/validators';
+import { validateName } from '../../utils/validators';
 import { getErrorsObject } from '../../utils/formik/getErrorsObject';
 import { Header } from '../UI/Typeography/Header';
 import { SectionTitle } from '../UI/Typeography/SectionTitle';
@@ -31,6 +31,7 @@ import { ProfileManager } from './ProfileManager';
 import { ProfileReports } from './ProfileReports';
 import { teamFetchStarted, usersFetchStarted } from '../../redux/accounts/slice';
 import { ProfileVacationFields } from './ProfileVacationFields';
+import { validateProfilePhone } from './validators';
 
 import styles from './Profile.css';
 
@@ -218,7 +219,7 @@ export function Profile({
           const errors = getErrorsObject(values, {
             firstName: validateName,
             lastName: validateName,
-            phone: validatePhone,
+            phone: validateProfilePhone,
           });
 
           if (values.absenceStatus !== 'active' && (!values.substituteUserIds || values.substituteUserIds.length === 0)) {

--- a/frontend/src/public/components/Profile/__tests__/ChangePassword.test.tsx
+++ b/frontend/src/public/components/Profile/__tests__/ChangePassword.test.tsx
@@ -21,6 +21,10 @@ describe('ChangePassword', () => {
       </IntlProvider>,
     );
 
+    expect(screen.getByText('Old password')).toHaveClass('title_required');
+    expect(screen.getByText('New password')).toHaveClass('title_required');
+    expect(screen.getByText('New password (confirm)')).toHaveClass('title_required');
+
     userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
 
     await waitFor(() => {

--- a/frontend/src/public/components/Profile/__tests__/ChangePassword.test.tsx
+++ b/frontend/src/public/components/Profile/__tests__/ChangePassword.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { IntlProvider } from 'react-intl';
+
+import { enMessages } from '../../../lang/locales/en_US';
+import { ChangePassword } from '../ChangePassword';
+
+describe('ChangePassword', () => {
+  it('marks an empty password confirmation as invalid', async () => {
+    const sendChangePassword = jest.fn();
+
+    render(
+      <IntlProvider locale="en" messages={enMessages}>
+        <ChangePassword
+          isOpen
+          handleCloseModal={jest.fn()}
+          sendChangePassword={sendChangePassword}
+          loading={false}
+        />
+      </IntlProvider>,
+    );
+
+    userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('New password (confirm)').parentElement).toHaveTextContent(
+        'Please enter your new password',
+      );
+    });
+    expect(sendChangePassword).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/public/components/Profile/__tests__/Profile.test.tsx
+++ b/frontend/src/public/components/Profile/__tests__/Profile.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { IntlProvider } from 'react-intl';
+import { useDispatch } from 'react-redux';
+
+import { enMessages } from '../../../lang/locales/en_US';
+import { IAuthUser } from '../../../types/redux';
+import { Profile } from '../Profile';
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useDispatch: jest.fn(),
+}));
+
+jest.mock('../AvatarController', () => ({ AvatarController: () => null }));
+jest.mock('../ChangePassword', () => ({ ChangePassword: () => null }));
+jest.mock('../ProfileManager', () => ({ ProfileManager: () => null }));
+jest.mock('../ProfileReports', () => ({ ProfileReports: () => null }));
+jest.mock('../ProfileVacationFields', () => ({ ProfileVacationFields: () => null }));
+jest.mock('../../UI/Fields/Checkbox', () => ({ FormikCheckbox: () => null }));
+jest.mock('../../UI', () => ({ FormikDropdownList: () => null }));
+
+const user = {
+  id: 1,
+  email: 'user@example.com',
+  firstName: 'Test',
+  lastName: 'User',
+  phone: '',
+  loading: false,
+  isDigestSubscriber: false,
+  isTasksDigestSubscriber: false,
+  isCommentsMentionsSubscriber: false,
+  isNewTasksSubscriber: false,
+  isNewslettersSubscriber: false,
+  isSpecialOffersSubscriber: false,
+  language: 'en',
+  timezone: 'UTC',
+  dateFdw: '0',
+  dateFmt: 'MMM dd, yyy, p',
+  isAdmin: false,
+  managerId: null,
+  reportIds: [],
+} as unknown as IAuthUser;
+
+describe('Profile', () => {
+  it('does not save an empty phone number', async () => {
+    const editCurrentUser = jest.fn();
+    (useDispatch as jest.Mock).mockReturnValue(jest.fn());
+
+    render(
+      <IntlProvider locale="en" messages={enMessages}>
+        <Profile
+          user={user}
+          editCurrentUser={editCurrentUser}
+          sendChangePassword={jest.fn()}
+          onChangeTab={jest.fn()}
+          onVacationActivate={jest.fn()}
+          onVacationDeactivate={jest.fn()}
+          availableUsers={[]}
+        />
+      </IntlProvider>,
+    );
+
+    expect(screen.getByText('Phone number')).toHaveClass('title_required');
+
+    userEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Please enter your phone')).toBeInTheDocument();
+    });
+    expect(editCurrentUser).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/public/components/Profile/__tests__/validators.test.ts
+++ b/frontend/src/public/components/Profile/__tests__/validators.test.ts
@@ -1,0 +1,9 @@
+import { validateProfilePhone } from '../validators';
+
+describe('validateProfilePhone', () => {
+  it('requires a phone number and validates its format', () => {
+    expect(validateProfilePhone('')).toBe('validation.phone-number-empty');
+    expect(validateProfilePhone('123')).toBe('validation.phone-number-invalid');
+    expect(validateProfilePhone('+14155552671')).toBe('');
+  });
+});

--- a/frontend/src/public/components/Profile/validators.ts
+++ b/frontend/src/public/components/Profile/validators.ts
@@ -1,6 +1,4 @@
-/* eslint-disable */
-/* prettier-ignore */
-import { hasWhitespaces, IRule, isEmpty, validateFieldCreator } from '../../utils/validators';
+import { hasWhitespaces, IRule, isEmpty, validateFieldCreator, validatePhone } from '../../utils/validators';
 
 export const OLD_PASSWORD_RULES: IRule[] = [
   {
@@ -16,7 +14,7 @@ export const NEW_PASSWORD_RULES: IRule[] = [
   },
   {
     message: 'validation.change-password-field-too-short',
-    isInvalid: value => value.length !== 0 && value.length < 6,
+    isInvalid: (value) => value.length !== 0 && value.length < 6,
   },
   {
     message: 'validation.change-password-field-contain-spaces',
@@ -26,3 +24,5 @@ export const NEW_PASSWORD_RULES: IRule[] = [
 
 export const validateOldPassword = validateFieldCreator(OLD_PASSWORD_RULES);
 export const validateNewPassword = validateFieldCreator(NEW_PASSWORD_RULES);
+export const validateProfilePhone = (value: string) =>
+  (isEmpty(value) ? 'validation.phone-number-empty' : validatePhone(value));


### PR DESCRIPTION
### 1. Release notes

Added missing required-field validation and visual indicators to Profile and Change Password forms. Profile phone number and all password fields now reject empty values before submission.

---

### 2. Context

- **Issue:** #11894
- **App Location:** User Profile (`/profile`) and Change Password modal.
- **Related Changes:** Added profile-specific phone validation and completed the password confirmation validation map.

---

### 3. Solution & Implementation Details

* **Required profile phone:** Added a required marker to the Profile phone field.
* **Empty phone validation:** Added `validateProfilePhone` to return `validation.phone-number-empty` before applying the existing phone format validator.
* **Preserved phone format validation:** Non-empty values continue to use the shared phone validator.
* **Required password fields:** Added required markers to old password, new password, and confirmation fields.
* **Confirmation validation:** Added `confirmNewPassword` to the Formik validation map so an empty confirmation cannot be submitted.
* **Existing password rules retained:** Minimum length, whitespace, old/new equality, and new/confirmation equality checks remain in place.
* **Suppression cleanup:** Removed touched lint/format suppression comments from profile validators and fixed the underlying formatting.

---

### 4. What to Test

#### 4.1 Preconditions

1. Log in as a standard user.
2. Open the User Profile page.
3. Ensure the account supports password authentication.

#### 4.2 Positive Scenarios / Testing Report

| Scenario | Description (Steps & Expected Result) | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| :--- | :--- | :---: | :---: | :---: | :---: |
| **Required indicators** | Open Profile and Change Password.<br>**Result:** Phone, old password, new password, and confirmation display required indicators. | [ ] | [ ] | [ ] | [ ] |
| **Valid profile phone** | Enter a valid international phone number and save.<br>**Result:** Validation passes and the profile update is submitted. | [ ] | [ ] | [ ] | [ ] |
| **Valid password change** | Enter valid old/new/confirmation values with matching new passwords.<br>**Result:** The change-password request is submitted. | [ ] | [ ] | [ ] | [ ] |
| **Corrected validation** | Trigger a required error, then enter a valid value.<br>**Result:** The error clears and the form can be submitted. | [ ] | [ ] | [ ] | [ ] |

#### 4.3 Negative Scenarios & Edge Cases

| Scenario | Description (Steps & Expected Result) | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| :--- | :--- | :---: | :---: | :---: | :---: |
| **Empty phone** | Clear the phone field and submit Profile.<br>**Result:** Empty-phone validation is shown and no update request is sent. | [ ] | [ ] | [ ] | [ ] |
| **Invalid phone format** | Enter `123` and submit.<br>**Result:** Invalid phone format validation is shown. | [ ] | [ ] | [ ] | [ ] |
| **Empty old password** | Leave old password empty.<br>**Result:** Submission is blocked with a required error. | [ ] | [ ] | [ ] | [ ] |
| **Empty new password** | Leave new password empty.<br>**Result:** Submission is blocked with a required error. | [ ] | [ ] | [ ] | [ ] |
| **Empty confirmation** | Fill old/new password but leave confirmation empty.<br>**Result:** Confirmation validation blocks submission. | [ ] | [ ] | [ ] | [ ] |
| **Mismatched confirmation** | Enter different new and confirmation values.<br>**Result:** Password mismatch validation remains visible. | [ ] | [ ] | [ ] | [ ] |
| **Short or spaced password** | Enter a short new password or one containing spaces.<br>**Result:** Existing password rules block submission. | [ ] | [ ] | [ ] | [ ] |

#### 4.4 Verification Points

- **UI:** Required markers appear on all affected fields.
- **Validation:** Empty and invalid phone errors are distinct.
- **Validation:** Empty confirmation is handled before password submission.
- **Network:** Invalid forms do not send profile/password requests.
- **Console:** No Formik or uncontrolled-input warnings.

#### 4.5 API Verification

- **Profile update:** Confirm no request is sent while phone is empty or invalid; valid submissions preserve the existing request payload.
- **Change password:** Confirm no request is sent with empty required fields; valid submissions preserve old/new password payload behavior.
- No backend API contract changes are included.

#### 4.6 What Was NOT Tested

- Manual browser matrix testing remains unchecked.
- Password reset/forgot-password flows outside the authenticated profile.
- SSO-only accounts without password authentication.
- Backend password policy beyond existing frontend rules.

---

### 5. Affected Areas

| Scenario | Description | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| :--- | :--- | :---: | :---: | :---: | :---: |
| **Profile Phone** | Required marker, empty validation, and format validation. | [ ] | [ ] | [ ] | [ ] |
| **Change Password** | Required markers and old/new/confirmation validation. | [ ] | [ ] | [ ] | [ ] |
| **Profile Validators** | New profile-specific required phone validator. | [ ] | [ ] | [ ] | [ ] |

---

### 6. Unit Tests

- `Profile.test.tsx`: Verifies that an empty phone prevents profile saving.
- `ChangePassword.test.tsx`: Verifies that an empty password confirmation is invalid and prevents submission.
- `validators.test.ts`: Covers empty, invalid, and valid profile phone values.

---

### 7. Commits

- `7c3c5adc` — `11894 fix(profile): validate required fields`
- `c5c7ea2c` — `11894 fix(profile): mark required fields`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Validate phone and password confirmation fields on the profile page
- Adds `validateProfilePhone` to [validators.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/317/files#diff-f60cc3992ecb2b34d8df6a11255bc5a9c65791a44c8951e2721920018c8ccfd6), which requires a non-empty value before deferring to the existing `validatePhone` rules.
- Applies `validateProfilePhone` to the phone field in the [Profile](https://github.com/pneumaticapp/pneumaticworkflow/pull/317/files#diff-1f1b8ba041c89404674bfa4198fab01080243072fe97506f1fde0f4367b043f0) form and marks it as required.
- Adds `confirmNewPassword` to the validators map in [ChangePassword](https://github.com/pneumaticapp/pneumaticworkflow/pull/317/files#diff-424263588b808c13588ce73bc35fe8303ed13362a97a5411d714a82fcc5c1578), using the same rules as `newPassword`, and marks all three password fields as required.
- Behavioral Change: empty or invalid phone and password confirmation values now surface validation errors and block form submission.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized c5c7ea2.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->