### PR TITLE
48648 frontend [ fieldsets ] Type conflict in IKickoffClient between Template Editor and Runtime

### DIFF
--- a/frontend/src/public/__stubs__/templates.factory.ts
+++ b/frontend/src/public/__stubs__/templates.factory.ts
@@ -1,4 +1,4 @@
-import { IKickoffClient, ITemplateResponse, ITemplateTask, ITemplateTaskClient } from '../types/template';
+import { ITemplateKickoffClient, ITemplateResponse, ITemplateTask, ITemplateTaskClient } from '../types/template';
 import { createEmptyTaskDueDate } from '../utils/dueDate/createEmptyTaskDueDate';
 
 export const makeTemplateTaskClient = (overrides: Partial<ITemplateTaskClient> = {}): ITemplateTaskClient => ({
@@ -42,7 +42,7 @@ export const makeTemplateTask = (overrides: Partial<ITemplateTask> = {}): ITempl
   ...overrides,
 });
 
-export const makeKickoffClient = (overrides: Partial<IKickoffClient> = {}): IKickoffClient => ({
+export const makeKickoffClient = (overrides: Partial<ITemplateKickoffClient> = {}): ITemplateKickoffClient => ({
   description: '',
   fields: [],
   fieldsets: [],

--- a/frontend/src/public/components/KickoffEdit/KickoffEdit.tsx
+++ b/frontend/src/public/components/KickoffEdit/KickoffEdit.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useEffect } from 'react';
 import classnames from 'classnames';
 import { useIntl } from 'react-intl';
-import { IExtraField, IKickoffClient } from '../../types/template';
+import { IExtraField, IRuntimeKickoffClient } from '../../types/template';
 import { IFieldsetRuntime } from '../../types/fieldset';
 import { EInputNameBackgroundColor } from '../../types/workflow';
 import { isArrayWithItems } from '../../utils/helpers';
@@ -17,7 +17,7 @@ import { Button } from '../UI/Buttons/Button';
 import styles from './KickoffEdit.css';
 
 export interface IEditKickoffProps {
-  kickoff: IKickoffClient | null;
+  kickoff: IRuntimeKickoffClient | null;
   fieldsets?: IFieldsetRuntime[];
   isLoading?: boolean;
   accountId: number;

--- a/frontend/src/public/components/PublicFormsApp/common/types.ts
+++ b/frontend/src/public/components/PublicFormsApp/common/types.ts
@@ -1,9 +1,6 @@
-import { IKickoffClient } from '../../../types/template';
-import { IFieldsetRuntime } from '../../../types/fieldset';
+import { IRuntimeKickoffClient } from '../../../types/template';
 
-export interface IPublicFormKickoff extends Omit<IKickoffClient, 'fieldsets'> {
-  fieldsets: IFieldsetRuntime[];
-}
+export type IPublicFormKickoff = IRuntimeKickoffClient;
 
 export interface IPublicForm {
   accountId: number;

--- a/frontend/src/public/components/TemplateEdit/KickoffRedux/KickoffRedux.tsx
+++ b/frontend/src/public/components/TemplateEdit/KickoffRedux/KickoffRedux.tsx
@@ -20,7 +20,7 @@ import { MergedOutputRows } from '../TaskOutputFlow/MergedOutputRows';
 
 import { KickoffMenu } from './KickoffMenu';
 import { IntlMessages } from '../../IntlMessages';
-import {  EExtraFieldType, IExtraField, ETemplateParts, IKickoffClient, ITemplateClient } from '../../../types/template';
+import {  EExtraFieldType, IExtraField, ETemplateParts, ITemplateKickoffClient, ITemplateClient } from '../../../types/template';
 import { IFieldsetCatalogItem } from '../../../types/fieldset';
 import { isArrayWithItems } from '../../../utils/helpers';
 import { ExtraFieldsMap } from '../ExtraFields/utils/ExtraFieldsMap';
@@ -44,7 +44,7 @@ export interface IKickoffReduxProps {
   intl: IntlShape;
   accountId: number;
   templateStatus: ETemplateStatus;
-  setKickoff(value: IKickoffClient): void;
+  setKickoff(value: ITemplateKickoffClient): void;
 }
 
 export function KickoffRedux({
@@ -84,7 +84,7 @@ export function KickoffRedux({
     setIsOpen(!isOpen);
   };
 
-  const handleChangeKickoff = (newKickoff: IKickoffClient) => {
+  const handleChangeKickoff = (newKickoff: ITemplateKickoffClient) => {
     setKickoff(newKickoff);
   };
 

--- a/frontend/src/public/components/TemplateEdit/KickoffRedux/__tests__/KickoffRedux.test.tsx
+++ b/frontend/src/public/components/TemplateEdit/KickoffRedux/__tests__/KickoffRedux.test.tsx
@@ -7,7 +7,7 @@ import { makeExtraField } from '../../../../__stubs__/fields.factory';
 import { makeFieldsetBindingClient, makeFieldsetField } from '../../../../__stubs__/fieldsets.factory';
 import {
   IExtraField,
-  IKickoffClient,
+  ITemplateKickoffClient,
   ITemplateClient,
 } from '../../../../types/template';
 import { IFieldsetCatalogItem } from '../../../../types/fieldset';
@@ -175,14 +175,14 @@ describe('KickoffRedux', () => {
     ...overrides,
   });
 
-  const makeKickoff = (overrides: Partial<IKickoffClient> = {}): IKickoffClient => ({
+  const makeKickoff = (overrides: Partial<ITemplateKickoffClient> = {}): ITemplateKickoffClient => ({
     description: '',
     fields: [],
     fieldsets: [],
     ...overrides,
   });
 
-  const makeTemplate = (kickoff: IKickoffClient): ITemplateClient => ({
+  const makeTemplate = (kickoff: ITemplateKickoffClient): ITemplateClient => ({
     id: 1,
     kickoff,
     wfNameTemplate: '',
@@ -195,7 +195,7 @@ describe('KickoffRedux', () => {
   });
 
   const renderKickoff = (params: {
-    kickoff: IKickoffClient;
+    kickoff: ITemplateKickoffClient;
     setKickoff?: jest.Mock;
   }) => {
     const setKickoff = params.setKickoff ?? jest.fn();

--- a/frontend/src/public/components/TemplateEdit/KickoffRedux/utils/isKickoffCleared.ts
+++ b/frontend/src/public/components/TemplateEdit/KickoffRedux/utils/isKickoffCleared.ts
@@ -1,9 +1,9 @@
 /* eslint-disable */
 /* prettier-ignore */
-import { IKickoffClient } from '../../../../types/template';
+import { ITemplateKickoffClient } from '../../../../types/template';
 import { isArrayWithItems } from '../../../../utils/helpers';
 
-export const isKickoffCleared = (kickoff: IKickoffClient) => {
+export const isKickoffCleared = (kickoff: ITemplateKickoffClient) => {
   const hasFields = isArrayWithItems(kickoff.fields);
 
   return !hasFields && !kickoff.description;

--- a/frontend/src/public/components/TemplateEdit/TaskForm/DueDate/DueDate.tsx
+++ b/frontend/src/public/components/TemplateEdit/TaskForm/DueDate/DueDate.tsx
@@ -5,7 +5,7 @@ import classnames from 'classnames';
 import { DropdownList, Duration } from '../../../UI';
 import { TrashIcon } from '../../../icons';
 
-import { IDueDate, IKickoffClient, ITemplateTaskClient } from '../../../../types/template';
+import { IDueDate, ITemplateKickoffClient, ITemplateTaskClient } from '../../../../types/template';
 import { START_DURATION } from '../../constants';
 import { getRuleTargetOptions, TRuleTargetOption } from './utils/getRuleTargetOptions';
 import { getRulePrepositionOptions, TRulePrepositionOption } from './utils/getRulePrepositionOptions';
@@ -17,7 +17,7 @@ import stylesTaskForm from '../TaskForm.css';
 interface IDueInProps {
   currentTask: ITemplateTaskClient;
   tasks: ITemplateTaskClient[];
-  kickoff: IKickoffClient;
+  kickoff: ITemplateKickoffClient;
   onChange(value: IDueDate): void;
   dueDate: ITemplateTaskClient['rawDueDate'];
 }

--- a/frontend/src/public/components/TemplateEdit/TaskForm/DueDate/utils/__tests__/getRuleTargetOptions.test.ts
+++ b/frontend/src/public/components/TemplateEdit/TaskForm/DueDate/utils/__tests__/getRuleTargetOptions.test.ts
@@ -1,4 +1,4 @@
-import { EExtraFieldType, IKickoffClient, ITemplateTaskClient } from '../../../../../../types/template';
+import { EExtraFieldType, ITemplateKickoffClient, ITemplateTaskClient } from '../../../../../../types/template';
 import { makeFieldsetField, makeFieldsetBindingClient } from '../../../../../../__stubs__/fieldsets.factory';
 import { createEmptyTaskDueDate } from '../../../../../../utils/dueDate/createEmptyTaskDueDate';
 import { getRuleTargetOptions } from '../getRuleTargetOptions';
@@ -28,7 +28,7 @@ const makeTask = (overrides: Partial<ITemplateTaskClient> = {}): ITemplateTaskCl
   ...overrides,
 });
 
-const makeKickoff = (overrides: Partial<IKickoffClient> = {}): IKickoffClient => ({
+const makeKickoff = (overrides: Partial<ITemplateKickoffClient> = {}): ITemplateKickoffClient => ({
   description: '',
   fields: [],
   fieldsets: [],

--- a/frontend/src/public/components/TemplateEdit/TaskForm/DueDate/utils/getRuleTargetOptions.ts
+++ b/frontend/src/public/components/TemplateEdit/TaskForm/DueDate/utils/getRuleTargetOptions.ts
@@ -1,6 +1,6 @@
 import {
   EExtraFieldType,
-  IKickoffClient,
+  ITemplateKickoffClient,
   ITemplateTaskClient,
   TDueDateRuleTarget,
 } from '../../../../../types/template';
@@ -16,7 +16,7 @@ export type TRuleTargetOption = TDropdownOptionBase & {
 export function getRuleTargetOptions(
   currentTask: ITemplateTaskClient,
   tasks: ITemplateTaskClient[],
-  kickoff: IKickoffClient,
+  kickoff: ITemplateKickoffClient,
 ): readonly [TRuleTargetOption[], TRuleTargetOption[], TRuleTargetOption[]] {
   const prevTasks = getPreviousTasks(currentTask, tasks);
   const prevDateVariables = getTaskVariables(kickoff, tasks, currentTask).filter(

--- a/frontend/src/public/components/TemplateEdit/TaskForm/TaskForm.tsx
+++ b/frontend/src/public/components/TemplateEdit/TaskForm/TaskForm.tsx
@@ -6,7 +6,7 @@ import { useSelector } from 'react-redux';
 import { TaskDescriptionEditor } from './TaskDescriptionEditor';
 import { scrollToElement } from '../../../utils/helpers';
 import { TUserListItem } from '../../../types/user';
-import { IKickoffClient, ITemplateTaskClient } from '../../../types/template';
+import { ITemplateKickoffClient, ITemplateTaskClient } from '../../../types/template';
 import { TTaskVariable, TTaskFormPart, ETaskFormParts } from '../types';
 import { OutputFormIntl } from '../OutputForm/OutputForm';
 import { ShowMore } from '../../UI/ShowMore';
@@ -38,7 +38,7 @@ export interface ITaskFormProps {
   accountId: number;
   isTeamInvitesModalOpen: boolean;
   tasks: ITemplateTaskClient[];
-  kickoff: IKickoffClient;
+  kickoff: ITemplateKickoffClient;
   patchTask(args: TPatchTaskPayload): void;
 }
 

--- a/frontend/src/public/components/TemplateEdit/TaskForm/utils/__tests__/getTaskVariables.test.ts
+++ b/frontend/src/public/components/TemplateEdit/TaskForm/utils/__tests__/getTaskVariables.test.ts
@@ -1,7 +1,7 @@
 import { createElement } from 'react';
 import { render, screen } from '@testing-library/react';
 
-import { EExtraFieldType, IKickoffClient, ITemplateTaskClient } from '../../../../../types/template';
+import { EExtraFieldType, ITemplateKickoffClient, ITemplateTaskClient } from '../../../../../types/template';
 import { IFieldsetRuntime } from '../../../../../types/fieldset';
 import { makeExtraField } from '../../../../../__stubs__/fields.factory';
 import { makeFieldsetRuntime, makeFieldsetBindingClient, makeFieldsetField } from '../../../../../__stubs__/fieldsets.factory';
@@ -20,7 +20,7 @@ import {
   SYSTEM_VARIABLE_SUBTITLE,
 } from '../getTaskVariables';
 
-const mockKikoff: IKickoffClient = {
+const mockKikoff: ITemplateKickoffClient = {
   description: 'Kickoff description',
   fields: [
     makeExtraField({
@@ -223,7 +223,7 @@ describe('getTaskVariables', () => {
 
 describe('getKickoffVariables with fieldsets', () => {
   it('adds kickoff fieldset fields after regular kickoff fields', () => {
-    const kickoff: IKickoffClient = {
+    const kickoff: ITemplateKickoffClient = {
       ...mockKikoff,
       fieldsets: [makeFieldsetBindingClient({
         apiNameBinding: mockFieldsetData.apiNameBinding,
@@ -242,7 +242,7 @@ describe('getKickoffVariables with fieldsets', () => {
   });
 
   it('skips fieldset missing from catalog without crashing or producing phantom options', () => {
-    const kickoff: IKickoffClient = {
+    const kickoff: ITemplateKickoffClient = {
       ...mockKikoff,
       fieldsets: [
         makeFieldsetBindingClient({ apiNameBinding: 'missing-fs' }),
@@ -379,7 +379,7 @@ describe('useWorkflowNameVariables', () => {
 
   it('includes 4 system variables plus single-line kickoff and fieldset fields, filters out multi-line types', () => {
 
-    const kickoff: IKickoffClient = {
+    const kickoff: ITemplateKickoffClient = {
       description: '',
       fields: [
         makeExtraField({

--- a/frontend/src/public/components/TemplateEdit/TaskForm/utils/getTaskVariables.tsx
+++ b/frontend/src/public/components/TemplateEdit/TaskForm/utils/getTaskVariables.tsx
@@ -4,7 +4,8 @@ import { useMemo } from 'react';
 import { useIntl } from 'react-intl';
 
 import {
-  IKickoffClient,
+  ITemplateKickoffClient,
+  IRuntimeKickoffClient,
   IExtraField,
   ITemplateTaskClient,
   IFieldsetBindingClient,
@@ -46,7 +47,7 @@ export function getLocalizedSystemVariable({
 }
 
 type TGetVariablesParam = {
-  kickoff: Pick<IKickoffClient, 'fields'> & { fieldsets?: (IFieldsetBindingClient | TTemplateFieldFieldset)[] };
+  kickoff: Pick<ITemplateKickoffClient, 'fields'> & { fieldsets?: (IFieldsetBindingClient | TTemplateFieldFieldset)[] };
   tasks: (Pick<ITemplateTaskClient, 'fields' | 'apiName'> & {
     name?: ITemplateTaskClient['name'];
     fieldsets?: (IFieldsetBindingClient | TTemplateFieldFieldset)[];
@@ -131,7 +132,7 @@ export function getVariables(params: TGetVariablesParam): TTaskVariable[] {
 }
 
 export function getKickoffVariables(
-  kickoff?: Pick<IKickoffClient, 'fields'> & { fieldsets?: (IFieldsetBindingClient | TTemplateFieldFieldset)[] },
+  kickoff?: Pick<ITemplateKickoffClient, 'fields'> & { fieldsets?: (IFieldsetBindingClient | TTemplateFieldFieldset)[] },
 ) {
   const fromFields = kickoff?.fields.map((field) => getVariableFromField(field, 'Kick-off form')) ?? [];
   const fromFieldsets = getVariablesFromSelectedFieldsets(
@@ -144,7 +145,7 @@ export function getKickoffVariables(
 }
 
 export function getTaskVariables(
-  kickoff: IKickoffClient,
+  kickoff: ITemplateKickoffClient,
   tasks: ITemplateTaskClient[],
   currentTask: ITemplateTaskClient,
   templateId?: number,
@@ -189,7 +190,7 @@ export const getSingleLineVariables = (variables: TTaskVariable[]) => {
 };
 
 export const useWorkflowNameVariables = (
-  kickoff?: Pick<IKickoffClient, 'fields' | 'fieldsets'>,
+  kickoff?: Pick<ITemplateKickoffClient | IRuntimeKickoffClient, 'fields' | 'fieldsets'>,
 ) => {
   const { formatMessage } = useIntl();
 

--- a/frontend/src/public/components/TemplateEdit/utils/__tests__/getRunnableWorkflow.test.ts
+++ b/frontend/src/public/components/TemplateEdit/utils/__tests__/getRunnableWorkflow.test.ts
@@ -1,4 +1,4 @@
-import { ETaskPerformerType, EExtraFieldType, IKickoffClient } from '../../../../types/template';
+import { ETaskPerformerType, EExtraFieldType, ITemplateKickoffClient } from '../../../../types/template';
 import { IFieldsetRuntime } from '../../../../types/fieldset';
 import { makeExtraField } from '../../../../__stubs__/fields.factory';
 import { makeFieldsetRuntime } from '../../../../__stubs__/fieldsets.factory';
@@ -200,7 +200,7 @@ describe('getRunnableWorkflow.', () => {
 
 
   it('loadDatasetsMap returns {} and does not call getDataset when there are no dataset ids', async () => {
-    const kickoff: IKickoffClient = { description: '', fields: [], fieldsets: [] };
+    const kickoff: ITemplateKickoffClient = { description: '', fields: [], fieldsets: [] };
 
     const result = await loadDatasetsMap(kickoff, []);
 
@@ -209,7 +209,7 @@ describe('getRunnableWorkflow.', () => {
   });
 
   it('loadDatasetsMap dedups dataset id shared by a kickoff field and a fieldset field', async () => {
-    const kickoff: IKickoffClient = {
+    const kickoff: ITemplateKickoffClient = {
       description: '',
       fields: [makeExtraField({ apiName: 'k-f', name: 'K', type: EExtraFieldType.Checkbox, dataset: 7 })],
       fieldsets: [],

--- a/frontend/src/public/components/TemplateEdit/utils/getRunnableWorkflow.ts
+++ b/frontend/src/public/components/TemplateEdit/utils/getRunnableWorkflow.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
 /* prettier-ignore */
-import { ITemplateClient, ITemplateTaskClient, IKickoffClient, IExtraField } from '../../../types/template';
+import { ITemplateClient, ITemplateTaskClient, ITemplateKickoffClient, IExtraField } from '../../../types/template';
 import { IFieldsetRuntime } from '../../../types/fieldset';
 import { setPerformersCounts } from '../../../utils/template';
 import { IRunWorkflow } from '../../WorkflowEditPopup/types';
@@ -15,7 +15,7 @@ export type TTemplateToRunWorkflow = Pick<
 
 import { getDataset } from '../../../api/datasets/getDataset';
 
-function getKickoffDatasetIds(kickoff: IKickoffClient, fieldsets: IFieldsetRuntime[] = []): number[] {
+function getKickoffDatasetIds(kickoff: ITemplateKickoffClient, fieldsets: IFieldsetRuntime[] = []): number[] {
   const ids = new Set<number>();
   for (const field of kickoff.fields) {
     if (field.dataset) ids.add(field.dataset);
@@ -28,7 +28,7 @@ function getKickoffDatasetIds(kickoff: IKickoffClient, fieldsets: IFieldsetRunti
   return [...ids];
 }
 
-export async function loadDatasetsMap(kickoff: IKickoffClient, fieldsets: IFieldsetRuntime[] = []): Promise<Record<number, string[]>> {
+export async function loadDatasetsMap(kickoff: ITemplateKickoffClient, fieldsets: IFieldsetRuntime[] = []): Promise<Record<number, string[]>> {
   const datasetIds = getKickoffDatasetIds(kickoff, fieldsets);
   if (datasetIds.length === 0) {
     return {};
@@ -56,7 +56,7 @@ function applyDatasetsToFields(fields: IExtraField[], datasetsMap: Record<number
   }));
 }
 
-function convertSelectionsToValues(kickoff: IKickoffClient, datasetsMap: Record<number, string[]>): IKickoffClient {
+function convertSelectionsToValues(kickoff: ITemplateKickoffClient, datasetsMap: Record<number, string[]>): ITemplateKickoffClient {
   return {
     ...kickoff,
     fields: applyDatasetsToFields(kickoff.fields, datasetsMap),

--- a/frontend/src/public/components/WorkflowEditPopup/types.ts
+++ b/frontend/src/public/components/WorkflowEditPopup/types.ts
@@ -1,10 +1,11 @@
-import { ITemplateClient } from '../../types/template';
+import { ITemplateClient, ITemplateKickoffClient, IRuntimeKickoffClient } from '../../types/template';
 import { IFieldsetRuntime } from '../../types/fieldset';
 
-export interface IRunWorkflow extends Pick<ITemplateClient, 'wfNameTemplate' | 'name' | 'kickoff' | 'description'> {
+export interface IRunWorkflow extends Omit<Pick<ITemplateClient, 'wfNameTemplate' | 'name' | 'kickoff' | 'description'>, 'kickoff'> {
   id: number;
   tasksCount: number;
   performersCount: number;
+  kickoff: ITemplateKickoffClient | IRuntimeKickoffClient;
   isUrgent?: boolean;
   ancestorTaskId?: number;
   dueDate?: string;

--- a/frontend/src/public/components/WorkflowEditPopup/utils/getInitialKickoff.ts
+++ b/frontend/src/public/components/WorkflowEditPopup/utils/getInitialKickoff.ts
@@ -1,8 +1,6 @@
-/* eslint-disable */
-/* prettier-ignore */
-import { IKickoffClient } from '../../../types/template';
+import { ITemplateKickoffClient, IRuntimeKickoffClient } from '../../../types/template';
 import { ExtraFieldsHelper } from '../../TemplateEdit/ExtraFields/utils/ExtraFieldsHelper';
 
-export function getInitialKickoff(kickoff: IKickoffClient): IKickoffClient {
+export function getInitialKickoff<T extends ITemplateKickoffClient | IRuntimeKickoffClient>(kickoff: T): T {
   return { ...kickoff, fields: new ExtraFieldsHelper(kickoff.fields).getFieldsWithValues() };
 }

--- a/frontend/src/public/components/Workflows/WorkflowsGridPage/WorkflowCard/utils/__tests__/getClonedKickoff.test.ts
+++ b/frontend/src/public/components/Workflows/WorkflowsGridPage/WorkflowCard/utils/__tests__/getClonedKickoff.test.ts
@@ -1,7 +1,7 @@
 import { IWorkflowDetailsKickoff } from '../../../../../../types/workflow';
-import { EExtraFieldType, IKickoffClient, IFieldsetBindingClient } from '../../../../../../types/template';
+import { EExtraFieldType, ITemplateKickoffClient } from '../../../../../../types/template';
 import { IFieldsetRuntime } from '../../../../../../types/fieldset';
-import { makeFieldsetRuntime } from '../../../../../../__stubs__/fieldsets.factory';
+import { makeFieldsetRuntime, makeFieldsetBindingClient, makeFieldsetField } from '../../../../../../__stubs__/fieldsets.factory';
 import { makeExtraField } from '../../../../../../__stubs__/fields.factory';
 import { getClonedKickoff } from '../getClonedKickoff';
 
@@ -119,7 +119,7 @@ const mockWorkflowDetailKickoff: IWorkflowDetailsKickoff = {
   ],
 };
 
-const templateKickoffMock: IKickoffClient = {
+const templateKickoffMock: ITemplateKickoffClient = {
   description:
     ' youtube: \nhttps://www.youtube.com/watch?v=JZRm7NKTPhk\n loom:\nhttps://www.loom.com/share/29f210bc12484eaa81ca462381fb4415?t=0\n 404 loom:\n\nhttps://www.loom.com/share/9853f0790ad2408094a3717bfcf4a0c0\nYoutube 404 :\n\nhttps://www.youtube.com/watch?v=D6hIeqZt22g',
   fields: [
@@ -333,7 +333,7 @@ describe('getClonedKickoff', () => {
         ],
       };
 
-      const emptyTemplateKickoff: IKickoffClient = {
+      const emptyTemplateKickoff: ITemplateKickoffClient = {
         description: '',
         fields: [],
         fieldsets: [],
@@ -371,7 +371,7 @@ describe('getClonedKickoff', () => {
         ],
       };
 
-      const templateKickoff: IKickoffClient = {
+      const templateKickoff: ITemplateKickoffClient = {
         description: '',
         fields: [
           {
@@ -411,7 +411,7 @@ describe('getClonedKickoff', () => {
         ],
       };
 
-      const templateKickoff: IKickoffClient = {
+      const templateKickoff: ITemplateKickoffClient = {
         description: '',
         fields: [
           {
@@ -455,22 +455,26 @@ describe('getClonedKickoff', () => {
         ],
       };
 
-      const templateKickoff: IKickoffClient = {
+      const templateKickoff: ITemplateKickoffClient = {
         description: '',
         fields: [],
         fieldsets: [
-          makeFieldsetRuntime({
+          makeFieldsetBindingClient({
             apiNameBinding: 'fs-1',
             name: 'Fieldset 1',
             fields: [
-              makeExtraField({
+              makeFieldsetField({
                 apiName: 'fs-field-1',
                 name: 'FS Checkbox',
                 type: EExtraFieldType.Checkbox,
-                selections: ['Opt1', 'Opt2', 'Opt3'],
+                selections: [
+                  { apiName: 'Opt1', value: 'Opt1' },
+                  { apiName: 'Opt2', value: 'Opt2' },
+                  { apiName: 'Opt3', value: 'Opt3' },
+                ],
               }),
             ],
-          }) as unknown as IFieldsetBindingClient,
+          }),
         ],
       };
 
@@ -495,15 +499,15 @@ describe('getClonedKickoff', () => {
         ],
       };
 
-      const templateKickoff: IKickoffClient = {
+      const templateKickoff: ITemplateKickoffClient = {
         description: '',
         fields: [],
         fieldsets: [
-          makeFieldsetRuntime({
+          makeFieldsetBindingClient({
             apiNameBinding: 'fs-valid',
             name: 'Valid Fieldset',
             fields: [],
-          }) as unknown as IFieldsetBindingClient,
+          }),
         ],
       };
 
@@ -534,21 +538,21 @@ describe('getClonedKickoff', () => {
         ],
       };
 
-      const templateKickoff: IKickoffClient = {
+      const templateKickoff: ITemplateKickoffClient = {
         description: '',
         fields: [],
         fieldsets: [
-          makeFieldsetRuntime({
+          makeFieldsetBindingClient({
             apiNameBinding: 'raw-backend-fs',
             name: 'Template Fieldset',
             fields: [
-              makeExtraField({
+              makeFieldsetField({
                 apiName: 'raw-field-1',
                 name: 'Field 1',
                 type: EExtraFieldType.String,
               }),
             ],
-          }) as unknown as IFieldsetBindingClient,
+          }),
         ],
       };
 

--- a/frontend/src/public/components/Workflows/WorkflowsGridPage/WorkflowCard/utils/getClonedKickoff.ts
+++ b/frontend/src/public/components/Workflows/WorkflowsGridPage/WorkflowCard/utils/getClonedKickoff.ts
@@ -3,15 +3,15 @@
 import {
   EExtraFieldType,
   IExtraField,
-  IKickoffClient,
+  ITemplateKickoffClient,
+  IRuntimeKickoffClient,
   TExtraFieldValue,
-  IFieldsetBindingClient,
 } from '../../../../../types/template';
 import { IWorkflowDetailsKickoff } from '../../../../../types/workflow';
 import { getEditKickoff } from '../../../../../utils/workflows';
 import { normalizeSelections } from '../../../../TemplateEdit/utils/normalizeSelections';
 import { normalizeCheckboxValue } from '../../../../../utils/fields';
-import { IFieldsetField } from '../../../../../types/fieldset';
+import { IFieldsetField, IFieldsetRuntime } from '../../../../../types/fieldset';
 
 function normalizeKickoffFields(
   fields: (IExtraField | IFieldsetField)[] = [],
@@ -31,12 +31,12 @@ function normalizeKickoffFields(
 
 export function getClonedKickoff(
   workflowKickoff: IWorkflowDetailsKickoff,
-  templateKickoff: IKickoffClient,
-): IKickoffClient {
+  templateKickoff: ITemplateKickoffClient,
+): IRuntimeKickoffClient {
   const kickoff = getEditKickoff(workflowKickoff);
   const finalFields = normalizeKickoffFields(kickoff.fields, templateKickoff.fields);
 
-  const finalFieldsets = (kickoff.fieldsets || [])
+  const finalFieldsets: IFieldsetRuntime[] = (kickoff.fieldsets || [])
     .map((fieldset) => {
       // TODO (Technical Debt): Backend workflow fieldsets contain raw properties (id, apiName),
       // while client-side template fieldsets expect apiNameBinding.
@@ -56,15 +56,12 @@ export function getClonedKickoff(
         fields: normalizeKickoffFields(fieldset.fields, templateFieldset.fields),
       };
     })
-    .filter(Boolean);
+    .filter((fieldset): fieldset is IFieldsetRuntime => Boolean(fieldset));
 
-  // TODO (Technical Debt): IKickoffClient.fieldsets is typed as IFieldsetBindingClient[] (template editor shape),
-  // but runtime workflow execution components expect IFieldsetRuntime[] (with IExtraField[]).
-  // Cast is required until IKickoffClient type is separated/narrowed between editor and runtime contexts.
   return {
     ...kickoff,
     fields: finalFields,
-    fieldsets: finalFieldsets as unknown as IFieldsetBindingClient[],
+    fieldsets: finalFieldsets,
   };
 }
 

--- a/frontend/src/public/redux/dashboard/saga.ts
+++ b/frontend/src/public/redux/dashboard/saga.ts
@@ -43,7 +43,7 @@ import { getTemplate } from '../../api/getTemplate';
 
 import { openRunWorkflowModal } from '../runWorkflowModal/actions';
 import { getRunnableWorkflow, loadDatasetsMap } from '../../components/TemplateEdit/utils/getRunnableWorkflow';
-import { ITemplateResponse, IExtraField, IKickoffClient } from '../../types/template';
+import { ITemplateResponse, IExtraField, ITemplateKickoffClient} from '../../types/template';
 import { IFieldsetRuntime } from '../../types/fieldset';
 import { mapTemplateFieldsetsToRuntime } from '../../utils/mapTemplateFieldsetsToRuntime';
 import { mapFieldsetBindingsToClient } from '../../utils/mapFieldsetsAPIToClient';
@@ -175,7 +175,7 @@ export function* openRunWorflowByTemplateDataSaga({
 
     const kickoffFields = mapFieldsToExtraFields(templateData.kickoff?.fields || []);
 
-    const kickoff: IKickoffClient = {
+    const kickoff: ITemplateKickoffClient = {
       description: '',
       fields: kickoffFields,
       fieldsets: [],

--- a/frontend/src/public/redux/runWorkflowModal/__tests__/reducer.test.ts
+++ b/frontend/src/public/redux/runWorkflowModal/__tests__/reducer.test.ts
@@ -2,7 +2,7 @@
 /* prettier-ignore */
 import { reducer, INIT_STATE } from '../reducer';
 import { openRunWorkflowModal } from '../actions';
-import { IKickoffClient, EExtraFieldType } from '../../../types/template';
+import { EExtraFieldType, ITemplateKickoffClient } from '../../../types/template';
 import { makeFieldsetBindingClient, makeFieldsetRuntime } from '../../../__stubs__/fieldsets.factory';
 import { makeExtraField } from '../../../__stubs__/fields.factory';
 
@@ -22,7 +22,7 @@ describe('runWorkflowModal reducer', () => {
       wfNameTemplate: '',
     };
 
-    const kickoff: IKickoffClient = {
+    const kickoff: ITemplateKickoffClient = {
       description:
         'youtube: \nhttps://www.youtube.com/watch?v=JZRm7NKTPhk\n loom:\nhttps://www.loom.com/share/29f210bc12484eaa81ca462381fb4415?t=0\n 404 loom:\n\nhttps://www.loom.com/share/9853f0790ad2408094a3717bfcf4a0c0\nYoutube 404 :\n\nhttps://www.youtube.com/watch?v=D6hIeqZt22g',
       fields: [

--- a/frontend/src/public/redux/selectors/template.ts
+++ b/frontend/src/public/redux/selectors/template.ts
@@ -1,5 +1,5 @@
 import { IApplicationState } from '../../types/redux';
-import { ITemplateClient, ITemplateTaskClient, IKickoffClient, IExtraField } from '../../types/template';
+import { ITemplateClient, ITemplateTaskClient, ITemplateKickoffClient, IExtraField } from '../../types/template';
 
 export const getTemplateData = (state: IApplicationState): ITemplateClient => {
   return state.template.data;
@@ -7,7 +7,7 @@ export const getTemplateData = (state: IApplicationState): ITemplateClient => {
 
 export const getTemplateStatus = (state: IApplicationState) => state.template.status;
 
-export const getKickoff = (state: IApplicationState): IKickoffClient =>
+export const getKickoff = (state: IApplicationState): ITemplateKickoffClient =>
   state.template.data.kickoff;
 
 export const getKickoffFields = (state: IApplicationState): IExtraField[] =>

--- a/frontend/src/public/redux/workflows/saga.ts
+++ b/frontend/src/public/redux/workflows/saga.ts
@@ -115,7 +115,7 @@ import { sendWorkflowComment } from '../../api/sendWorkflowComment';
 import { finishWorkflow } from '../../api/finishWorkflow';
 import { editWorkflow, IEditWorkflowResponse } from '../../api/editWorkflow';
 import { getTemplatesTitles, TGetTemplatesTitlesResponse } from '../../api/getTemplatesTitles';
-import { IKickoffClient, ITemplateResponse, TTemplatePreset } from '../../types/template';
+import { IRuntimeKickoffClient, ITemplateResponse, TTemplatePreset } from '../../types/template';
 import { getWorkflowLogStore } from '../selectors/workflowLog';
 
 import { TChannelAction } from '../tasks/saga';
@@ -128,7 +128,6 @@ import { deleteWorkflow } from '../../api/deleteWorkflow';
 import { getTemplate } from '../../api/getTemplate';
 import { getRunnableWorkflow, loadDatasetsMap } from '../../components/TemplateEdit/utils/getRunnableWorkflow';
 import { mapTemplateFieldsetsToRuntime } from '../../utils/mapTemplateFieldsetsToRuntime';
-import { IFieldsetRuntime } from '../../types/fieldset';
 import { getClonedKickoff } from '../../components/Workflows/WorkflowsGridPage/WorkflowCard/utils/getClonedKickoff';
 import { getWorkflowsCurrentPerformerCounters } from '../../api/getWorkflowsCurrentPerformerCounters';
 import { getWorkflowsStartersCounters } from '../../api/getWorkflowsStartersCounters';
@@ -640,7 +639,7 @@ export function* cloneWorkflowSaga({
       return;
     }
 
-    const kickoff: IKickoffClient = yield getClonedKickoff(
+    const kickoff: IRuntimeKickoffClient = yield getClonedKickoff(
       formattedworkflowDetails.kickoff, normalizedTemplate.kickoff,
     );
 
@@ -649,9 +648,7 @@ export function* cloneWorkflowSaga({
         ...runnableWorkflow,
         name: `${workflowName} (Clone)`,
         kickoff,
-        // TODO (Technical Debt): Sync cloned fieldsets into loadedFieldsets for WorkflowEditPopup modal.
-        // Cast is required due to shared IKickoffClient type usage across editor & runtime contexts.
-        loadedFieldsets: (kickoff.fieldsets || []) as unknown as IFieldsetRuntime[],
+        loadedFieldsets: kickoff.fieldsets || [],
       }),
     );
   } catch (error) {

--- a/frontend/src/public/redux/workflows/slice.ts
+++ b/frontend/src/public/redux/workflows/slice.ts
@@ -13,7 +13,7 @@ import { IDeleteComment } from '../../api/workflows/deleteComment';
 import { IEditComment } from '../../api/workflows/editComment';
 
 import { IStoreWorkflows, IWorkflowLog, IWorkflowsList } from '../../types/redux';
-import { IKickoffClient, ITemplateTitleBaseWithCount, TTemplatePreset } from '../../types/template';
+import { IRuntimeKickoffClient, ITemplateTitleBaseWithCount, TTemplatePreset } from '../../types/template';
 import { ITemplateStep } from '../../types/tasks';
 import {
   EWorkflowsLoadingStatus,
@@ -64,7 +64,7 @@ export const initialWorkflowsFilters: IWorkflowsSettings['values'] = {
 const initialWorkflowEdit = {
   workflow: {
     name: '',
-    kickoff: { description: '', fields: [], fieldsets: [] } as IKickoffClient,
+    kickoff: { description: '', fields: [], fieldsets: [] } as IRuntimeKickoffClient,
   },
   isWorkflowNameEditing: false,
   isKickoffEditing: false,

--- a/frontend/src/public/redux/workflows/types.ts
+++ b/frontend/src/public/redux/workflows/types.ts
@@ -1,7 +1,7 @@
 
 
 import { ITemplateStep } from '../../types/tasks';
-import { IKickoffClient, TOrderedFields } from '../../types/template';
+import { IRuntimeKickoffClient, TOrderedFields } from '../../types/template';
 import { EWorkflowsLogSorting, IWorkflowClient } from '../../types/workflow';
 
 export type TOpenWorkflowLogPopupPayload = {
@@ -28,7 +28,7 @@ export type TRemoveWorkflowFromListPayload = {
 export type TEditWorkflowPayload = {
   typeChange?: string;
   name?: string;
-  kickoff?: IKickoffClient | null;
+  kickoff?: IRuntimeKickoffClient | null;
   isUrgent?: boolean;
   dueDate?: string | null;
   workflowId: number;

--- a/frontend/src/public/types/template.ts
+++ b/frontend/src/public/types/template.ts
@@ -36,7 +36,7 @@ export interface ITemplate {
 
 export interface ITemplateClient extends Omit<ITemplate, 'kickoff' | 'tasks'> {
   tasks: ITemplateTaskClient[];
-  kickoff: IKickoffClient;
+  kickoff: ITemplateKickoffClient;
 }
 
 export enum ETemplateOwnerRole {
@@ -237,14 +237,12 @@ export interface IKickoff {
   fieldsets: IFieldsetBinding[];
 }
 
-/** 
- * TODO (Technical Debt): IKickoffClient is currently shared between Template Editor
- * (where fieldsets use IFieldsetBindingClient[] with template field definitions) and Workflow
- * Runtime / Cloning (where fieldsets hold filled values using IFieldsetRuntime[]).
- * Future refactoring should separate or narrow editor vs runtime kickoff types to avoid type casts.
- */
-export interface IKickoffClient extends Omit<IKickoff, 'fieldsets'> {
+export interface ITemplateKickoffClient extends Omit<IKickoff, 'fieldsets'> {
   fieldsets: IFieldsetBindingClient[];
+}
+
+export interface IRuntimeKickoffClient extends Omit<IKickoff, 'fieldsets'> {
+  fieldsets: IFieldsetRuntime[];
 }
 
 /** Kickoff shape from template list APIs (GET /templates/, GET /templates/titles-by-owners) */

--- a/frontend/src/public/types/workflow.ts
+++ b/frontend/src/public/types/workflow.ts
@@ -2,7 +2,7 @@ import { TUserId } from './user';
 import { TUploadedFile } from '../utils/uploadFiles';
 import { ITask, ITemplateStep, TaskWithTsp } from './tasks';
 import {
-  IKickoffClient,
+  IRuntimeKickoffClient,
   IExtraField,
   ITemplateTitle,
   ETemplateOwnerType,
@@ -73,7 +73,7 @@ export interface IWorkflowDetails {
 
 export interface IWorkflowEditData {
   name?: string;
-  kickoff?: IKickoffClient | null;
+  kickoff?: IRuntimeKickoffClient | null;
 }
 
 export interface IWorkflowEdit {

--- a/frontend/src/public/utils/mappers.ts
+++ b/frontend/src/public/utils/mappers.ts
@@ -1,4 +1,4 @@
-import { IExtraField, IKickoffClient } from '../types/template';
+import { IExtraField, IRuntimeKickoffClient } from '../types/template';
 import { isArrayWithItems } from './helpers';
 import { IRunWorkflow } from '../components/WorkflowEditPopup/types';
 import { ExtraFieldsHelper } from '../components/TemplateEdit/ExtraFields/utils/ExtraFieldsHelper';
@@ -162,7 +162,7 @@ export const mapEndOfDayTsp = (fields: IExtraField[]): IExtraField[] => {
   }));
 };
 
-export const getNormalizedKickoff = (kickoff: Pick<IKickoffClient, 'fields'>): { [key: string]: string } => {
+export const getNormalizedKickoff = (kickoff: Pick<IRuntimeKickoffClient, 'fields'>): { [key: string]: string } => {
   const mappedKickoffFields = new ExtraFieldsHelper(kickoff.fields).normalizeFieldsValues();
   const mappedKickoff = isArrayWithItems(mappedKickoffFields) ? Object.assign({}, ...mappedKickoffFields) : null;
   return mappedKickoff;

--- a/frontend/src/public/utils/template.ts
+++ b/frontend/src/public/utils/template.ts
@@ -2,7 +2,7 @@ import {
   ITemplate,
   ITemplateClient,
   ITemplateTaskClient,
-  IKickoffClient,
+  ITemplateKickoffClient,
   ITemplateRequest,
   ITemplateTaskRequest,
   ITemplateResponse,
@@ -44,7 +44,7 @@ export function getTemplateIdFromUrl(url: string) {
   return Number(template) ? template : null;
 }
 
-export function getEmptyKickoff(): IKickoffClient {
+export function getEmptyKickoff(): ITemplateKickoffClient {
   return {
     description: '',
     fields: [],

--- a/frontend/src/public/utils/workflows.ts
+++ b/frontend/src/public/utils/workflows.ts
@@ -1,5 +1,5 @@
 import { EDashboardActivityAction, EWorkflowLogEvent, ECommentType, IWorkflowDetailsKickoff } from '../types/workflow';
-import { ITemplateTaskClient, IKickoffClient, IExtraField, IFieldsetBindingClient } from '../types/template';
+import { ITemplateTaskClient, IRuntimeKickoffClient, IExtraField } from '../types/template';
 
 import { isArrayWithItems, deepCopy } from './helpers';
 import { ExtraFieldsHelper } from '../components/TemplateEdit/ExtraFields/utils/ExtraFieldsHelper';
@@ -53,7 +53,7 @@ export const moveWorkflowField = (a: number, b: number, arr: IExtraField[]) => {
   return copy;
 };
 
-export const getEditKickoff = (kickoff: IWorkflowDetailsKickoff): IKickoffClient => {
+export const getEditKickoff = (kickoff: IWorkflowDetailsKickoff): IRuntimeKickoffClient => {
   const kickoffFields = new ExtraFieldsHelper(kickoff.output).getFieldsWithValues();
   const kickoffDescritpiton = kickoff.description || '';
   const kickoffFieldsets = (kickoff.fieldsets || []).map((fieldset) => ({
@@ -64,9 +64,7 @@ export const getEditKickoff = (kickoff: IWorkflowDetailsKickoff): IKickoffClient
   return {
     description: kickoffDescritpiton,
     fields: kickoffFields,
-    // Safe cast: workflow runtime components & API only consume field values from 'fields'.
-    // Template-only properties (rules & sharedFieldsetId) are ignored during workflow execution.
-    fieldsets: kickoffFieldsets as unknown as IFieldsetBindingClient[],
+    fieldsets: kickoffFieldsets,
   };
 };
 


### PR DESCRIPTION
## 1. Release notes

Internal typing refactoring: the monolithic `IKickoffClient` interface has been split into two domain-specific interfaces — `ITemplateKickoffClient` (template editor) and `IRuntimeKickoffClient` (workflow run/clone). Application behavior is unchanged.

---

## 2. Problem

The single `IKickoffClient` interface was used in two fundamentally different contexts:

- **Template editor** — works with `fieldsets: IFieldsetBindingClient[]` (fieldset bindings containing `sharedFieldsetId`, `rules`).
- **Workflow run / clone** — works with `fieldsets: IFieldsetRuntime[]` (hydrated fieldsets with populated data).

This prevented TypeScript from distinguishing the template context from the runtime context, leading to:
- Unsafe type casts (`as unknown as ...`).
- False compatibility: functions expecting template data could technically accept runtime data and vice versa.
- Compilation errors when passing a runtime kickoff to functions typed with a template kickoff.

---

## 3. Context

- Task: #48648
- Location in application: Kick-off form — used in the workflow run modal (Dashboard, Templates, Workflows), template editor, and workflow cloning.
- Related tasks: `fieldsets` branch — adding shared fieldset support, which exposed the type conflict.

---

## 4. Solution

The monolithic `IKickoffClient` has been split into two interfaces in `types/template.ts`:

- **`ITemplateKickoffClient`** (`fieldsets: IFieldsetBindingClient[]`) — for the template editor context.
- **`IRuntimeKickoffClient`** (`fieldsets: IFieldsetRuntime[]`) — for the workflow run and clone context.

All 29 files previously importing `IKickoffClient` have been updated to the appropriate domain type based on analysis of the actual data flow.

---

## 5. Implementation details

### Types (`types/template.ts`)
- **Before:** `IKickoffClient` with `fieldsets: IFieldsetBindingClient[]` — a single type for all contexts.
- **After:** Two interfaces, both extending `Omit<IKickoff, 'fieldsets'>` and overriding `fieldsets` with their own type.

### Run modal (`WorkflowEditPopup/types.ts`)
- **Before:** `IRunWorkflow.kickoff: IKickoffClient`.
- **After:** `IRunWorkflow.kickoff: ITemplateKickoffClient | IRuntimeKickoffClient` — the modal serves both scenarios (template run and workflow clone).

### Modal helpers
- **`getInitialKickoff`** — converted to a generic `<T extends ITemplateKickoffClient | IRuntimeKickoffClient>` to preserve the exact type on output.
- **`useWorkflowNameVariables`** — parameter widened to `Pick<ITemplateKickoffClient | IRuntimeKickoffClient, 'fields' | 'fieldsets'>`, since the hook only needs `name` and `fields` from fieldsets.

### Sagas
- **`dashboard/saga.ts`** — typed as `ITemplateKickoffClient` (data from template).
- **`workflows/saga.ts`** — typed as `IRuntimeKickoffClient` (data from `getClonedKickoff`); removed unsafe `as unknown as IFieldsetRuntime[]` cast.

### Utilities (`getRunnableWorkflow.ts`)
- `loadDatasetsMap` and `convertSelectionsToValues` typed as `ITemplateKickoffClient` (work with template data during run preparation).

---

## 6. Testing

### 6.1 Preconditions

- Dev environment running (`npm run local`).
- A template exists with a kick-off form containing: regular fields (String, Date, Checkbox) and at least one fieldset.
- At least one completed or active workflow exists (for cloning).

### 6.2 Positive scenarios

| Scenario | Description (steps and expected result) | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| :--- | :--- | :--- | :--- | :--- | :--- |
| **Run from Dashboard** | Open Dashboard → Click "Run" on a template with fieldsets → Modal opens, fields and fieldsets are displayed → Fill in fields → Click "Run" → Workflow is created. | [ ] | [ ] | [ ] | [ ] |
| **Run from Templates** | Open Templates → Click "Run" on a template → Modal behaves the same as from Dashboard. | [ ] | [ ] | [ ] | [ ] |
| **Clone workflow** | Open Workflows → Select a workflow → Click "Clone" → Modal opens with pre-filled data from the original workflow → Run the clone. | [ ] | [ ] | [ ] | [ ] |
| **Name variables** | Open run modal for a template with kick-off form → Fields from kick-off (including fieldset fields) are available as variables for the workflow name. | [ ] | [ ] | [ ] | [ ] |

### 6.3 Negative scenarios

| Scenario | Description (steps and expected result) | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| :--- | :--- | :--- | :--- | :--- | :--- |
| **Empty run form** | Run a template with no kick-off fields and no fieldsets → Modal opens, run completes without errors. | [ ] | [ ] | [ ] | [ ] |
| **Required fields** | Run a template with required fields → Leave them empty → "Run" button is disabled. | [ ] | [ ] | [ ] | [ ] |

### 6.4 Verification points

- UI: the run modal correctly displays fields and fieldsets.
- UI: when cloning, data from the original workflow is pre-filled.
- Browser console: no JavaScript errors when opening/closing the modal.

### 6.6 What was NOT tested

- Locales were not checked (changes do not affect text content).
- Backend is not affected — changes are frontend-only (TypeScript types).
- Load testing was not performed.

---

## 7. Refactoring

**Justification:** Splitting the types is necessary for fieldset support in the kick-off form. The monolithic `IKickoffClient` created a type conflict between template and runtime contexts, blocking safe extension of functionality. The split reduces the cost of future fieldset features and eliminates an entire class of type cast errors.

This is a purely type-level refactoring — the compiled JavaScript (runtime code) is identical before and after the changes.

| Scenario | Description (steps and expected result) | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| :--- | :--- | :--- | :--- | :--- | :--- |
| **Run regression** | Run a workflow with kick-off form (fields + fieldsets) → Workflow is created, data is correct. | [ ] | [ ] | [ ] | [ ] |
| **Clone regression** | Clone an existing workflow → Data is pre-filled, clone launches successfully. | [ ] | [ ] | [ ] | [ ] |
| **DueDate regression** | In template editor → Set up a DueDate rule on a Date field from a fieldset → Rule is saved. | [ ] | [ ] | [ ] | [ ] |

---

## 8. Affected areas testing

Changes affected shared hooks and utilities used in multiple contexts:

| Scenario | Description (steps and expected result) | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| :--- | :--- | :--- | :--- | :--- | :--- |
| **useWorkflowNameVariables (KickoffRedux)** | Template editor → Kick-off → Verify that variables from fields and fieldsets are available in workflow name configuration. | [ ] | [ ] | [ ] | [ ] |
| **getInitialKickoff (modal)** | Open the run modal → Verify that initial field values are correctly initialized (empty fields, default values). | [ ] | [ ] | [ ] | [ ] |
| **getRunnableWorkflow (sagas)** | Run a workflow with Dataset fields (Checkbox with dataset) → Values are loaded from the dataset. | [ ] | [ ] | [ ] | [ ] |

---

## 9. Unit tests

Existing tests updated to use the new domain-specific types:

- **`reducer.test.ts`** — `runWorkflowModal` reducer tests: kickoff mocks migrated to `ITemplateKickoffClient`.
- **`getRunnableWorkflow.test.ts`** — `loadDatasetsMap` tests: mocks migrated to `ITemplateKickoffClient`.
- **`getRuleTargetOptions.test.ts`** — DueDate rule tests: mocks migrated to `ITemplateKickoffClient`.

All 230 test suites (1601 tests) pass successfully.

---

## 10. Commits

- `78899203` — `48648 refactor(types): split IKickoffClient into ITemplateKickoffClient and IRuntimeKickoffClient`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Split `IKickoffClient` into `ITemplateKickoffClient` and `IRuntimeKickoffClient` to resolve type conflict
- Replaces the single `IKickoffClient` type (which had an ambiguous `fieldsets` type) with two explicit interfaces in [template.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/329/files#diff-f32255dd9aba79d2f448ed2f82d5b566319d45f79a57fe8b4f0f503ec9fe6e6d): `ITemplateKickoffClient` (fieldsets as `IFieldsetBindingClient[]`) and `IRuntimeKickoffClient` (fieldsets as `IFieldsetRuntime[]`).
- Updates all Template Editor components, Redux selectors, sagas, and utilities to use `ITemplateKickoffClient`; all runtime/workflow-edit paths use `IRuntimeKickoffClient`.
- `getClonedKickoff` now explicitly accepts `ITemplateKickoffClient` and returns `IRuntimeKickoffClient`, making the template-to-runtime conversion boundary type-safe.
- `getInitialKickoff` is converted to a generic function to preserve the input kickoff shape without casts.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7889920.</sup>
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->