### PR TITLE
12704 fix(markdown): support YouTube time_continue links

### DIFF
--- a/frontend/src/public/components/RichText/__tests__/RichText.test.tsx
+++ b/frontend/src/public/components/RichText/__tests__/RichText.test.tsx
@@ -171,6 +171,17 @@ describe('RichText', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  it('embeds a YouTube link when time_continue precedes the video id', () => {
+    const props: IRichTextProps = {
+      text: 'https://www.youtube.com/watch?time_continue=68&v=Bg1n3EEsODs&feature=emb_title',
+      isMarkdownMode: true,
+    };
+
+    const { container } = render(<RichText {...props} />);
+
+    expect(container.querySelector('iframe')?.getAttribute('src')).toBe('//www.youtube.com/embed/Bg1n3EEsODs');
+  });
+
   it('RichText and loom link in text flag return text with loom iframe', () => {
     const props: IRichTextProps = {
       text: 'test1 https://www.loom.com/share/7f68fa7f01e349cab91b0c36168f68c3?t=1',

--- a/frontend/src/public/constants/defaultValues.ts
+++ b/frontend/src/public/constants/defaultValues.ts
@@ -37,7 +37,7 @@ export const hostNameRegex = /(^https?:\/\/)(www[0-9]?\.)?([^/:]+)/i;
 export const mentionsRegex = /\[((?:[^\]\\]|\\.)+)\|([0-9]+)\]/;
 export const variableRegex = /\{\{\s?([а-яa-z0-9\-_]+)\s?\}\}/i;
 export const youtubeVideoRegexp =
-  /(?:http(?:s?):\/\/(?:www\.)?youtu(?:be\.com\/watch\?v=|\.be\/)([\w\-\_]*)(?:&(?:amp;)?‌​[\w\?‌​=]*)?)/gi;
+  /(?:https?:\/\/(?:www\.)?(?:youtube\.com\/watch\?(?:[^#\s&]+&)*v=|youtu\.be\/))([\w-]+)/gi;
 export const loomVideoRegexp =
   /(?:https?:\/\/(?:www\.|stage\.)?(?:use)?(?:loom|loomlocal)\.com(?::4444)?\/share\/([a-f0-9]+))(?:\?t=[0-9]*)?/gi;
 export const wistiaVideoRegexp = /(?:https?:\/\/)?[a-z0-9]+\.wistia\.com\/medias\/([a-z0-9]+)/gi;


### PR DESCRIPTION
### 1. Release notes

Fixed YouTube video embedding for watch URLs where `time_continue` or another query parameter appears before the `v` video identifier.

---

### 2. Context

- **Issue:** #12704
- **App Location:** Rich text content containing embedded video links, including task descriptions, comments, and instructions.
- **Related Changes:** Updated the shared YouTube URL matcher used by RichText embedding and video-paste analytics.

---

### 3. Solution & Implementation Details

* **Query parameter support:** Updated `youtubeVideoRegexp` to allow one or more query parameters before the `v` parameter.
* **Correct ID extraction:** The matcher captures only the YouTube video ID from URLs such as `https://www.youtube.com/watch?time_continue=68&v=Bg1n3EEsODs&feature=emb_title`.
* **Existing formats preserved:** Standard `youtube.com/watch?v=...` and `youtu.be/...` URLs remain supported.
* **Shared fix:** Because the common regex is reused, both RichText iframe generation and paste analytics recognize the extended format.
* **Regression coverage:** Added a RichText test using the reported URL and verified the expected embed source.

---

### 4. What to Test

#### 4.1 Preconditions

1. Log in to the application.
2. Open any rich-text input that supports video embedding.
3. Have a valid YouTube video URL available.

#### 4.2 Positive Scenarios / Testing Report

| Scenario | Description (Steps & Expected Result) | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| :--- | :--- | :---: | :---: | :---: | :---: |
| **time_continue before video ID** | Paste `https://www.youtube.com/watch?time_continue=68&v=Bg1n3EEsODs&feature=emb_title`.<br>**Result:** The link renders as a YouTube iframe using video ID `Bg1n3EEsODs`. | [ ] | [ ] | [ ] | [ ] |
| **Standard watch URL** | Paste `https://www.youtube.com/watch?v=Bg1n3EEsODs`.<br>**Result:** Existing embedding behavior remains unchanged. | [ ] | [ ] | [ ] | [ ] |
| **Short YouTube URL** | Paste `https://youtu.be/Bg1n3EEsODs`.<br>**Result:** Existing short-link embedding remains unchanged. | [ ] | [ ] | [ ] | [ ] |
| **Additional preceding parameters** | Paste a watch URL containing multiple query parameters before `v`.<br>**Result:** The correct video ID is extracted and embedded. | [ ] | [ ] | [ ] | [ ] |

#### 4.3 Negative Scenarios & Edge Cases

| Scenario | Description (Steps & Expected Result) | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| :--- | :--- | :---: | :---: | :---: | :---: |
| **Missing video ID** | Paste a YouTube watch URL without a `v` parameter.<br>**Result:** It is not converted into an invalid iframe. | [ ] | [ ] | [ ] | [ ] |
| **Unrelated query parameter containing v** | Paste a URL where `v` is part of another parameter name.<br>**Result:** It is not interpreted as the video ID parameter. | [ ] | [ ] | [ ] | [ ] |
| **Non-YouTube URL** | Paste a regular URL with a `v` query parameter.<br>**Result:** It remains a normal link. | [ ] | [ ] | [ ] | [ ] |
| **YouTube URL mixed with text** | Add text before and after the reported URL.<br>**Result:** Text remains visible and only the URL becomes an iframe. | [ ] | [ ] | [ ] | [ ] |

#### 4.4 Verification Points

- **UI:** The video iframe appears instead of a plain link.
- **Embed source:** The iframe `src` is `//www.youtube.com/embed/Bg1n3EEsODs`.
- **Regression:** Existing standard and short YouTube links continue to embed.
- **Console:** No URL parsing or iframe rendering errors.

#### 4.5 API Verification

- No API contract or request changes are included.
- Verification is limited to client-side URL recognition and iframe generation.

#### 4.6 What Was NOT Tested

- Manual browser matrix testing remains unchecked.
- Private, removed, age-restricted, or region-restricted YouTube videos.
- YouTube playlist and Shorts URL formats.
- External YouTube availability and playback behavior.

---

### 5. Affected Areas

| Scenario | Description | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| :--- | :--- | :---: | :---: | :---: | :---: |
| **RichText Video Embedding** | Recognition and rendering of YouTube watch URLs. | [ ] | [ ] | [ ] | [ ] |
| **Video Paste Analytics** | Recognition of the same URL format by the shared matcher. | [ ] | [ ] | [ ] | [ ] |

---

### 6. Unit Tests

- `RichText.test.tsx`: Added a regression case proving that a YouTube URL with `time_continue` before `v` renders `//www.youtube.com/embed/Bg1n3EEsODs`.
- Automated result: 33 RichText tests passed; 5 snapshots passed.
- ESLint passed for the modified source file; the test path is excluded by the repository ESLint configuration.

---

### 7. Commits

- `fcd9c34e` — `12704 fix(rich-text): support YouTube time_continue links`
