### PR TITLE
16025 frontend [ users ] Update team users in realtime

### DIFF
--- a/frontend/src/public/api/getActiveUsersCount.ts
+++ b/frontend/src/public/api/getActiveUsersCount.ts
@@ -3,6 +3,7 @@ import { commonRequest } from './commonRequest';
 
 export interface IGetActiveUsersCountResponse {
   activeUsers: number;
+  tenantsActiveUsers: number;
 }
 
 export function getActiveUsersCount() {

--- a/frontend/src/public/redux/accounts/__tests__/saga.test.ts
+++ b/frontend/src/public/redux/accounts/__tests__/saga.test.ts
@@ -1,0 +1,34 @@
+import { call, put, select } from 'redux-saga/effects';
+
+import { getActiveUsersCount } from '../../../api/getActiveUsersCount';
+import { EUserStatus, TUserListItem } from '../../../types/user';
+import { activeUsersCountFetchFinished } from '../slice';
+import { fetchActiveUsersCount } from '../saga';
+import { getAccountsStore } from '../../selectors/user';
+
+const makeUser = (id: number, status = EUserStatus.Active): TUserListItem => ({
+  id,
+  firstName: `User ${id}`,
+  lastName: '',
+  email: `user-${id}@test.com`,
+  phone: '',
+  photo: '',
+  status,
+  type: 'user',
+  isAdmin: false,
+  isAccountOwner: false,
+});
+
+describe('accounts saga', () => {
+  it('refreshes tenants count without overwriting local active users count', () => {
+    const gen = fetchActiveUsersCount();
+
+    expect(gen.next().value).toEqual(call(getActiveUsersCount));
+    expect(gen.next({ activeUsers: 1, tenantsActiveUsers: 4 } as never).value).toEqual(select(getAccountsStore));
+    expect(gen.next({
+      users: [],
+      team: { list: [makeUser(1), makeUser(2), makeUser(3, EUserStatus.Invited)] },
+    } as never).value).toEqual(put(activeUsersCountFetchFinished({ activeUsers: 2, tenantsActiveUsers: 4 })));
+    expect(gen.next().done).toBe(true);
+  });
+});

--- a/frontend/src/public/redux/accounts/__tests__/slice.test.ts
+++ b/frontend/src/public/redux/accounts/__tests__/slice.test.ts
@@ -67,4 +67,20 @@ describe('accounts reducer realtime users', () => {
 
     expect(state.planInfo.activeUsers).toBe(2);
   });
+
+  it('does not overwrite active users count when websocket arrives before users fetch', () => {
+    let state = accountsReducer(undefined, activeUsersCountFetchFinished({ activeUsers: 5, tenantsActiveUsers: 0 }));
+
+    state = accountsReducer(state, upsertUserFromWs(makeUser(1, 'Artyom')));
+
+    expect(state.planInfo.activeUsers).toBe(5);
+  });
+
+  it('keeps active users count when websocket deletion arrives before users fetch', () => {
+    let state = accountsReducer(undefined, activeUsersCountFetchFinished({ activeUsers: 5, tenantsActiveUsers: 0 }));
+
+    state = accountsReducer(state, removeUserFromWs(1));
+
+    expect(state.planInfo.activeUsers).toBe(5);
+  });
 });

--- a/frontend/src/public/redux/accounts/__tests__/slice.test.ts
+++ b/frontend/src/public/redux/accounts/__tests__/slice.test.ts
@@ -1,0 +1,70 @@
+import accountsReducer, {
+  activeUsersCountFetchFinished,
+  removeUserFromWs,
+  teamFetchFinished,
+  upsertUserFromWs,
+  usersFetchFinished,
+} from '../slice';
+import { EUserStatus, TUserListItem } from '../../../types/user';
+
+const makeUser = (id: number, firstName: string, status = EUserStatus.Active): TUserListItem => ({
+  id,
+  firstName,
+  lastName: '',
+  email: `${firstName.toLowerCase()}@test.com`,
+  phone: '',
+  photo: '',
+  status,
+  type: 'user',
+  isAdmin: false,
+  isAccountOwner: false,
+});
+
+describe('accounts reducer realtime users', () => {
+  it('keeps websocket users sorted and derives active users count', () => {
+    let state = accountsReducer(undefined, activeUsersCountFetchFinished({ activeUsers: 1, tenantsActiveUsers: 0 }));
+    state = accountsReducer(state, usersFetchFinished([
+      makeUser(1, 'Artyom'),
+      makeUser(3, 'very-long-invited-user-email-address@example.com', EUserStatus.Invited),
+    ]));
+    state = accountsReducer(state, teamFetchFinished(state.users));
+
+    state = accountsReducer(state, upsertUserFromWs(makeUser(2, 'Artyom')));
+
+    expect(state.planInfo.activeUsers).toBe(2);
+    expect(state.team.list.map((user) => user.id)).toEqual([1, 2, 3]);
+  });
+
+  it('removes websocket deleted user', () => {
+    let state = accountsReducer(undefined, activeUsersCountFetchFinished({ activeUsers: 2, tenantsActiveUsers: 0 }));
+    state = accountsReducer(state, usersFetchFinished([
+      makeUser(1, 'Artyom'),
+      makeUser(2, 'Artyom'),
+    ]));
+    state = accountsReducer(state, teamFetchFinished(state.users));
+
+    state = accountsReducer(state, removeUserFromWs(2));
+
+    expect(state.planInfo.activeUsers).toBe(1);
+    expect(state.team.list.map((user) => user.id)).toEqual([1]);
+  });
+
+  it('derives active users count from fetched users', () => {
+    const state = accountsReducer(undefined, usersFetchFinished([
+      makeUser(1, 'Artyom'),
+      makeUser(2, 'Invited', EUserStatus.Invited),
+    ]));
+
+    expect(state.planInfo.activeUsers).toBe(1);
+  });
+
+  it('derives active users count from fetched team users', () => {
+    const state = accountsReducer(undefined, teamFetchFinished([
+      makeUser(1, 'Artyom'),
+      makeUser(2, 'Test'),
+      makeUser(3, 'Invited', EUserStatus.Invited),
+    ]));
+
+    expect(state.planInfo.activeUsers).toBe(2);
+  });
+});

--- a/frontend/src/public/redux/accounts/saga.ts
+++ b/frontend/src/public/redux/accounts/saga.ts
@@ -61,7 +61,7 @@ import { setGeneralLoaderVisibility } from '../general/actions';
 import { auth } from '../../api/auth';
 import { startFreeSubscription } from '../../api/startFreeSubscription';
 import { getActiveUsersCount, IGetActiveUsersCountResponse } from '../../api/getActiveUsersCount';
-import { sortUsersByStatus, sortUsersByNameAsc, sortUsersByNameDesc } from '../../utils/users';
+import { getActiveUsers, sortUsersByStatus, sortUsersByNameAsc, sortUsersByNameDesc } from '../../utils/users';
 import { getAccountPlan } from '../selectors/accounts';
 import { getAbsolutePath } from '../../utils/getAbsolutePath';
 import { createUser as createUserApi } from '../../api/createUser';
@@ -120,8 +120,13 @@ export function* fetchUsers(
 export function* fetchActiveUsersCount() {
   try {
     const { activeUsers, tenantsActiveUsers }: IGetActiveUsersCountResponse = yield call(getActiveUsersCount);
+    const accounts: ReturnType<typeof getAccountsStore> = yield select(getAccountsStore);
+    const localUsers = accounts.team.list.length ? accounts.team.list : accounts.users;
 
-    yield put(activeUsersCountFetchFinished({ activeUsers, tenantsActiveUsers }));
+    yield put(activeUsersCountFetchFinished({
+      activeUsers: localUsers.length ? getActiveUsers(localUsers).length : activeUsers,
+      tenantsActiveUsers,
+    }));
   } catch (error) {
     console.info('fetch active users count error : ', error);
   }
@@ -247,6 +252,7 @@ function* fetchDeleteUser({ payload: { userId, reassignedUserId } }: PayloadActi
     NotificationManager.success({ message: 'team.delete-success-msg' });
     yield put(teamFetchStarted({}));
     yield put(usersFetchStarted());
+    yield put(loadActiveUsersCount());
   } catch (err) {
     NotificationManager.warning({ message: getErrorMessage(err) });
   } finally {
@@ -262,6 +268,7 @@ function* fetchDeclineInvite({ payload: { userId, inviteId, reassignedUserId } }
     NotificationManager.success({ message: 'team.decline-invite-success-msg' });
     yield put(teamFetchStarted({}));
     yield put(usersFetchStarted());
+    yield put(loadActiveUsersCount());
   } catch (err) {
     NotificationManager.warning({ message: getErrorMessage(err) });
   } finally {
@@ -346,6 +353,7 @@ function* createUserSaga({ payload }: PayloadAction<ICreateUserRequest>) {
 
     yield put(teamFetchStarted({}));
     yield put(usersFetchStarted());
+    yield put(loadActiveUsersCount());
   } catch (error) {
     NotificationManager.notifyApiError( error, { message: getErrorMessage(error) });
     logger.error('failed to create user', error);

--- a/frontend/src/public/redux/accounts/saga.ts
+++ b/frontend/src/public/redux/accounts/saga.ts
@@ -64,7 +64,6 @@ import { getActiveUsersCount, IGetActiveUsersCountResponse } from '../../api/get
 import { sortUsersByStatus, sortUsersByNameAsc, sortUsersByNameDesc } from '../../utils/users';
 import { getAccountPlan } from '../selectors/accounts';
 import { getAbsolutePath } from '../../utils/getAbsolutePath';
-import { getTenantsCountStore } from '../selectors/tenants';
 import { createUser as createUserApi } from '../../api/createUser';
 import { editTeamUser } from '../../api/editTeamUser';
 
@@ -120,10 +119,9 @@ export function* fetchUsers(
 
 export function* fetchActiveUsersCount() {
   try {
-    const { activeUsers }: IGetActiveUsersCountResponse = yield call(getActiveUsersCount);
-    const tenantCount: number = yield select(getTenantsCountStore);
+    const { activeUsers, tenantsActiveUsers }: IGetActiveUsersCountResponse = yield call(getActiveUsersCount);
 
-    yield put(activeUsersCountFetchFinished({ activeUsers, tenantsActiveUsers: tenantCount || 333 }));
+    yield put(activeUsersCountFetchFinished({ activeUsers, tenantsActiveUsers }));
   } catch (error) {
     console.info('fetch active users count error : ', error);
   }
@@ -249,7 +247,6 @@ function* fetchDeleteUser({ payload: { userId, reassignedUserId } }: PayloadActi
     NotificationManager.success({ message: 'team.delete-success-msg' });
     yield put(teamFetchStarted({}));
     yield put(usersFetchStarted());
-    yield put(loadActiveUsersCount());
   } catch (err) {
     NotificationManager.warning({ message: getErrorMessage(err) });
   } finally {
@@ -265,7 +262,6 @@ function* fetchDeclineInvite({ payload: { userId, inviteId, reassignedUserId } }
     NotificationManager.success({ message: 'team.decline-invite-success-msg' });
     yield put(teamFetchStarted({}));
     yield put(usersFetchStarted());
-    yield put(loadActiveUsersCount());
   } catch (err) {
     NotificationManager.warning({ message: getErrorMessage(err) });
   } finally {
@@ -350,7 +346,6 @@ function* createUserSaga({ payload }: PayloadAction<ICreateUserRequest>) {
 
     yield put(teamFetchStarted({}));
     yield put(usersFetchStarted());
-    yield put(loadActiveUsersCount());
   } catch (error) {
     NotificationManager.notifyApiError( error, { message: getErrorMessage(error) });
     logger.error('failed to create user', error);

--- a/frontend/src/public/redux/accounts/slice.ts
+++ b/frontend/src/public/redux/accounts/slice.ts
@@ -1,7 +1,7 @@
 import { createSlice, PayloadAction, createAction } from '@reduxjs/toolkit';
 
 import { EDeleteUserModalState, IAccounts, IAccountPlan } from '../../types/redux';
-import { EUserListSorting, TUserListItem, ICreateUserRequest } from '../../types/user';
+import { EUserListSorting, EUserStatus, TUserListItem, ICreateUserRequest } from '../../types/user';
 import { ESubscriptionPlan } from '../../types/account';
 
 import {
@@ -59,6 +59,35 @@ function setUserProperties(users: TUserListItem[], userId: number, changedProps:
   });
 }
 
+const getUserNameForSorting = (user: TUserListItem) => (user.firstName || user.email).toLowerCase();
+
+function sortUsers(users: TUserListItem[], sorting: EUserListSorting) {
+  const sorted = users.slice().sort((user1, user2) => {
+    if (getUserNameForSorting(user1) === getUserNameForSorting(user2)) return 0;
+
+    return getUserNameForSorting(user1) > getUserNameForSorting(user2) ? 1 : -1;
+  });
+
+  if (sorting === EUserListSorting.NameDesc) {
+    return sorted.reverse();
+  }
+
+  if (sorting === EUserListSorting.Status) {
+    return sorted.sort((user1, user2) => {
+      const user1Status = user1.status === EUserStatus.Invited ? 1 : 0;
+      const user2Status = user2.status === EUserStatus.Invited ? 1 : 0;
+
+      return user1Status - user2Status;
+    });
+  }
+
+  return sorted;
+}
+
+const getActiveUsersCount = (users: TUserListItem[]) => users.filter(
+  (user) => user.status === EUserStatus.Active && user.type === 'user',
+).length;
+
 const accountsSlice = createSlice({
   name: 'accounts',
   initialState,
@@ -79,6 +108,7 @@ const accountsSlice = createSlice({
     teamFetchFinished: (state, action: PayloadAction<TUserListItem[]>) => {
       state.team.isLoading = false;
       state.team.list = action.payload;
+      state.planInfo.activeUsers = getActiveUsersCount(action.payload);
     },
 
     usersFetchFailed: (state) => {
@@ -89,10 +119,12 @@ const accountsSlice = createSlice({
     usersFetchFinished: (state, action: PayloadAction<TUserListItem[]>) => {
       state.isLoading = false;
       state.users = action.payload;
+      state.planInfo.activeUsers = getActiveUsersCount(action.payload);
     },
 
     activeUsersCountFetchFinished: (state, action: PayloadAction<TActiveUsersCountFetchFinishedPayload>) => {
       state.planInfo.activeUsers = action.payload.activeUsers;
+      state.planInfo.tenantsActiveUsers = action.payload.tenantsActiveUsers;
     },
 
     setCurrentPlan: (state, action: PayloadAction<IAccountPlan>) => {
@@ -197,20 +229,23 @@ const accountsSlice = createSlice({
       const user = action.payload;
       const upsertList = (list: TUserListItem[]) => {
         const hasUser = list.some((item) => item.id === user.id);
-        if (!hasUser) {
-          return [...list, user];
-        }
-        return list.map((item) => (item.id === user.id ? { ...item, ...user } : item));
+        const nextList = hasUser
+          ? list.map((item) => (item.id === user.id ? { ...item, ...user } : item))
+          : [...list, user];
+
+        return sortUsers(nextList, state.userListSorting);
       };
 
       state.users = upsertList(state.users);
       state.team.list = upsertList(state.team.list);
+      state.planInfo.activeUsers = getActiveUsersCount(state.users);
     },
 
     removeUserFromWs: (state, action: PayloadAction<number>) => {
       const removeFromList = (list: TUserListItem[]) => list.filter((item) => item.id !== action.payload);
       state.users = removeFromList(state.users);
       state.team.list = removeFromList(state.team.list);
+      state.planInfo.activeUsers = getActiveUsersCount(state.users);
     },
   },
 });

--- a/frontend/src/public/redux/accounts/slice.ts
+++ b/frontend/src/public/redux/accounts/slice.ts
@@ -227,6 +227,7 @@ const accountsSlice = createSlice({
 
     upsertUserFromWs: (state, action: PayloadAction<TUserListItem>) => {
       const user = action.payload;
+      const hasLocalUsers = Boolean(state.users.length || state.team.list.length);
       const upsertList = (list: TUserListItem[]) => {
         const hasUser = list.some((item) => item.id === user.id);
         const nextList = hasUser
@@ -238,14 +239,19 @@ const accountsSlice = createSlice({
 
       state.users = upsertList(state.users);
       state.team.list = upsertList(state.team.list);
-      state.planInfo.activeUsers = getActiveUsersCount(state.users);
+      if (hasLocalUsers) {
+        state.planInfo.activeUsers = getActiveUsersCount(state.team.list.length ? state.team.list : state.users);
+      }
     },
 
     removeUserFromWs: (state, action: PayloadAction<number>) => {
+      const hasLocalUsers = Boolean(state.users.length || state.team.list.length);
       const removeFromList = (list: TUserListItem[]) => list.filter((item) => item.id !== action.payload);
       state.users = removeFromList(state.users);
       state.team.list = removeFromList(state.team.list);
-      state.planInfo.activeUsers = getActiveUsersCount(state.users);
+      if (hasLocalUsers) {
+        state.planInfo.activeUsers = getActiveUsersCount(state.team.list.length ? state.team.list : state.users);
+      }
     },
   },
 });

--- a/frontend/src/public/redux/menu/__tests__/saga.test.ts
+++ b/frontend/src/public/redux/menu/__tests__/saga.test.ts
@@ -1,0 +1,33 @@
+import { put, select } from 'redux-saga/effects';
+
+import { setMenuItemCounter } from '../actions';
+import { updateCounterSaga } from '../saga';
+import { teamFetchFinished, usersFetchFinished } from '../../accounts/slice';
+import { getTotalTasksCount } from '../../selectors/tasks';
+import { getAccountPlan } from '../../selectors/accounts';
+import { getTenantsCountStore } from '../../selectors/tenants';
+import { IAccountPlan } from '../../../types/redux';
+
+const plan = { activeUsers: 3 } as IAccountPlan;
+
+describe('menu counter saga', () => {
+  it('updates team counter after users list changes', () => {
+    const gen = updateCounterSaga(usersFetchFinished([]));
+
+    expect(gen.next().value).toEqual(select(getTotalTasksCount));
+    expect(gen.next(0 as never).value).toEqual(select(getAccountPlan));
+    expect(gen.next(plan as never).value).toEqual(select(getTenantsCountStore));
+    expect(gen.next(0 as never).value).toEqual(put(setMenuItemCounter({ id: 'team', value: 3, type: 'info' })));
+    expect(gen.next().value).toEqual(put(setMenuItemCounter({ id: 'tenants', value: 0, type: 'info' })));
+    expect(gen.next().done).toBe(true);
+  });
+
+  it('updates team counter after team list changes', () => {
+    const gen = updateCounterSaga(teamFetchFinished([]));
+
+    expect(gen.next().value).toEqual(select(getTotalTasksCount));
+    expect(gen.next(0 as never).value).toEqual(select(getAccountPlan));
+    expect(gen.next(plan as never).value).toEqual(select(getTenantsCountStore));
+    expect(gen.next(0 as never).value).toEqual(put(setMenuItemCounter({ id: 'team', value: 3, type: 'info' })));
+  });
+});

--- a/frontend/src/public/redux/menu/saga.ts
+++ b/frontend/src/public/redux/menu/saga.ts
@@ -2,9 +2,14 @@
 import { all, fork, put, select, takeEvery } from 'redux-saga/effects';
 import { PayloadAction } from '@reduxjs/toolkit';
 import { EMenuActions, mergeMenuItems, setMenuItemCounter } from './actions';
-import { activeUsersCountFetchFinished, setCurrentPlan } from '../accounts/slice';
-import { TActiveUsersCountFetchFinishedPayload } from '../accounts/types';
-import { IAccountPlan } from '../../types/redux';
+import {
+  activeUsersCountFetchFinished,
+  removeUserFromWs,
+  setCurrentPlan,
+  teamFetchFinished,
+  upsertUserFromWs,
+  usersFetchFinished,
+} from '../accounts/slice';
 import { getAuthUser } from '../selectors/user';
 import { generateMenuItems, createMenuCounter } from '../../utils/menu';
 import { IMenuItem } from '../../types/menu';
@@ -31,7 +36,7 @@ export function* generateMenuSaga() {
   }
 }
 
-type TUpdateCounterAction = PayloadAction<number>  | PayloadAction<TActiveUsersCountFetchFinishedPayload> | PayloadAction<IAccountPlan>;
+type TUpdateCounterAction = PayloadAction<unknown>;
 
 export function* updateCounterSaga(action: TUpdateCounterAction) {
   const tasksCount: ReturnType<typeof getTotalTasksCount> = yield select(getTotalTasksCount);
@@ -45,9 +50,14 @@ export function* updateCounterSaga(action: TUpdateCounterAction) {
     },
     {
       check: () =>
-        [activeUsersCountFetchFinished.type, setCurrentPlan.type].some(
-          (t) => t === action.type,
-        ),
+        [
+          activeUsersCountFetchFinished.type,
+          removeUserFromWs.type,
+          setCurrentPlan.type,
+          teamFetchFinished.type,
+          upsertUserFromWs.type,
+          usersFetchFinished.type,
+        ].some((t) => t === action.type),
       getCounters: () =>
         [createMenuCounter('team', teamCount), createMenuCounter('tenants', tenantCount)].filter(
           Boolean,
@@ -71,7 +81,11 @@ export function* watchUpdateCounter() {
     [
       changeTasksCount.type,
       activeUsersCountFetchFinished.type,
+      removeUserFromWs.type,
       setCurrentPlan.type,
+      teamFetchFinished.type,
+      upsertUserFromWs.type,
+      usersFetchFinished.type,
     ],
     updateCounterSaga,
   );

--- a/frontend/src/public/redux/realtime/__tests__/routeRealtimeEvent.test.ts
+++ b/frontend/src/public/redux/realtime/__tests__/routeRealtimeEvent.test.ts
@@ -1,10 +1,11 @@
-import { call, select } from 'redux-saga/effects';
+import { call, put, select } from 'redux-saga/effects';
 
 import { routeRealtimeEvent } from '../utils/routeRealtimeEvent';
 import { handleRemoveTask } from '../../tasks/saga';
 import { ERealtimeEnvelopeType, IRealtimeWsEnvelope } from '../types';
 import { ETaskListCompletionStatus, ETaskStatus } from '../../../types/tasks';
 import { getTasksSettings } from '../../selectors/tasks';
+import { activeUsersCountFetchFinished, upsertUserFromWs } from '../../accounts/slice';
 
 jest.mock('../../../utils/logger', () => ({
   logger: { info: jest.fn(), error: jest.fn() },
@@ -110,5 +111,46 @@ describe('routeRealtimeEvent — task_deleted list updates', () => {
     const step = gen.next();
 
     expect(step.value).toEqual(call(handleRemoveTask, 45, true));
+  });
+
+  it('USER_CREATED upserts user', () => {
+    const envelope = {
+      id: '5',
+      dateCreatedTsp: 0,
+      type: ERealtimeEnvelopeType.USER_CREATED,
+      data: {
+        id: 2,
+        firstName: 'Artyom',
+        lastName: '',
+        email: 'artyom@test.com',
+        photo: null,
+        isAdmin: false,
+        isAccountOwner: false,
+        managerId: null,
+        subordinatesIds: [],
+      },
+    } as IRealtimeWsEnvelope;
+
+    const gen = routeRealtimeEvent(envelope);
+
+    expect(gen.next().value).toEqual(put(upsertUserFromWs(expect.objectContaining({ id: 2, firstName: 'Artyom' }))));
+    expect(gen.next().done).toBe(true);
+  });
+
+  it('ACCOUNT_PLAN_CHANGED updates active users count', () => {
+    const envelope = {
+      id: '6',
+      dateCreatedTsp: 0,
+      type: ERealtimeEnvelopeType.ACCOUNT_PLAN_CHANGED,
+      data: {
+        activeUsers: 2,
+        tenantsActiveUsers: 1,
+      },
+    } as IRealtimeWsEnvelope;
+
+    const gen = routeRealtimeEvent(envelope);
+
+    expect(gen.next().value).toEqual(put(activeUsersCountFetchFinished({ activeUsers: 2, tenantsActiveUsers: 1 })));
+    expect(gen.next().done).toBe(true);
   });
 });

--- a/frontend/src/public/redux/realtime/types.ts
+++ b/frontend/src/public/redux/realtime/types.ts
@@ -1,5 +1,6 @@
 import { IWorkflowLogItem } from "../../types/workflow";
 import { ETaskStatus } from "../../types/tasks";
+import { EUserStatus, IUserVacation } from "../../types/user";
 import { EUserGroupType } from "../team/types";
 
 export interface IWsEnvelopeBase {
@@ -20,6 +21,7 @@ export enum ERealtimeEnvelopeType {
   GROUP_CREATED = 'group_created',
   GROUP_UPDATED = 'group_updated',
   GROUP_DELETED = 'group_deleted',
+  ACCOUNT_PLAN_CHANGED = 'account_plan_changed',
 }
 
 export type IRealtimeWsEnvelope =
@@ -35,6 +37,8 @@ export type IRealtimeWsEnvelope =
   | (IWsEnvelopeBase & { type: ERealtimeEnvelopeType.GROUP_CREATED; data: IWsGroupData })
   | (IWsEnvelopeBase & { type: ERealtimeEnvelopeType.GROUP_UPDATED; data: IWsGroupData })
   | (IWsEnvelopeBase & { type: ERealtimeEnvelopeType.GROUP_DELETED; data: IWsGroupData })
+  // account events
+  | (IWsEnvelopeBase & { type: ERealtimeEnvelopeType.ACCOUNT_PLAN_CHANGED; data: IWsAccountPlanChangedData })
   // notification events
   | (IWsEnvelopeBase & { type: ERealtimeEnvelopeType.NOTIFICATION_CREATED; data: IWsNotificationCreatedData })
   // process events
@@ -212,10 +216,13 @@ export interface IWsUserData {
   lastName: string;
   email: string;
   photo: string | null;
+  phone?: string;
+  status?: EUserStatus;
   isAdmin: boolean;
   isAccountOwner: boolean;
   managerId: number | null;
   subordinatesIds: number[];
+  vacation?: IUserVacation | null;
 }
 
 export interface IWsGroupData {
@@ -224,6 +231,11 @@ export interface IWsGroupData {
   photo: string | null;
   type: EUserGroupType;
   users: number[];
+}
+
+export interface IWsAccountPlanChangedData {
+  activeUsers: number;
+  tenantsActiveUsers: number;
 }
 
 // ======================= utils

--- a/frontend/src/public/redux/realtime/utils/mapUserFromWs.ts
+++ b/frontend/src/public/redux/realtime/utils/mapUserFromWs.ts
@@ -8,9 +8,9 @@ export function mapWsUserToListItem(user: IWsUserData): TUserListItem {
     ...userData,
     photo: user.photo ?? '',
     type: 'user',
-    phone: '',
-    status: EUserStatus.Active,
+    phone: user.phone ?? '',
+    status: user.status ?? EUserStatus.Active,
     reportIds,
-    vacation: null,
+    vacation: user.vacation ?? null,
   };
 }

--- a/frontend/src/public/redux/realtime/utils/routeRealtimeEvent.ts
+++ b/frontend/src/public/redux/realtime/utils/routeRealtimeEvent.ts
@@ -5,7 +5,7 @@ import type { IStoreTask, IStoreWorkflows } from '../../../types/redux';
 import { ERealtimeEnvelopeType } from '../types';
 
 import { handleAddTask, handleRemoveTask } from '../../tasks/saga';
-import { upsertUserFromWs, removeUserFromWs } from '../../accounts/slice';
+import { activeUsersCountFetchFinished, upsertUserFromWs, removeUserFromWs } from '../../accounts/slice';
 import { mapWsUserToListItem } from './mapUserFromWs';
 import { mapTaskCreatedDataToListItem } from './mapTaskCreatedToListItem';
 import { upsertGroupFromWs, removeGroupFromWs, updateTaskWorkflowLogItem } from '../../actions';
@@ -73,6 +73,10 @@ export function* routeRealtimeEvent(envelope: IRealtimeWsEnvelope) {
     }
     case ERealtimeEnvelopeType.GROUP_DELETED: {
       yield put(removeGroupFromWs(envelope.data.id));
+      break;
+    }
+    case ERealtimeEnvelopeType.ACCOUNT_PLAN_CHANGED: {
+      yield put(activeUsersCountFetchFinished(envelope.data));
       break;
     }
     case ERealtimeEnvelopeType.EVENT_CREATED:


### PR DESCRIPTION
### 1. Release notes

Added real-time synchronization for team users and active-user counters. User create, update, delete, and account-plan WebSocket events now update local user lists, sorting, plan aggregates, and menu counters without requiring a page refresh.

---

### 2. Context

- **Issue:** #16025
- **App Location:** Team (`/team`), account/user selectors, and sidebar Team/Tenants counters.
- **Related Changes:** Extended realtime event mapping, accounts state updates, active-user count loading, and menu counter subscriptions.

---

### 3. Solution & Implementation Details

* **Realtime user upsert:** User create/update events insert or update users in both account and team lists.
* **Realtime user removal:** User delete events remove the user from all local user lists.
* **Stable list sorting:** Realtime updates reapply the selected name/status sorting so new or edited users appear in the correct position.
* **Complete WebSocket mapping:** User phone, status, vacation, manager, and subordinate data are preserved when available, with safe defaults for older payloads.
* **Active-user derivation:** Active counts are recalculated from loaded local users and exclude invited/non-user entries.
* **Pre-fetch count preservation:** WebSocket events received before the initial users request do not overwrite the server-provided aggregate with an incomplete local list.
* **Account plan event:** Added `account_plan_changed` routing to refresh active and tenant user aggregates in real time.
* **Accurate count API:** Added `tenantsActiveUsers` to the active-user count response and removed the previous fallback tenant count.
* **Menu refresh:** Team and tenant menu counters now react to user fetch, team fetch, realtime upsert/removal, plan updates, and aggregate updates.

---

### 4. What to Test

#### 4.1 Preconditions

1. Log in as an account administrator in two browser sessions.
2. Open Team in the first session and keep the sidebar visible.
3. Open Team or Admin user management in the second session.
4. Note current Team and Tenants counters.

#### 4.2 Positive Scenarios / Testing Report

| Scenario | Description (Steps & Expected Result) | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| :--- | :--- | :---: | :---: | :---: | :---: |
| **Create/invite user** | Create or invite a user in session B.<br>**Result:** Session A inserts the user without refresh and keeps the selected sorting. | [ ] | [ ] | [ ] | [ ] |
| **Update user** | Change a user's name, status, role, vacation, or manager data.<br>**Result:** Session A updates the existing row without creating a duplicate. | [ ] | [ ] | [ ] | [ ] |
| **Delete user** | Delete/deactivate a user in session B.<br>**Result:** Session A removes the user from the local list. | [ ] | [ ] | [ ] | [ ] |
| **Name sorting** | Select ascending or descending name sorting, then create/update a user.<br>**Result:** The realtime result appears in the correct sorted position. | [ ] | [ ] | [ ] | [ ] |
| **Status sorting** | Sort by status and invite a user.<br>**Result:** Invited users remain grouped after realtime insertion. | [ ] | [ ] | [ ] | [ ] |
| **Active user counter** | Activate, invite, or remove a user.<br>**Result:** The Team counter reflects active users only. | [ ] | [ ] | [ ] | [ ] |
| **Account plan change** | Trigger an account plan aggregate update.<br>**Result:** Team and tenant counters update through `account_plan_changed`. | [ ] | [ ] | [ ] | [ ] |

#### 4.3 Negative Scenarios & Edge Cases

| Scenario | Description (Steps & Expected Result) | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| :--- | :--- | :---: | :---: | :---: | :---: |
| **Event before initial fetch** | Throttle the users request and trigger a user WebSocket event first.<br>**Result:** The existing aggregate count is preserved until a complete local list is available. | [ ] | [ ] | [ ] | [ ] |
| **Duplicate update event** | Send the same user update more than once.<br>**Result:** Only one row for that user exists. | [ ] | [ ] | [ ] | [ ] |
| **Delete unknown user** | Receive deletion for a user absent from the current list.<br>**Result:** Existing users and aggregate count remain valid. | [ ] | [ ] | [ ] | [ ] |
| **Missing optional WS fields** | Receive a legacy payload without phone, status, or vacation.<br>**Result:** Safe defaults are used and rendering does not fail. | [ ] | [ ] | [ ] | [ ] |
| **Invited user count** | Invite a user without activating them.<br>**Result:** The user appears in Team but is not counted as active. | [ ] | [ ] | [ ] | [ ] |

#### 4.4 Verification Points

- **UI:** Team rows update without a reload and without duplicates.
- **UI:** Current name/status sorting is maintained after every event.
- **Counters:** Team active-user and tenant counters match server/account state.
- **Console:** No unknown realtime event or state-shape warnings.

#### 4.5 API Verification

- **WebSocket events:** Verify `user_created`, `user_updated`, `user_deleted`, and `account_plan_changed` envelopes.
- **User payload:** Verify IDs, status, phone, vacation, manager, and subordinate IDs are mapped when present.
- **Active count request:** Verify the response contains both `activeUsers` and `tenantsActiveUsers`.
- **Account plan payload:** Verify `activeUsers` and `tenantsActiveUsers` update the corresponding store values.

#### 4.6 What Was NOT Tested

- Manual browser matrix testing remains unchecked.
- WebSocket reconnect/backfill behavior after a long offline period.
- Backend event delivery guarantees and ordering.
- Very large team list performance.

---

### 5. Affected Areas

| Scenario | Description | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| :--- | :--- | :---: | :---: | :---: | :---: |
| **Team Users** | Realtime creation, update, removal, and sorting. | [ ] | [ ] | [ ] | [ ] |
| **Accounts Store** | Local lists and active-user aggregate derivation. | [ ] | [ ] | [ ] | [ ] |
| **Sidebar Menu** | Team and tenant counter refresh triggers. | [ ] | [ ] | [ ] | [ ] |
| **Realtime Router** | User and account-plan event routing/mapping. | [ ] | [ ] | [ ] | [ ] |

---

### 6. Unit Tests

- `redux/accounts/__tests__/slice.test.ts`: Covers sorted realtime upserts, deletion, fetched counts, invited users, and pre-fetch count preservation.
- `redux/accounts/__tests__/saga.test.ts`: Verifies tenant aggregate refresh without overwriting the complete local active-user count.
- `redux/menu/__tests__/saga.test.ts`: Verifies menu counter refresh after users and team list changes.
- `redux/realtime/__tests__/routeRealtimeEvent.test.ts`: Covers user upsert and `account_plan_changed` routing alongside existing task event cases.

---

### 7. Commits

- `84c1139e` — `16025 fix(users): update team users in realtime`
- `e03f49ed` — `16025 fix(users): refresh active users aggregate`
- `e7c39154` — `16025 fix(users): preserve count before users fetch`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Update team user counts in realtime via WebSocket events
- Adds handling for `ACCOUNT_PLAN_CHANGED` WebSocket events in [`routeRealtimeEvent.ts`](https://github.com/pneumaticapp/pneumaticworkflow/pull/320/files#diff-b537f732570d083e1f8676825a0777e571312604565d5e9c1f8aedbe3c819d6b), dispatching `activeUsersCountFetchFinished` with `activeUsers` and `tenantsActiveUsers`.
- Updates [`accounts/slice.ts`](https://github.com/pneumaticapp/pneumaticworkflow/pull/320/files#diff-cc636bd6331dcbf7ffca5f09f7a45de665ccbdf2e7541e6880e1d1fe78756ff3) so `upsertUserFromWs` and `removeUserFromWs` recalculate `planInfo.activeUsers` from local user lists after each WebSocket mutation, and maintain list sort order.
- Updates [`accounts/saga.ts`](https://github.com/pneumaticapp/pneumaticworkflow/pull/320/files#diff-3f3761f83879606ea480b556ebf4a7505ca7ccd2a623174e2a913862c58d72e9) to derive active user counts from local team/user lists when available, falling back to the API count.
- Expands menu counter updates in [`menu/saga.ts`](https://github.com/pneumaticapp/pneumaticworkflow/pull/320/files#diff-03ee65be1e006c830e698aaf0157ddb07bca1e09aa1896e5392cdb35284ea492) to trigger on `upsertUserFromWs`, `removeUserFromWs`, `teamFetchFinished`, and `usersFetchFinished`, so the team and tenants counters stay current.
- Maps `phone`, `status`, and `vacation` fields from WebSocket user payloads so invited/vacationing users are reflected correctly in the list.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized e7c3915.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->