### PR TITLE
 48713 backend [ tasks ] Soft-deleted task performers are incorrectly visible in /v3/tasks list

### DIFF
--- a/backend/src/processes/queries.py
+++ b/backend/src/processes/queries.py
@@ -1161,7 +1161,8 @@ class TaskListQuery(
               pt.is_deleted IS FALSE
             )
             LEFT JOIN processes_taskperformer ptp ON (
-              pt.id = ptp.task_id
+              pt.id = ptp.task_id AND
+              ptp.is_deleted IS FALSE
             )
             LEFT JOIN accounts_usergroup_users aug ON (
               ptp.group_id = aug.usergroup_id AND

--- a/backend/src/processes/tests/test_views/test_tasks/test_list.py
+++ b/backend/src/processes/tests/test_views/test_tasks/test_list.py
@@ -1765,6 +1765,33 @@ def test_list__ordering_by_reversed_overdue__ok(api_client):
     assert response.data[2]['id'] == task_11.id
 
 
+def test_list__soft_deleted_performer__not_shown(api_client):
+    # arrange
+    account = create_test_account()
+    user = create_test_admin(account=account)
+    workflow = create_test_workflow(user, tasks_count=1)
+    task = workflow.tasks.get(number=1)
+    task.taskperformer_set.all().delete()
+
+    # Simulate the bug condition: a performer is soft-deleted
+    # but has a directly_status != DELETED
+    TaskPerformer.objects.create(
+        task_id=task.id,
+        type=PerformerType.USER,
+        user=user,
+        directly_status=DirectlyStatus.CREATED,
+        is_deleted=True,
+    )
+    api_client.token_authenticate(user=user)
+
+    # act
+    response = api_client.get('/v3/tasks')
+
+    # assert
+    assert response.status_code == 200
+    assert len(response.data) == 0
+
+
 def test_list__filter_assigned_to__ok(api_client):
 
     # arrange


### PR DESCRIPTION
## 1. Description (problem)
This PR fixes a bug where soft-deleted task performers continued to see someone else's task in their task list (`/v3/tasks` endpoint). The issue manifested in the UI under "My Tasks" when a user was assigned as a performer on a specific step, the task was reverted to a previous step, and then the user was manually removed from the performers list. The task incorrectly remained in their list.
## 2. Context
When a performer is removed from a task via the UI, their record in `TaskPerformer` is marked as deleted (`is_deleted = True`), and the `directly_status` changes to `DELETED` (1). However, due to how `get_or_create` works upon re-adding a performer, or after a revert, an old record could remain where `is_deleted = True` but `directly_status != DELETED`. 
The raw SQL query responsible for fetching the task list failed to respect the `is_deleted` flag for the main performers table.
## 3. Solution
Added a check to the `TaskListQuery` raw SQL to ensure that the performer record is not soft-deleted. The database will now properly filter out outdated, soft-deleted performer records when returning the list.
## 4. Implementation Details
- In `backend/src/processes/queries.py` (method `_get_from`), added `AND ptp.is_deleted IS FALSE` to the `LEFT JOIN processes_taskperformer ptp` block.
- In `backend/src/processes/tests/test_views/test_tasks/test_list.py`, added a new test `test_list__soft_deleted_performer__not_shown` to prevent regressions.
## 5. What to Test (for the tester — AI or human)
### 5.1 Preconditions
- Testing should be done in a dev environment.
- Two users from the same account are required (e.g., User A — admin/initiator, User B — regular user).
- Ensure the backend is running on the current branch `backend/tasks/48713__soft_deleted_performers_incorrectly_visible_in_tasks_list`.
### 5.2 Positive Scenarios
1. **Log in** as User A, create a 2-step workflow. Assign User B as a performer for step 2.
2. **Start the workflow** and complete step 1 so the task moves to step 2.
3. **Log in** as User B. Verify the task appears in their "My Tasks" list.
4. **Switch back** to User A, revert the task back to step 1.
5. **On step 1**, manually remove User B from the upcoming step 2 performers and add another user instead.
6. **Complete step 1** again.
7. **Log in** as User B and check the task list.
   - **Expected Result**: The task is no longer in User B's "My Tasks" list.
### 5.3 Negative Scenarios and Edge Cases
1. **Self-removal**
   - User B assigns themselves to a task and then removes themselves.
   - **Expected Result**: The task immediately disappears from their list, and it is no longer returned in the `/v3/tasks` response.
2. **Empty performers list**
   - Verify that when all performers are removed, the task correctly shows up only for the account owner/admin.
### 5.4 Verification Points
- **API**: Check the `GET /v3/tasks` response for User B. The task they were removed from must not be in the results array.
- **Database** (optional): Check the `processes_taskperformer` records for the user. The `is_deleted` field should be `True`.
### 5.5 API Checks (conditional)
- **Incoming response**: In the `GET /v3/tasks` endpoint, check the JSON response. Verify the length of the returned array is correct for the removed user and the task object is missing.
### 5.6 What Was NOT Tested
- Not tested under load.
- Locales were not tested (out of scope).
- Mobile devices were not tested.
- Not tested in production.
## 6. Testing Affected Areas (dependencies)
- **Task Lists**: Since the base SQL query `TaskListQuery` was modified, perform a quick check on the `/v3/tasks` endpoint with filters:
  - "Active only" filter (`is_completed=false`).
  - "Completed only" filter (`is_completed=true`).
  - Verify that tasks for other active performers and group performers are displayed correctly.
## 7. Refactoring
- No refactoring was done, this is a targeted fix.
## 8. Commits with Fixes
- `[hash]` - fix(tasks): exclude soft-deleted performers from tasks list
## 9. Release notes:
- Fixed an issue where users could still see tasks in their task list after being removed from the performers list.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix soft-deleted task performers appearing in `/v3/tasks` list
> The LEFT JOIN to `processes_taskperformer` in `TaskListQuery._get_from` now requires `ptp.is_deleted IS FALSE`, filtering out soft-deleted performers. Without this, tasks assigned to soft-deleted performers were still returned in the task list. A regression test in [test_list.py](https://github.com/pneumaticapp/pneumaticworkflow/pull/330/files#diff-8bb5f60dd185e69659ee012b16a6da9aa43e04d5dc56e70fe1e63a2e6cadc1ca) confirms that tasks with `is_deleted=True` performers are no longer returned.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0a5ccaa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->