### PR TITLE
14138 frontend [ invites ] Fix invited performer display

### DIFF
--- a/frontend/src/public/components/UI/form/UsersDropdown/UsersDropdown.css
+++ b/frontend/src/public/components/UI/form/UsersDropdown/UsersDropdown.css
@@ -5,7 +5,7 @@
   color: var(--pneumatic-color-black100);
 
   &__icon {
-    margin-right: 0.5rem;
+    margin-right: 0.8rem;
   }
 }
 

--- a/frontend/src/public/components/UI/form/UsersDropdown/UsersDropdown.css
+++ b/frontend/src/public/components/UI/form/UsersDropdown/UsersDropdown.css
@@ -5,23 +5,46 @@
   color: var(--pneumatic-color-black100);
 
   &__icon {
-    margin-right: 8px;
+    margin-right: 0.5rem;
   }
 }
 
 .user-option {
+  overflow: hidden;
+  width: 100%;
+  min-width: 0;
+
   &__content {
     display: flex;
+    overflow: hidden;
     align-items: center;
+    width: 100%;
+    min-width: 0;
+  }
 
-    p {
-      @mixin text-overflow;
+  &__label {
+    margin: 0;
+    overflow: hidden;
+    min-width: 0;
+    max-width: 24rem;
+    white-space: nowrap;
+    text-overflow: ellipsis;
 
-      margin: 0;
+    &_invited {
+      color: var(--pneumatic-color-link-hover);
     }
   }
 
   &__avatar {
     margin-right: 0.8rem;
+    flex-shrink: 0;
+  }
+
+  &__checkbox,
+  &__checkbox-label,
+  &__checkbox-title {
+    overflow: hidden;
+    width: 100%;
+    min-width: 0;
   }
 }

--- a/frontend/src/public/components/UI/form/UsersDropdown/UsersDropdown.tsx
+++ b/frontend/src/public/components/UI/form/UsersDropdown/UsersDropdown.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useState } from 'react';
+import classnames from 'classnames';
 import { useIntl } from 'react-intl';
 import { ActionMeta, FormatOptionLabelMeta } from 'react-select';
 
 import { TDropdownOptionBase, IDropdownListProps, DropdownList, Checkbox, Avatar, TAvatarUser } from '../..';
-import { TUserListItem, isUserAbsent } from '../../../../types/user';
+import { EUserStatus, TUserListItem, isUserAbsent } from '../../../../types/user';
 import { BoldPlusIcon } from '../../../icons';
 import { ETaskPerformerType } from '../../../../types/template';
 import { getUserById } from '../../../UserData/utils/getUserById';
@@ -25,6 +26,8 @@ export enum EOptionTypes {
 export type TUsersDropdownOption = TDropdownOptionBase & {
   firstName?: string;
   lastName?: string;
+  email?: string;
+  status?: EUserStatus;
   id: number;
   optionType: EOptionTypes;
 };
@@ -156,9 +159,13 @@ export function UsersDropdownComponent<TOption extends TUsersDropdownOption>({
     const renderLabel = () => {
       const currentUser: TUserListItem | TUsersDropdownOption | null =
         option.optionType !== EOptionTypes.Group ? getUserById(users, Number(option.id)) : option;
+      const isInvited = currentUser?.status === EUserStatus.Invited || option.status === EUserStatus.Invited;
+      const displayLabel = isInvited
+        ? currentUser?.email || option.email || String(option.label).replace(/\s*\(invited user\)\s*$/i, '')
+        : option.label;
 
       return (
-        <div className={styles['user-option__content']} title={option.label as string}>
+        <div className={styles['user-option__content']} title={displayLabel as string}>
           {formatOptionLabelMeta.context === 'menu' && (
             <Avatar
               size="sm"
@@ -167,8 +174,13 @@ export function UsersDropdownComponent<TOption extends TUsersDropdownOption>({
               isEmpty={option.optionType !== EOptionTypes.User && option.optionType !== EOptionTypes.Group}
             />
           )}
-          <p className={styles['user-option__label']}>
-            {option.label}
+          <p
+            className={classnames(
+              styles['user-option__label'],
+              isInvited && styles['user-option__label_invited'],
+            )}
+          >
+            {displayLabel}
             {isUserAbsent(currentUser as TUserListItem) && (
               <span className={styles['user-option__badge']}>
                 {(currentUser as TUserListItem)?.vacation?.absenceStatus === 'sick_leave' ? ' 🏥' : ' ✈️'}
@@ -189,6 +201,9 @@ export function UsersDropdownComponent<TOption extends TUsersDropdownOption>({
             }}
             title={renderLabel()}
             checked={isSelected}
+            containerClassName={styles['user-option__checkbox']}
+            labelClassName={styles['user-option__checkbox-label']}
+            titleClassName={styles['user-option__checkbox-title']}
           />
         ) : (
           renderLabel()

--- a/frontend/src/public/components/UI/form/UsersDropdown/__tests__/UsersDropdown.test.tsx
+++ b/frontend/src/public/components/UI/form/UsersDropdown/__tests__/UsersDropdown.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+
+import { enMessages } from '../../../../../lang/locales/en_US';
+import { EUserStatus } from '../../../../../types/user';
+import { EOptionTypes, UsersDropdownComponent } from '../UsersDropdown';
+
+jest.mock('../../..', () => ({
+  Avatar: () => null,
+  Checkbox: ({ title }: { title: React.ReactNode }) => <span>{title}</span>,
+  DropdownList: ({ options, formatOptionLabel }: any) => (
+    <div>
+      {options.map((option: any) => (
+        <div key={option.value}>
+          {formatOptionLabel(option, { context: 'menu', selectValue: [] })}
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+describe('UsersDropdownComponent', () => {
+  it('shows invited users without the status suffix', () => {
+    const email = 'very-long-invited-user-email@example.com';
+    const invitedUser = {
+      id: 1,
+      email,
+      firstName: '',
+      lastName: '',
+      phone: '',
+      photo: '',
+      status: EUserStatus.Invited,
+      type: 'user' as const,
+    };
+
+    render(
+      <IntlProvider locale="en" messages={enMessages}>
+        <UsersDropdownComponent
+          options={[
+            {
+              ...invitedUser,
+              optionType: EOptionTypes.User,
+              label: `${email} (invited user)`,
+              value: 'user-1',
+            },
+          ]}
+          users={[invitedUser]}
+          inviteLabel="Invite team member"
+          isTeamInvitesModalOpen={false}
+          recentInvitedUsers={[]}
+          isAdmin={false}
+          onChange={jest.fn()}
+          onClickInvite={jest.fn()}
+          openTeamInvitesPopup={jest.fn()}
+        />
+      </IntlProvider>,
+    );
+
+    expect(screen.getByText(email)).toBeInTheDocument();
+    expect(screen.queryByText(/invited user/i)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### 1. Release notes

Fixed invited-user rendering in Users dropdowns. Invited performers now display their email without the redundant “(invited user)” suffix, use the invited-state color, and truncate safely inside menu and checkbox layouts.

---

### 2. Context

- **Issue:** #14138
- **App Location:** Task Performers and all forms using `UsersDropdown`.
- **Related Changes:** Extended dropdown user options with email/status data and strengthened overflow handling for long invited-user labels.

---

### 3. Solution & Implementation Details

* **Invited-user detection:** Dropdown labels recognize invited users from either the resolved user record or option status.
* **Email-first label:** Invited users display their email instead of a generated name/status label.
* **Suffix cleanup:** Legacy “(invited user)” text is removed when email data is only available through the option label.
* **Invited-state styling:** Invited labels use the existing link-hover color token.
* **Long-label truncation:** Added width, min-width, overflow, ellipsis, and flex-shrink rules to keep long emails inside the menu.
* **Checkbox layout support:** Added dedicated container, label, and title classes so multi-select rows truncate correctly.
* **Accurate tooltip/title:** The full cleaned display label is used as the option title.
* **Option typing:** Added optional `email` and `status` fields to `TUsersDropdownOption`.

---

### 4. What to Test

#### 4.1 Preconditions

1. Log in to an account where inviting users is allowed.
2. Invite a user with a long email address but do not activate the account.
3. Open a task/template form containing `UsersDropdown`.

#### 4.2 Positive Scenarios / Testing Report

| Scenario | Description (Steps & Expected Result) | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| :--- | :--- | :---: | :---: | :---: | :---: |
| **Invited performer label** | Open the performer dropdown and locate the invited user.<br>**Result:** Only the email is shown; “(invited user)” is absent. | [ ] | [ ] | [ ] | [ ] |
| **Invited-state color** | Compare invited and active user rows.<br>**Result:** The invited email uses the configured invited/link-hover color. | [ ] | [ ] | [ ] | [ ] |
| **Long invited email** | Use an email longer than the dropdown width.<br>**Result:** The row truncates with ellipsis and does not widen the menu. | [ ] | [ ] | [ ] | [ ] |
| **Full title** | Hover the truncated invited email.<br>**Result:** The title exposes the full cleaned email value. | [ ] | [ ] | [ ] | [ ] |
| **Select invited user** | Select and deselect the invited user in a multi-select dropdown.<br>**Result:** Checkbox state and option identity remain correct. | [ ] | [ ] | [ ] | [ ] |
| **Active user display** | Inspect an active user option.<br>**Result:** Existing full-name, avatar, and absence badge rendering remains unchanged. | [ ] | [ ] | [ ] | [ ] |

#### 4.3 Negative Scenarios & Edge Cases

| Scenario | Description (Steps & Expected Result) | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| :--- | :--- | :---: | :---: | :---: | :---: |
| **Missing email property** | Render an invited option whose email exists only in the legacy label.<br>**Result:** The suffix is stripped and the remaining label is shown. | [ ] | [ ] | [ ] | [ ] |
| **Missing resolved user** | Render an invited option before the users list finishes loading.<br>**Result:** Option-level email/status data is used without crashing. | [ ] | [ ] | [ ] | [ ] |
| **Narrow mobile viewport** | Open the dropdown on a narrow screen.<br>**Result:** Avatar and checkbox remain visible and the email truncates within the row. | [ ] | [ ] | [ ] | [ ] |
| **Group option** | Inspect a group entry in the same dropdown.<br>**Result:** Group labels are not styled or treated as invited users. | [ ] | [ ] | [ ] | [ ] |

#### 4.4 Verification Points

- **UI:** Invited users display a clean email without status suffix.
- **UI:** Long labels do not cause horizontal menu overflow.
- **UI:** Active users, groups, avatars, and absence badges remain unchanged.
- **Console:** No text overflow, invalid class, or rendering warnings.

#### 4.5 API Verification

- No API request changes are included.
- Verify user data supplied to the dropdown includes `email` and invited `status` when available.
- Confirm selected option IDs and option types sent by consumers remain unchanged.

#### 4.6 What Was NOT Tested

- Manual browser matrix testing remains unchecked.
- Invitation email delivery and acceptance flow.
- Dropdown consumers that do not use `UsersDropdown`.

---

### 5. Affected Areas

| Scenario | Description | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| :--- | :--- | :---: | :---: | :---: | :---: |
| **Task Performers** | Invited performer option rendering and selection. | [ ] | [ ] | [ ] | [ ] |
| **Template User Fields** | Invited users shown through shared UsersDropdown. | [ ] | [ ] | [ ] | [ ] |
| **Multi-select Checkboxes** | Truncation and width handling for long labels. | [ ] | [ ] | [ ] | [ ] |

---

### 6. Unit Tests

- `UsersDropdown.test.tsx`: Verifies that an invited user displays the email without the status suffix and exposes the full email through the title.

---

### 7. Commits

- `e2aa711e` — `14138 fix(invites): fix invited performer display`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix invited performer display in UsersDropdown to show email without '(invited user)' suffix
> - Invited users in `UsersDropdownComponent` now display their email address instead of the raw label with the `(invited user)` suffix, with the title tooltip matching this value.
> - Applies an `_invited` modifier class to the label for invited users, rendering it in the link-hover color.
> - Updates [UsersDropdown.css](https://github.com/pneumaticapp/pneumaticworkflow/pull/318/files#diff-c4bb5a4dd4b90729b329ab1a7d875518a920511cfd4212ff13ee6b3c2a62f789) to constrain and truncate long option content with ellipsis, and adds overflow/width rules for checkbox, label, and title areas.
> - Adds a test in [UsersDropdown.test.tsx](https://github.com/pneumaticapp/pneumaticworkflow/pull/318/files#diff-650f9004150380d508f591da77ccff937df2df07cf7befea37e44bc70ec0066d) asserting the email is shown and the suffix is omitted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8f802b7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->