### PR TITLE
15964 frontend [ Logs ] Show performer label for user events only

### DIFF
--- a/frontend/src/public/components/Workflows/WorkflowLog/WorkflowLogEvents/WorkflowLogAddedPerformer/WorkflowLogAddedPerformer.tsx
+++ b/frontend/src/public/components/Workflows/WorkflowLog/WorkflowLogEvents/WorkflowLogAddedPerformer/WorkflowLogAddedPerformer.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable */
-/* prettier-ignore */
 import * as React from 'react';
 import { useIntl } from 'react-intl';
 import { IWorkflowLogItem } from '../../../../../types/workflow';
@@ -12,53 +10,42 @@ import { UserData } from '../../../../UserData';
 
 import styles from './WorkflowLogAddedPerformer.css';
 
-export interface IWorkflowLogAddedPerformerProps
-  extends Pick<IWorkflowLogItem, 'created' | 'userId' | 'targetUserId'> {}
+export interface IWorkflowLogAddedPerformerProps extends Pick<IWorkflowLogItem, 'created' | 'targetUserId'> {}
 
-export function WorkflowLogAddedPerformer({ userId, created, targetUserId }: IWorkflowLogAddedPerformerProps) {
+export function WorkflowLogAddedPerformer({ created, targetUserId }: IWorkflowLogAddedPerformerProps) {
   const { formatMessage } = useIntl();
 
   return (
-    <UserData userId={userId}>
-      {(user) => {
-        if (!user) {
-          return null;
-        }
+    <div className={styles['container']}>
+      <div className={styles['avatar']}>
+        <Avatar size="lg" sizeMobile="sm" isSystemAvatar />
+      </div>
+      <div className={styles['body']}>
+        <p className={styles['title']}>
+          <span className={styles['title__text']}>{formatMessage({ id: 'general.pneumatic' })}</span>
+          <span className={styles['title__icon']}>
+            <AddPerformerIcon />
+          </span>
+          <span className={styles['title__date']}>
+            <DateFormat date={created} />
+          </span>
+        </p>
 
-        return (
-          <div className={styles['container']}>
-            <div className={styles['avatar']}>
-              <Avatar user={user} size="lg" sizeMobile="sm" />
-            </div>
-            <div className={styles['body']}>
-              <p className={styles['title']}>
-                <span className={styles['title__text']}>{getUserFullName(user)}</span>
-                <span className={styles['title__icon']}>
-                  <AddPerformerIcon />
-                </span>
-                <span className={styles['title__date']}>
-                  <DateFormat date={created} />
-                </span>
-              </p>
+        {targetUserId && (
+          <div className={styles['text']}>
+            {formatMessage({ id: 'task.log-added-performer' })}
+            <UserData userId={targetUserId}>
+              {(user) => {
+                if (!user) {
+                  return null;
+                }
 
-              {targetUserId && (
-                <div className={styles['text']}>
-                  {formatMessage({ id: 'task.log-added-performer' })}
-                  <UserData userId={targetUserId}>
-                    {(user) => {
-                      if (!user) {
-                        return null;
-                      }
-
-                      return <span className={styles['username']}>{getUserFullName(user, { withAtSign: true })}</span>;
-                    }}
-                  </UserData>
-                </div>
-              )}
-            </div>
+                return <span className={styles['username']}>{getUserFullName(user, { withAtSign: true })}</span>;
+              }}
+            </UserData>
           </div>
-        );
-      }}
-    </UserData>
+        )}
+      </div>
+    </div>
   );
 }

--- a/frontend/src/public/components/Workflows/WorkflowLog/WorkflowLogEvents/WorkflowLogAddedPerformerGroup/WorkflowLogAddedPerformerGroup.tsx
+++ b/frontend/src/public/components/Workflows/WorkflowLog/WorkflowLogEvents/WorkflowLogAddedPerformerGroup/WorkflowLogAddedPerformerGroup.tsx
@@ -3,58 +3,45 @@ import { useIntl } from 'react-intl';
 import { IWorkflowLogItem } from '../../../../../types/workflow';
 
 import { DateFormat } from '../../../../UI/DateFormat';
-import { getUserFullName } from '../../../../../utils/users';
 import { Avatar } from '../../../../UI/Avatar';
 import { AddPerformerIcon } from '../../../../icons';
-import { UserData } from '../../../../UserData';
 
 import styles from './WorkflowLogAddedPerformerGroup.css';
 import UserDataWithGroup from '../../../../UserDataWithGroup';
 import { ETemplateOwnerType } from '../../../../../types/template';
 
-export interface IWorkflowLogAddedPerformerProps
-  extends Pick<IWorkflowLogItem, 'created' | 'userId' | 'targetGroupId'> {}
+export interface IWorkflowLogAddedPerformerProps extends Pick<IWorkflowLogItem, 'created' | 'targetGroupId'> {}
 
-export function WorkflowLogAddedPerformerGroup({ userId, created, targetGroupId }: IWorkflowLogAddedPerformerProps) {
+export function WorkflowLogAddedPerformerGroup({ created, targetGroupId }: IWorkflowLogAddedPerformerProps) {
   const { formatMessage } = useIntl();
 
   return (
-    <UserData userId={userId}>
-      {(user) => {
-        if (!user) {
-          return null;
-        }
+    <div className={styles['container']}>
+      <div className={styles['avatar']}>
+        <Avatar size="lg" sizeMobile="sm" isSystemAvatar />
+      </div>
+      <div className={styles['body']}>
+        <p className={styles['title']}>
+          <span className={styles['title__text']}>{formatMessage({ id: 'general.pneumatic' })}</span>
+          <span className={styles['title__icon']}>
+            <AddPerformerIcon />
+          </span>
+          <span className={styles['title__date']}>
+            <DateFormat date={created} />
+          </span>
+        </p>
 
-        return (
-          <div className={styles['container']}>
-            <div className={styles['avatar']}>
-              <Avatar user={user} size="lg" sizeMobile="sm" />
-            </div>
-            <div className={styles['body']}>
-              <p className={styles['title']}>
-                <span className={styles['title__text']}>{getUserFullName(user)}</span>
-                <span className={styles['title__icon']}>
-                  <AddPerformerIcon />
-                </span>
-                <span className={styles['title__date']}>
-                  <DateFormat date={created} />
-                </span>
-              </p>
-
-              {targetGroupId && (
-                <div className={styles['text']}>
-                  {formatMessage({ id: 'task.log-added-performer-group' })}
-                  <UserDataWithGroup type={ETemplateOwnerType.UserGroup} idItem={targetGroupId}>
-                    {(targetUser) => {
-                      return <span className={styles['username']}>{targetUser.firstName}</span>;
-                    }}
-                  </UserDataWithGroup>
-                </div>
-              )}
-            </div>
+        {targetGroupId && (
+          <div className={styles['text']}>
+            {formatMessage({ id: 'task.log-added-performer-group' })}
+            <UserDataWithGroup type={ETemplateOwnerType.UserGroup} idItem={targetGroupId}>
+              {(targetUser) => {
+                return <span className={styles['username']}>{targetUser.firstName}</span>;
+              }}
+            </UserDataWithGroup>
           </div>
-        );
-      }}
-    </UserData>
+        )}
+      </div>
+    </div>
   );
 }

--- a/frontend/src/public/components/Workflows/WorkflowLog/WorkflowLogEvents/WorkflowLogDueDateChanged/WorkflowLogDueDateChanged.tsx
+++ b/frontend/src/public/components/Workflows/WorkflowLog/WorkflowLogEvents/WorkflowLogDueDateChanged/WorkflowLogDueDateChanged.tsx
@@ -6,53 +6,41 @@ import { getLanguage } from '../../../../../redux/selectors/user';
 import { Avatar } from '../../../../UI/Avatar';
 import { ClockIcon } from '../../../../icons';
 import { DateFormat } from '../../../../UI/DateFormat';
-import { getUserFullName } from '../../../../../utils/users';
-import { UserData } from '../../../../UserData';
 import { IWorkflowLogItem } from '../../../../../types/workflow';
 import { getDueInData } from '../../../../DueIn/utils/getDueInData';
 
 import styles from './WorkflowLogDueDateChanged.css';
 
-export type TWorkflowLogDueDateChangedProps = Pick<IWorkflowLogItem, 'userId' | 'created' | 'task'>;
+export type TWorkflowLogDueDateChangedProps = Pick<IWorkflowLogItem, 'created' | 'task'>;
 
-export function WorkflowLogDueDateChanged({ userId, created, task }: TWorkflowLogDueDateChangedProps) {
+export function WorkflowLogDueDateChanged({ created, task }: TWorkflowLogDueDateChangedProps) {
   const { formatMessage } = useIntl();
   const locale = useSelector(getLanguage);
   const dueDateData = task ? getDueInData([task.dueDate], undefined, undefined, locale) : null;
   const dueDate = dueDateData ? <DateFormat date={dueDateData.dueDate} /> : null;
 
   return (
-    <UserData userId={userId}>
-      {(userData) => {
-        if (!userData) {
-          return null;
-        }
+    <div className={styles['container']}>
+      <div className={styles['avatar']}>
+        <Avatar size="lg" sizeMobile="sm" isSystemAvatar />
+      </div>
+      <div className={styles['body']}>
+        <p className={styles['title']}>
+          <span className={styles['title__text']}>{formatMessage({ id: 'general.pneumatic' })}</span>
+          <span className={styles['title__icon']}>
+            <ClockIcon />
+          </span>
+          <span className={styles['title__date']}>
+            <DateFormat date={created} />
+          </span>
+        </p>
 
-        return (
-          <div className={styles['container']}>
-            <div className={styles['avatar']}>
-              <Avatar user={userData} size="lg" sizeMobile="sm" />
-            </div>
-            <div className={styles['body']}>
-              <p className={styles['title']}>
-                <span className={styles['title__text']}>{getUserFullName(userData)}</span>
-                <span className={styles['title__icon']}>
-                  <ClockIcon />
-                </span>
-                <span className={styles['title__date']}>
-                  <DateFormat date={created} />
-                </span>
-              </p>
-
-              <div className={styles['text']}>
-                {dueDate
-                  ? formatMessage({ id: 'workflows.due-date-changed' }, { date: dueDate })
-                  : formatMessage({ id: 'workflows.due-date-removed' })}
-              </div>
-            </div>
-          </div>
-        );
-      }}
-    </UserData>
+        <div className={styles['text']}>
+          {dueDate
+            ? formatMessage({ id: 'workflows.due-date-changed' }, { date: dueDate })
+            : formatMessage({ id: 'workflows.due-date-removed' })}
+        </div>
+      </div>
+    </div>
   );
 }

--- a/frontend/src/public/components/Workflows/WorkflowLog/WorkflowLogEvents/WorkflowLogRemovedPerformer/WorkflowLogRemovedPerformer.tsx
+++ b/frontend/src/public/components/Workflows/WorkflowLog/WorkflowLogEvents/WorkflowLogRemovedPerformer/WorkflowLogRemovedPerformer.tsx
@@ -10,55 +10,42 @@ import { UserData } from '../../../../UserData';
 
 import styles from './WorkflowLogRemovedPerformer.css';
 
-export interface IWorkflowLogRemovedPerformerProps
-  extends Pick<IWorkflowLogItem, 'created' | 'userId' | 'targetUserId'> {}
+export interface IWorkflowLogRemovedPerformerProps extends Pick<IWorkflowLogItem, 'created' | 'targetUserId'> {}
 
-export function WorkflowLogRemovedPerformer({ userId, created, targetUserId }: IWorkflowLogRemovedPerformerProps) {
+export function WorkflowLogRemovedPerformer({ created, targetUserId }: IWorkflowLogRemovedPerformerProps) {
   const { formatMessage } = useIntl();
 
   return (
-    <UserData userId={userId}>
-      {(user) => {
-        if (!user) {
-          return null;
-        }
+    <div className={styles['container']}>
+      <div className={styles['avatar']}>
+        <Avatar size="lg" sizeMobile="sm" isSystemAvatar />
+      </div>
+      <div className={styles['body']}>
+        <p className={styles['title']}>
+          <span className={styles['title__text']}>{formatMessage({ id: 'general.pneumatic' })}</span>
+          <span className={styles['title__icon']}>
+            <RemovePerformerIcon />
+          </span>
+          <span className={styles['title__date']}>
+            <DateFormat date={created} />
+          </span>
+        </p>
 
-        return (
-          <div className={styles['container']}>
-            <div className={styles['avatar']}>
-              <Avatar user={user} size="lg" sizeMobile="sm" />
-            </div>
-            <div className={styles['body']}>
-              <p className={styles['title']}>
-                <span className={styles['title__text']}>{getUserFullName(user)}</span>
-                <span className={styles['title__icon']}>
-                  <RemovePerformerIcon />
-                </span>
-                <span className={styles['title__date']}>
-                  <DateFormat date={created} />
-                </span>
-              </p>
+        {targetUserId && (
+          <div className={styles['text']}>
+            {formatMessage({ id: 'task.log-removed-performer' })}
+            <UserData userId={targetUserId}>
+              {(userData) => {
+                if (!userData) {
+                  return null;
+                }
 
-              {targetUserId && (
-                <div className={styles['text']}>
-                  {formatMessage({ id: 'task.log-removed-performer' })}
-                  <UserData userId={targetUserId}>
-                    {(userData) => {
-                      if (!userData) {
-                        return null;
-                      }
-
-                      return (
-                        <span className={styles['username']}>{getUserFullName(userData, { withAtSign: true })}</span>
-                      );
-                    }}
-                  </UserData>
-                </div>
-              )}
-            </div>
+                return <span className={styles['username']}>{getUserFullName(userData, { withAtSign: true })}</span>;
+              }}
+            </UserData>
           </div>
-        );
-      }}
-    </UserData>
+        )}
+      </div>
+    </div>
   );
 }

--- a/frontend/src/public/components/Workflows/WorkflowLog/WorkflowLogEvents/WorkflowLogRemovedPerformerGroup/WorkflowLogRemovedPerformerGroup.tsx
+++ b/frontend/src/public/components/Workflows/WorkflowLog/WorkflowLogEvents/WorkflowLogRemovedPerformerGroup/WorkflowLogRemovedPerformerGroup.tsx
@@ -3,58 +3,45 @@ import { useIntl } from 'react-intl';
 import { IWorkflowLogItem } from '../../../../../types/workflow';
 
 import { DateFormat } from '../../../../UI/DateFormat';
-import { getUserFullName } from '../../../../../utils/users';
 import { Avatar } from '../../../../UI/Avatar';
 import { RemovePerformerIcon } from '../../../../icons';
-import { UserData } from '../../../../UserData';
 
 import styles from './WorkflowLogRemovedPerformerGroup.css';
 import UserDataWithGroup from '../../../../UserDataWithGroup';
 import { ETemplateOwnerType } from '../../../../../types/template';
 
-export interface IWorkflowLogRemovedPerformerProps
-  extends Pick<IWorkflowLogItem, 'created' | 'userId' | 'targetGroupId'> {}
+export interface IWorkflowLogRemovedPerformerProps extends Pick<IWorkflowLogItem, 'created' | 'targetGroupId'> {}
 
-export function WorkflowLogRemovedPerformerGroup({ userId, created, targetGroupId }: IWorkflowLogRemovedPerformerProps) {
+export function WorkflowLogRemovedPerformerGroup({ created, targetGroupId }: IWorkflowLogRemovedPerformerProps) {
   const { formatMessage } = useIntl();
 
   return (
-    <UserData userId={userId}>
-      {(user) => {
-        if (!user) {
-          return null;
-        }
+    <div className={styles['container']}>
+      <div className={styles['avatar']}>
+        <Avatar size="lg" sizeMobile="sm" isSystemAvatar />
+      </div>
+      <div className={styles['body']}>
+        <p className={styles['title']}>
+          <span className={styles['title__text']}>{formatMessage({ id: 'general.pneumatic' })}</span>
+          <span className={styles['title__icon']}>
+            <RemovePerformerIcon />
+          </span>
+          <span className={styles['title__date']}>
+            <DateFormat date={created} />
+          </span>
+        </p>
 
-        return (
-          <div className={styles['container']}>
-            <div className={styles['avatar']}>
-              <Avatar user={user} size="lg" sizeMobile="sm" />
-            </div>
-            <div className={styles['body']}>
-              <p className={styles['title']}>
-                <span className={styles['title__text']}>{getUserFullName(user)}</span>
-                <span className={styles['title__icon']}>
-                  <RemovePerformerIcon />
-                </span>
-                <span className={styles['title__date']}>
-                  <DateFormat date={created} />
-                </span>
-              </p>
-
-              {targetGroupId && (
-                <div className={styles['text']}>
-                  {formatMessage({ id: 'task.log-removed-performer-group' })}
-                  <UserDataWithGroup type={ETemplateOwnerType.UserGroup} idItem={targetGroupId}>
-                    {(targetUser) => {
-                      return <span className={styles['username']}>{targetUser.firstName}</span>;
-                    }}
-                  </UserDataWithGroup>
-                </div>
-              )}
-            </div>
+        {targetGroupId && (
+          <div className={styles['text']}>
+            {formatMessage({ id: 'task.log-removed-performer-group' })}
+            <UserDataWithGroup type={ETemplateOwnerType.UserGroup} idItem={targetGroupId}>
+              {(targetUser) => {
+                return <span className={styles['username']}>{targetUser.firstName}</span>;
+              }}
+            </UserDataWithGroup>
           </div>
-        );
-      }}
-    </UserData>
+        )}
+      </div>
+    </div>
   );
 }

--- a/frontend/src/public/components/Workflows/WorkflowLog/WorkflowLogEvents/WorkflowLogWorkflowFinished/WorkflowLogWorkflowFinished.tsx
+++ b/frontend/src/public/components/Workflows/WorkflowLog/WorkflowLogEvents/WorkflowLogWorkflowFinished/WorkflowLogWorkflowFinished.tsx
@@ -6,14 +6,39 @@ import { WorkflowEndedIcon } from '../../../../icons';
 import { DateFormat } from '../../../../UI/DateFormat';
 import { getUserFullName } from '../../../../../utils/users';
 import { UserData } from '../../../../UserData';
-import { IWorkflowLogItem } from '../../../../../types/workflow';
+import { EWorkflowLogEvent, IWorkflowLogItem } from '../../../../../types/workflow';
 
 import styles from './WorkflowLogWorkflowFinished.css';
 
-export type TWorkflowLogWorkflowFinishedProps = Pick<IWorkflowLogItem, 'userId' | 'created'>;
+export type TWorkflowLogWorkflowFinishedProps = Pick<IWorkflowLogItem, 'userId' | 'created' | 'type'>;
 
-export function WorkflowLogWorkflowFinished({ userId, created }: TWorkflowLogWorkflowFinishedProps) {
+export function WorkflowLogWorkflowFinished({ userId, created, type }: TWorkflowLogWorkflowFinishedProps) {
   const { formatMessage } = useIntl();
+
+  const renderEvent = (title: string, avatar: React.ReactNode) => (
+    <div className={styles['container']}>
+      <div className={styles['avatar']}>{avatar}</div>
+      <div className={styles['body']}>
+        <p className={styles['title']}>
+          <span className={styles['title__text']}>{title}</span>
+          <span className={styles['title__icon']}>
+            <WorkflowEndedIcon />
+          </span>
+          <span className={styles['title__date']}>
+            <DateFormat date={created} />
+          </span>
+        </p>
+        <div className={styles['text']}>{formatMessage({ id: 'workflows.log-workflow-ended' })}</div>
+      </div>
+    </div>
+  );
+
+  if (type !== EWorkflowLogEvent.WorkflowComplete) {
+    return renderEvent(
+      formatMessage({ id: 'general.pneumatic' }),
+      <Avatar size="lg" sizeMobile="sm" isSystemAvatar />,
+    );
+  }
 
   return (
     <UserData userId={userId}>
@@ -22,23 +47,7 @@ export function WorkflowLogWorkflowFinished({ userId, created }: TWorkflowLogWor
           return null;
         }
 
-        return (
-          <div className={styles['container']}>
-            <div className={styles['avatar']}>
-              <Avatar user={user} size="lg" sizeMobile="sm" />
-            </div>
-            <div className={styles['body']}>
-              <p className={styles['title']}>
-                <span className={styles['title__text']}>{getUserFullName(user)}</span>
-                <span className={styles['title__icon']}>
-                  <WorkflowEndedIcon />
-                </span>
-                <span className={styles['title__date']}><DateFormat date={created} /></span>
-              </p>
-              <div className={styles['text']}>{formatMessage({ id: 'workflows.log-workflow-ended' })}</div>
-            </div>
-          </div>
-        );
+        return renderEvent(getUserFullName(user), <Avatar user={user} size="lg" sizeMobile="sm" />);
       }}
     </UserData>
   );

--- a/frontend/src/public/components/Workflows/WorkflowLog/WorkflowLogEvents/WorkflowLogWorkflowFinished/__tests__/WorkflowLogWorkflowFinished.test.tsx
+++ b/frontend/src/public/components/Workflows/WorkflowLog/WorkflowLogEvents/WorkflowLogWorkflowFinished/__tests__/WorkflowLogWorkflowFinished.test.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+
+import { WorkflowLogWorkflowFinished } from '../WorkflowLogWorkflowFinished';
+import { enMessages } from '../../../../../../lang/locales/en_US';
+import { EWorkflowLogEvent } from '../../../../../../types/workflow';
+
+jest.mock('../../../../../UserData', () => ({
+  UserData: jest.fn(({ children }: { children: (user: Record<string, string> | null) => React.ReactNode }) =>
+    children({ id: '1', firstName: 'Test', lastName: 'User', email: 'test@test.com' }),
+  ),
+}));
+
+jest.mock('../../../../../UI/Avatar', () => ({
+  Avatar: ({ isSystemAvatar }: { isSystemAvatar?: boolean }) => (
+    <div data-testid={isSystemAvatar ? 'system-avatar' : 'user-avatar'} />
+  ),
+}));
+
+jest.mock('../../../../../icons', () => ({
+  WorkflowEndedIcon: () => null,
+}));
+
+jest.mock('../../../../../UI/DateFormat', () => ({
+  DateFormat: () => 'mocked-date',
+}));
+
+jest.mock('../../../../../../utils/users', () => ({
+  getUserFullName: jest.fn(() => 'Test User'),
+}));
+
+const renderWithIntl = (ui: React.ReactElement) =>
+  render(React.createElement(IntlProvider, { locale: 'en', messages: enMessages }, ui));
+
+describe('WorkflowLogWorkflowFinished', () => {
+  it('shows user for workflow complete event', () => {
+    renderWithIntl(
+      <WorkflowLogWorkflowFinished userId={1} created="2024-01-01" type={EWorkflowLogEvent.WorkflowComplete} />,
+    );
+
+    expect(screen.getByText('Test User')).toBeInTheDocument();
+    expect(screen.getByTestId('user-avatar')).toBeInTheDocument();
+  });
+
+  it('shows system actor for automatic workflow finished event', () => {
+    renderWithIntl(
+      <WorkflowLogWorkflowFinished userId={1} created="2024-01-01" type={EWorkflowLogEvent.WorkflowFinished} />,
+    );
+
+    expect(screen.getByText('Pneumatic')).toBeInTheDocument();
+    expect(screen.queryByText('Test User')).not.toBeInTheDocument();
+    expect(screen.getByTestId('system-avatar')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/public/components/Workflows/WorkflowLog/WorkflowLogEvents/WorkflowLogWorkflowResumed/WorkflowLogWorkflowResumed.tsx
+++ b/frontend/src/public/components/Workflows/WorkflowLog/WorkflowLogEvents/WorkflowLogWorkflowResumed/WorkflowLogWorkflowResumed.tsx
@@ -4,45 +4,33 @@ import { useIntl } from 'react-intl';
 import { Avatar } from '../../../../UI/Avatar';
 import { AlarmCrossedIcon } from '../../../../icons';
 import { DateFormat } from '../../../../UI/DateFormat';
-import { getUserFullName } from '../../../../../utils/users';
-import { UserData } from '../../../../UserData';
 import { IWorkflowLogItem } from '../../../../../types/workflow';
 
 import styles from './WorkflowLogWorkflowResumed.css';
 
-export type TWorkflowLogWorkflowResumedProps = Pick<IWorkflowLogItem, 'userId' | 'created'>;
+export type TWorkflowLogWorkflowResumedProps = Pick<IWorkflowLogItem, 'created'>;
 
-export function WorkflowLogWorkflowResumed({ userId, created }: TWorkflowLogWorkflowResumedProps) {
+export function WorkflowLogWorkflowResumed({ created }: TWorkflowLogWorkflowResumedProps) {
   const { formatMessage } = useIntl();
 
   return (
-    <UserData userId={userId}>
-      {(userData) => {
-        if (!userData) {
-          return null;
-        }
+    <div className={styles['container']}>
+      <div className={styles['avatar']}>
+        <Avatar size="lg" sizeMobile="sm" isSystemAvatar />
+      </div>
+      <div className={styles['body']}>
+        <p className={styles['title']}>
+          <span className={styles['title__text']}>{formatMessage({ id: 'general.pneumatic' })}</span>
+          <span className={styles['title__icon']}>
+            <AlarmCrossedIcon fill="var(--pneumatic-color-notification3)" />
+          </span>
+          <span className={styles['title__date']}>
+            <DateFormat date={created} />
+          </span>
+        </p>
 
-        return (
-          <div className={styles['container']}>
-            <div className={styles['avatar']}>
-              <Avatar user={userData} size="lg" sizeMobile="sm" />
-            </div>
-            <div className={styles['body']}>
-              <p className={styles['title']}>
-                <span className={styles['title__text']}>{getUserFullName(userData)}</span>
-                <span className={styles['title__icon']}>
-                  <AlarmCrossedIcon fill="#4CAF50" />
-                </span>
-                <span className={styles['title__date']}>
-                  <DateFormat date={created} />
-                </span>
-              </p>
-
-              <div className={styles['text']}>{formatMessage({ id: 'workflows.event-resumed' })}</div>
-            </div>
-          </div>
-        );
-      }}
-    </UserData>
+        <div className={styles['text']}>{formatMessage({ id: 'workflows.event-resumed' })}</div>
+      </div>
+    </div>
   );
 }

--- a/frontend/src/public/components/Workflows/WorkflowLog/WorkflowLogEvents/WorkflowLogWorkflowSnoozedManually/WorkflowLogWorkflowSnoozedManually.tsx
+++ b/frontend/src/public/components/Workflows/WorkflowLog/WorkflowLogEvents/WorkflowLogWorkflowSnoozedManually/WorkflowLogWorkflowSnoozedManually.tsx
@@ -1,59 +1,48 @@
 import React from 'react';
 import { useIntl } from 'react-intl';
 
-import { useSelector } from "react-redux";
+import { useSelector } from 'react-redux';
 import { getLanguage } from '../../../../../redux/selectors/user';
 
 import { Avatar } from '../../../../UI/Avatar';
 import { AlarmIcon } from '../../../../icons';
 import { DateFormat } from '../../../../UI/DateFormat';
-import { getUserFullName } from '../../../../../utils/users';
-import { UserData } from '../../../../UserData';
 import { IWorkflowLogItem, IWorkflowDelay } from '../../../../../types/workflow';
 import { getSnoozedUntilDate } from '../../../../../utils/dateTime';
 
 import styles from './WorkflowLogWorkflowSnoozedManually.css';
 
-export type TWorkflowLogWorkflowSnoozedManuallyProps = Pick<IWorkflowLogItem, 'userId' | 'created'> & {
+export type TWorkflowLogWorkflowSnoozedManuallyProps = Pick<IWorkflowLogItem, 'created'> & {
   delay: IWorkflowDelay;
 };
 
 export function WorkflowLogWorkflowSnoozedManually({
-  userId,
   created,
   delay,
 }: TWorkflowLogWorkflowSnoozedManuallyProps) {
   const { formatMessage } = useIntl();
-  const locate = useSelector(getLanguage)
+  const locale = useSelector(getLanguage);
 
   return (
-    <UserData userId={userId}>
-      {(userData) => {
-        if (!userData) {
-          return null;
-        }
+    <div className={styles['container']}>
+      <div className={styles['avatar']}>
+        <Avatar size="lg" sizeMobile="sm" isSystemAvatar />
+      </div>
+      <div className={styles['body']}>
+        <p className={styles['title']}>
+          <span className={styles['title__text']}>{formatMessage({ id: 'general.pneumatic' })}</span>
+          <span className={styles['title__icon']}>
+            <AlarmIcon fill="var(--pneumatic-color-notification1)" />
+          </span>
+          <span className={styles['title__date']}>
+            <DateFormat date={created} />
+          </span>
+        </p>
 
-        return (
-          <div className={styles['container']}>
-            <div className={styles['avatar']}>
-              <Avatar user={userData} size="lg" sizeMobile="sm" />
-            </div>
-            <div className={styles['body']}>
-              <p className={styles['title']}>
-                <span className={styles['title__text']}>{getUserFullName(userData)}</span>
-                <span className={styles['title__icon']}>
-                  <AlarmIcon fill="#F44336" />
-                </span>
-                <span className={styles['title__date']}><DateFormat date={created} /></span>
-              </p>
-
-              <div className={styles['text']}>
-                {formatMessage({ id: 'workflows.event-snoozed-until' }, { date: getSnoozedUntilDate(delay, locate)})}
-              </div>
-            </div>
-          </div>
-        );
-      }}
-    </UserData>
+        <div className={styles['text']}>
+          {formatMessage({ id: 'workflows.event-snoozed-until' }, { date: getSnoozedUntilDate(delay, locale) })}
+        </div>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
### 1. Release notes

Corrected workflow log actor labels for system-generated events. Automatic performer, group, due-date, resume, snooze, and workflow-finished events now show Pneumatic with the system avatar, while genuine user-completion events continue to show the responsible user.

---

### 2. Context

- **Issue:** #15964
- **App Location:** Workflow Details and Task Card -> Workflow Log.
- **Related Changes:** Updated workflow-log event components to distinguish system-generated events from user-generated workflow completion.

---

### 3. Solution & Implementation Details

* **System actor rendering:** Automatic events now render the Pneumatic label and system avatar instead of resolving `userId` as the event author.
* **Performer events:** Added/removed user and group events retain the target performer/group label while using Pneumatic as the actor.
* **Due-date events:** Due-date change/removal events render as system actions without depending on user data.
* **Workflow state events:** Resume and manual snooze event headers use the shared system actor presentation.
* **Finished-event distinction:** `WorkflowComplete` keeps the actual user actor, while automatic `WorkflowFinished` uses Pneumatic.
* **Safer rendering:** System events no longer disappear when an unrelated user record cannot be resolved.
* **Cleanup:** Removed touched lint/format suppression comments and unused user-related imports/props.

---

### 4. What to Test

#### 4.1 Preconditions

1. Log in and start a workflow with at least one task.
2. Ensure the workflow can be snoozed/resumed and task performers can be changed.
3. Open Workflow Details or a Task Card with the Workflow Log visible.

#### 4.2 Positive Scenarios / Testing Report

| Scenario | Description (Steps & Expected Result) | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| :--- | :--- | :---: | :---: | :---: | :---: |
| **Add performer** | Add a user performer to a task.<br>**Result:** Event actor is Pneumatic; event text still identifies the target user. | [ ] | [ ] | [ ] | [ ] |
| **Remove performer** | Remove a user performer.<br>**Result:** Event actor is Pneumatic and the removed user remains visible in the message. | [ ] | [ ] | [ ] | [ ] |
| **Add/remove group** | Add and remove a performer group.<br>**Result:** Pneumatic is shown as actor and the correct group name is shown as target. | [ ] | [ ] | [ ] | [ ] |
| **Change due date** | Set, edit, and remove a task due date.<br>**Result:** Each event uses the system avatar/Pneumatic label and displays the expected date text. | [ ] | [ ] | [ ] | [ ] |
| **Snooze/resume workflow** | Snooze and then resume a workflow.<br>**Result:** Both state events show Pneumatic as the actor. | [ ] | [ ] | [ ] | [ ] |
| **Automatic workflow finish** | Trigger an automatic `WorkflowFinished` event.<br>**Result:** Pneumatic and the system avatar are shown. | [ ] | [ ] | [ ] | [ ] |
| **User workflow completion** | Complete a workflow through a user action producing `WorkflowComplete`.<br>**Result:** The actual user's name and avatar remain visible. | [ ] | [ ] | [ ] | [ ] |

#### 4.3 Negative Scenarios & Edge Cases

| Scenario | Description (Steps & Expected Result) | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| :--- | :--- | :---: | :---: | :---: | :---: |
| **Missing actor user** | Open a system event whose historical `userId` cannot be resolved.<br>**Result:** The event still renders with Pneumatic. | [ ] | [ ] | [ ] | [ ] |
| **Missing target user** | Open a performer event whose target user was deleted.<br>**Result:** The event shell remains stable without rendering a wrong actor. | [ ] | [ ] | [ ] | [ ] |
| **Missing target group** | Open a group event whose group no longer exists.<br>**Result:** No incorrect user label is shown and the log does not crash. | [ ] | [ ] | [ ] | [ ] |
| **Mixed event history** | Open a workflow containing system and user-complete events.<br>**Result:** Only user-generated completion entries show a user actor. | [ ] | [ ] | [ ] | [ ] |

#### 4.4 Verification Points

- **UI:** System events consistently use the Pneumatic label and system avatar.
- **UI:** Target users/groups remain distinct from the event actor.
- **UI:** `WorkflowComplete` still shows the actual user.
- **Console:** No missing-user render errors or prop warnings.

#### 4.5 API Verification

- No API contract changes are included.
- Inspect workflow-log responses and confirm event `type`, `targetUserId`, and `targetGroupId` still map to the expected UI.
- Verify `WorkflowComplete` and `WorkflowFinished` types produce different actor rendering.

#### 4.6 What Was NOT Tested

- Manual browser matrix testing remains unchecked.
- Historical events from backend versions with incompatible event types.
- Backend generation and authorization of workflow-log events.

---

### 5. Affected Areas

| Scenario | Description | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| :--- | :--- | :---: | :---: | :---: | :---: |
| **Performer Events** | Added/removed users and groups. | [ ] | [ ] | [ ] | [ ] |
| **Due Date Events** | Changed and removed due dates. | [ ] | [ ] | [ ] | [ ] |
| **Workflow State Events** | Snoozed, resumed, and automatically finished workflows. | [ ] | [ ] | [ ] | [ ] |
| **Workflow Completion** | User actor retained for genuine completion events. | [ ] | [ ] | [ ] | [ ] |

---

### 6. Unit Tests

- `WorkflowLogWorkflowFinished.test.tsx`: Verifies that `WorkflowComplete` shows the user and automatic `WorkflowFinished` shows Pneumatic.
- The remaining touched event components rely on their shared rendering patterns and manual scenario coverage above.

---

### 7. Commits

- `1517c4ca` — `15964 fix(logs): show performer label for user events only`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Show 'Pneumatic' system actor for automated workflow log events
- Workflow log event components for adding/removing performers, due date changes, snooze, resume, and workflow finish now render 'Pneumatic' with a system avatar instead of the acting user's name and avatar.
- `WorkflowLogWorkflowFinished` retains user-based rendering only for `EWorkflowLogEvent.WorkflowComplete`; all other finish event types (e.g. snoozed termination) show the system actor.
- `userId` prop is removed from all affected components except `WorkflowLogWorkflowFinished`, which still requires it for the `WorkflowComplete` path.
- Icon fill colors in `WorkflowLogWorkflowResumed` and `WorkflowLogWorkflowSnoozedManually` are updated from hardcoded hex values to CSS variables.
- Behavioral Change: callers of these components must remove `userId` from props (except `WorkflowLogWorkflowFinished`, which now also requires a `type` prop).

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1517c4c.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->