### PR TITLE
48394 frontend [ docker ] Set up a file service for local development

### DIFF
--- a/docker-compose.src.yml
+++ b/docker-compose.src.yml
@@ -537,7 +537,7 @@ services:
       AUTH_TOKEN_ITERATIONS: ${FILE_AUTH_TOKEN_ITERATIONS:-1}
     command: >
       sh -c "poetry run alembic -c src/shared_kernel/database/alembic.ini upgrade head &&
-             poetry run python -m src.main"
+             poetry run uvicorn src.main:app --host 0.0.0.0 --port ${FILE_PORT:-8000} --workers ${FILE_WORKERS:-1}"
     depends_on:
       file-postgres:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -539,7 +539,7 @@ services:
       BACKEND_PRIVATE_URL: ${BACKEND_PRIVATE_URL:-http://pneumatic-nginx/}
     command: >
       sh -c "poetry run alembic -c src/shared_kernel/database/alembic.ini upgrade head &&
-             poetry run python -m src.main"
+             poetry run uvicorn src.main:app --host 0.0.0.0 --port ${FILE_PORT:-8000} --workers ${FILE_WORKERS:-1}"
     depends_on:
       file-postgres:
         condition: service_healthy

--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -162,8 +162,8 @@ services:
       VERIFICATION_CHECK: no
       CORS_ORIGIN_ALLOW_ALL: no
       CORS_ALLOW_CREDENTIALS: yes
-      FILE_SERVICE_URL: ${FILE_SERVICE_URL:-http://file-service:8000}
-      CORS_ORIGIN_WHITELIST: "http://localhost:8000 http://localhost:8002"
+      FILE_SERVICE_URL: ${FILE_SERVICE_URL:-http://localhost:8002}
+      CORS_ORIGIN_WHITELIST: "http://localhost:8000 http://localhost:8002 http://localhost:3000"
       ENABLE_LOGGING: ${ENABLE_LOGGING:-no}
     volumes:
       - ../backend:/pneumatic_backend
@@ -277,8 +277,8 @@ services:
       VERIFICATION_CHECK: no
       CORS_ORIGIN_ALLOW_ALL: no
       CORS_ALLOW_CREDENTIALS: yes
-      FILE_SERVICE_URL: ${FILE_SERVICE_URL:-http://file-service:8000}
-      CORS_ORIGIN_WHITELIST: "http://localhost:8000 http://localhost:8002"
+      FILE_SERVICE_URL: ${FILE_SERVICE_URL:-http://localhost:8002}
+      CORS_ORIGIN_WHITELIST: "http://localhost:8000 http://localhost:8002 http://localhost:3000"
       ENABLE_LOGGING: ${ENABLE_LOGGING:-no}
     volumes:
       - ../backend:/pneumatic_backend
@@ -389,8 +389,8 @@ services:
       VERIFICATION_CHECK: no
       CORS_ORIGIN_ALLOW_ALL: no
       CORS_ALLOW_CREDENTIALS: yes
-      FILE_SERVICE_URL: ${FILE_SERVICE_URL:-http://file-service:8000}
-      CORS_ORIGIN_WHITELIST: "http://localhost:8000 http://localhost:8002"
+      FILE_SERVICE_URL: ${FILE_SERVICE_URL:-http://localhost:8002}
+      CORS_ORIGIN_WHITELIST: "http://localhost:8000 http://localhost:8002 http://localhost:3000"
       ENABLE_LOGGING: ${ENABLE_LOGGING:-no}
     volumes:
       - ../backend:/pneumatic_backend
@@ -434,6 +434,9 @@ services:
       KEY_PREFIX_REDIS: ${FILE_KEY_PREFIX_REDIS:-:1:}
       DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY:-django_secret_django_secret_django_secret}
       AUTH_TOKEN_ITERATIONS: ${FILE_AUTH_TOKEN_ITERATIONS:-1}
+    command: >
+      sh -c "poetry run alembic -c src/shared_kernel/database/alembic.ini upgrade head &&
+             poetry run python -m src.main"
     ports:
       - "8002:8000"
     depends_on:
@@ -493,7 +496,7 @@ services:
   seaweedfs-filer:
     image: chrislusf/seaweedfs:3.95
     container_name: pneumatic-seaweedfs-filer
-    command: filer -master="seaweedfs-master:9333" -s3 -s3.port=8333
+    command: filer -master="seaweedfs-master:9333" -s3 -s3.port=8333 -s3.config=/etc/seaweedfs/s3.json
     ports:
       # TODO(production): REMOVE — exposes unauthenticated Filer UI to the internet
       - "8888:8888"  # DEV ONLY
@@ -504,6 +507,7 @@ services:
       - seaweedfs-volume
     volumes:
       - ../storage/seaweedfs/filer.toml:/etc/seaweedfs/filer.toml
+      - ../storage/seaweedfs/s3.json:/etc/seaweedfs/s3.json:ro
       - ../seaweedfs/filer/data:/data:rw
     networks:
       - pneumatic

--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -163,7 +163,7 @@ services:
       CORS_ORIGIN_ALLOW_ALL: no
       CORS_ALLOW_CREDENTIALS: yes
       FILE_SERVICE_URL: ${FILE_SERVICE_URL:-http://localhost:8002}
-      CORS_ORIGIN_WHITELIST: "http://localhost:8000 http://localhost:8002 http://localhost:3000"
+      CORS_ORIGIN_WHITELIST: "http://localhost:8000 http://localhost:8002"
       ENABLE_LOGGING: ${ENABLE_LOGGING:-no}
     volumes:
       - ../backend:/pneumatic_backend
@@ -278,7 +278,7 @@ services:
       CORS_ORIGIN_ALLOW_ALL: no
       CORS_ALLOW_CREDENTIALS: yes
       FILE_SERVICE_URL: ${FILE_SERVICE_URL:-http://localhost:8002}
-      CORS_ORIGIN_WHITELIST: "http://localhost:8000 http://localhost:8002 http://localhost:3000"
+      CORS_ORIGIN_WHITELIST: "http://localhost:8000 http://localhost:8002"
       ENABLE_LOGGING: ${ENABLE_LOGGING:-no}
     volumes:
       - ../backend:/pneumatic_backend
@@ -390,7 +390,7 @@ services:
       CORS_ORIGIN_ALLOW_ALL: no
       CORS_ALLOW_CREDENTIALS: yes
       FILE_SERVICE_URL: ${FILE_SERVICE_URL:-http://localhost:8002}
-      CORS_ORIGIN_WHITELIST: "http://localhost:8000 http://localhost:8002 http://localhost:3000"
+      CORS_ORIGIN_WHITELIST: "http://localhost:8000 http://localhost:8002"
       ENABLE_LOGGING: ${ENABLE_LOGGING:-no}
     volumes:
       - ../backend:/pneumatic_backend

--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -436,7 +436,7 @@ services:
       AUTH_TOKEN_ITERATIONS: ${FILE_AUTH_TOKEN_ITERATIONS:-1}
     command: >
       sh -c "poetry run alembic -c src/shared_kernel/database/alembic.ini upgrade head &&
-             poetry run python -m src.main"
+             poetry run uvicorn src.main:app --host 0.0.0.0 --port ${FILE_PORT:-8000} --workers ${FILE_WORKERS:-1}"
     ports:
       - "8002:8000"
     depends_on:


### PR DESCRIPTION
## 1. Description (problem)
- **What it solves:** This PR configures the new `file-service` for local development, ensuring it is accessible to both the backend and the local frontend server.
- **What was wrong:** Previously, the file service URL pointed to an internal Docker network hostname (`http://file-service:8000`), which the local frontend (`localhost:3000`) could not access directly. Additionally, the S3 configuration for `seaweedfs-filer` was missing, and the service was started via `python -m src.main` instead of an explicit `uvicorn` command.
- **Where it manifested:** When running the local development environment via `docker-compose` and attempting to interact with the file service from the frontend.

## 2. Context
- Integration of the new `file-service` microservice into the project infrastructure.
- Proper port mapping, CORS settings, and startup scripts were required to ensure the service works correctly in a local dev environment (especially with `localhost:3000`).

## 3. Solution
- Updated `FILE_SERVICE_URL` to point to `http://localhost:8002`.
- Added `http://localhost:3000` to `CORS_ORIGIN_WHITELIST` to allow requests from the local React dev server.
- Updated the `file-service` startup script to explicitly use `uvicorn` with host, port, and worker configurations.
- Added the `s3.json` configuration mapping for the `seaweedfs-filer` container.

## 4. Implementation Details
- **Affected files:** `docker-compose.src.yml`, `docker-compose.yml`, `frontend/docker-compose.yml`.
- Mapped port `8002:8000` for the `file-service` in `frontend/docker-compose.yml`.
- The `seaweedfs-filer` container now starts with the `-s3.config=/etc/seaweedfs/s3.json` parameter, and the config file is mounted via volumes.

## 5. What to Test

### 5.1 Preconditions
- Local development environment.
- Branch `frontend/configuration/48394__setup_file_service_for_local_development` checked out.
- Docker Desktop running.

### 5.2 Positive Scenarios
1. Start the project using `docker-compose -f frontend/docker-compose.yml up -d` (or your specific start command).
2. Verify that the `file-service` and `seaweedfs-filer` containers start successfully and do not crash (check logs).
3. Start the local frontend on `http://localhost:3000` and ensure the application runs smoothly, and requests to the file service pass without CORS errors.

### 5.3 Negative Scenarios and Edge Cases
- No specific UI/API negative scenarios, as the changes are purely infrastructure and Docker configuration.

### 5.4 Verification Points
- Container logs for `file-service` (should show successful `uvicorn` startup).
- Container logs for `seaweedfs-filer` (should show successful S3 initialization).

### 5.6 What Was NOT Tested
- Production and Staging environments were not tested (changes only affect local docker-compose files).
- Locales were not tested.

## 6. Testing Affected Areas (dependencies)
- Other backend services (api, celery) should continue to start correctly and interact with the `file-service`. Ensure basic backend functionality is intact.

## 7. Refactoring
- N/A.

## 8. Commits with Fixes
- `d51f1493` 48394 fix(storage): update uvicorn command in docker-compose files
- `ab698cbf` 48394 fix(frontend): configure file service for local development

## 9. Release notes
- Configured `file-service` for local development (updated docker-compose files).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set up file service for local frontend development via uvicorn
> - Replaces `python -m src.main` with a uvicorn-based startup command in the file service container across [`docker-compose.yml`](https://github.com/pneumaticapp/pneumaticworkflow/pull/324/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3), [`docker-compose.src.yml`](https://github.com/pneumaticapp/pneumaticworkflow/pull/324/files#diff-f11168a69acca5524406d63f8be3493d9ca6df2b7f36502a45741fa7eee098aa), and [`frontend/docker-compose.yml`](https://github.com/pneumaticapp/pneumaticworkflow/pull/324/files#diff-1e95c17bec7bd3a8469a19e10405f0f4a25e5c23460ec46d396446161b6a2c73); runs Alembic migrations before starting the server
> - Port and worker count are configurable via `FILE_PORT` and `FILE_WORKERS` environment variables (defaults: 8000 and 1)
> - In [`frontend/docker-compose.yml`](https://github.com/pneumaticapp/pneumaticworkflow/pull/324/files#diff-1e95c17bec7bd3a8469a19e10405f0f4a25e5c23460ec46d396446161b6a2c73), changes the default `FILE_SERVICE_URL` for backend services from `http://file-service:8000` to `http://localhost:8002`, and adds `http://localhost:3000` to `CORS_ORIGIN_WHITELIST`
> - Configures SeaweedFS filer to load S3 settings from `/etc/seaweedfs/s3.json` via a read-only volume mount
> - Behavioral Change: backend services in the frontend compose environment will now target the file service at `http://localhost:8002` by default instead of `http://file-service:8000`
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #324 opened
>
> - Removed `http://localhost:3000` from `CORS_ORIGIN_WHITELIST` environment variable across three services in the Docker Compose configuration for local development [c42fe8c]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized d51f149. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->