### PR TITLE
⚙️ 48345 backend [ fieldsets ] Advanced fieldset rules

### DIFF
--- a/backend/src/processes/migrations/0259_populate_fieldset_title_from_name.py
+++ b/backend/src/processes/migrations/0259_populate_fieldset_title_from_name.py
@@ -1,0 +1,26 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('processes', '0258_rebuild_attachment_permissions'),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql="""
+                UPDATE processes_fieldset
+                SET title = name;
+            """,
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+        migrations.RunSQL(
+            sql="""
+                UPDATE processes_fieldsettemplate
+                SET title = name;
+            """,
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+
+    ]

--- a/backend/src/processes/serializers/templates/fieldset.py
+++ b/backend/src/processes/serializers/templates/fieldset.py
@@ -1,6 +1,6 @@
 from django.core.validators import MinValueValidator
 from rest_framework.fields import CharField, ChoiceField, IntegerField
-from rest_framework.serializers import ModelSerializer
+from rest_framework.serializers import ModelSerializer, SerializerMethodField
 from src.generics.fields import (
     RelatedApiNameListField, AccountPrimaryKeyRelatedField,
 )
@@ -10,6 +10,7 @@ from src.processes.models.templates.fieldset import (
     FieldsetTemplate,
     FieldsetTemplateRule,
 )
+from src.processes.models.templates.template import Template
 from src.processes.serializers.templates.field import (
     FieldTemplateSerializer,
 )
@@ -106,6 +107,7 @@ class SharedFieldsetTemplateSerializer(
             'layout',
             'rules',
             'fields',
+            'usage',
         )
 
     rules = FieldsetTemplateRuleSerializer(
@@ -119,3 +121,23 @@ class SharedFieldsetTemplateSerializer(
         default=list,
     )
     api_name = CharField(required=False, max_length=200)
+    usage = SerializerMethodField()
+
+    def get_usage(self, instance: FieldsetTemplate) -> list:
+        prefetched = getattr(instance, '_prefetched_objects_cache', {})
+        if 'child_fieldsets' in prefetched:
+            usage = {}
+            for child in instance.child_fieldsets.all():
+                usage[child.template_id] = {
+                    'id': child.template_id,
+                    'name': child.template.name,
+                }
+            return sorted(usage.values(), key=lambda elem: elem['id'])
+        return list(
+            Template.objects.filter(
+                id__in=instance.child_fieldsets.values('template_id'),
+            )
+            .order_by('id')
+            .distinct()
+            .values('id', 'name'),
+        )

--- a/backend/src/processes/services/fieldsets/fieldset.py
+++ b/backend/src/processes/services/fieldsets/fieldset.py
@@ -68,7 +68,7 @@ class FieldSetTemplateService(BaseModelService):
             'account': self.account,
             'order': order,
             'name': name,
-            'title': title,
+            'title': title or name,
             'description': description,
             'label_position': label_position,
             'layout': layout,

--- a/backend/src/processes/tests/test_services/test_fieldsets/test_fieldset_template_service.py
+++ b/backend/src/processes/tests/test_services/test_fieldsets/test_fieldset_template_service.py
@@ -63,7 +63,7 @@ def test__create_instance__default_params__ok():
     name = 'Test fieldset'
 
     # act
-    service._create_instance(
+    fieldset = service._create_instance(
         name=name,
         template_id=template.id,
         is_shared=False,
@@ -71,15 +71,16 @@ def test__create_instance__default_params__ok():
     )
 
     # assert
-    assert service.instance is not None
-    assert service.instance.name == name
-    assert service.instance.api_name
-    assert service.instance.template_id == template.id
-    assert service.instance.shared_fieldset_id == shared_fieldset.id
-    assert service.instance.account_id == account.id
-    assert service.instance.description == ''
-    assert service.instance.label_position == LabelPosition.TOP
-    assert service.instance.layout == FieldSetLayout.VERTICAL
+    assert service.instance == fieldset
+    assert fieldset.name == name
+    assert fieldset.api_name
+    assert fieldset.template_id == template.id
+    assert fieldset.shared_fieldset_id == shared_fieldset.id
+    assert fieldset.account_id == account.id
+    assert fieldset.title == name
+    assert fieldset.description == ''
+    assert fieldset.label_position == LabelPosition.TOP
+    assert fieldset.layout == FieldSetLayout.VERTICAL
 
 
 def test__create_instance__all_params__ok():
@@ -109,7 +110,7 @@ def test__create_instance__all_params__ok():
     api_name = 'fs-1'
 
     # act
-    service._create_instance(
+    fieldset = service._create_instance(
         name=name,
         template_id=template.id,
         is_shared=False,
@@ -121,13 +122,13 @@ def test__create_instance__all_params__ok():
     )
 
     # assert
-    assert service.instance.name == name
-    assert service.instance.template_id == template.id
-    assert service.instance.shared_fieldset_id == shared_fieldset.id
-    assert service.instance.description == description
-    assert service.instance.label_position == label_position
-    assert service.instance.layout == layout
-    assert service.instance.api_name == api_name
+    assert fieldset.name == name
+    assert fieldset.template_id == template.id
+    assert fieldset.shared_fieldset_id == shared_fieldset.id
+    assert fieldset.description == description
+    assert fieldset.label_position == label_position
+    assert fieldset.layout == layout
+    assert fieldset.api_name == api_name
 
 
 def test__create_instance__shared_fieldset__ok():
@@ -145,27 +146,31 @@ def test__create_instance__shared_fieldset__ok():
         auth_type=AuthTokenType.USER,
     )
     name = 'Test fieldset'
+    title = 'User friendly title'
+    description = 'User friendly description'
 
     # act
-    service._create_instance(
+    fieldset = service._create_instance(
         name=name,
+        title=title,
+        description=description,
         is_shared=True,
     )
 
     # assert
     assert service.instance is not None
-    assert service.instance.name == name
-    assert service.instance.is_shared is True
-    assert service.instance.template_id is None
-    assert service.instance.title == ''
-    assert service.instance.description == ''
-    assert service.instance.kickoff_id is None
-    assert service.instance.task_id is None
-    assert service.instance.shared_fieldset_id is None
-    assert service.instance.api_name
-    assert service.instance.account_id == account.id
-    assert service.instance.label_position == LabelPosition.TOP
-    assert service.instance.layout == FieldSetLayout.VERTICAL
+    assert fieldset.name == name
+    assert fieldset.is_shared is True
+    assert fieldset.template_id is None
+    assert fieldset.title == title
+    assert fieldset.description == description
+    assert fieldset.kickoff_id is None
+    assert fieldset.task_id is None
+    assert fieldset.shared_fieldset_id is None
+    assert fieldset.api_name
+    assert fieldset.account_id == account.id
+    assert fieldset.label_position == LabelPosition.TOP
+    assert fieldset.layout == FieldSetLayout.VERTICAL
 
 
 def test__create_instance__is_shared_api_name_provided__ok():
@@ -186,16 +191,16 @@ def test__create_instance__is_shared_api_name_provided__ok():
     api_name = 'fs-custom-1'
 
     # act
-    service._create_instance(
+    fieldset = service._create_instance(
         name=name,
         is_shared=True,
         api_name=api_name,
     )
 
     # assert
-    assert service.instance.api_name == api_name
-    assert service.instance.is_shared is True
-    assert service.instance.template_id is None
+    assert fieldset.api_name == api_name
+    assert fieldset.is_shared is True
+    assert fieldset.template_id is None
 
 
 def test__create_instance__not_shared_no_template_id__raise_exception():
@@ -1316,7 +1321,7 @@ def test_create_shared_fieldset__ok():
     # assert
     assert result.name == name
     assert result.is_shared is True
-    assert result.title == ''
+    assert result.title == name
     assert result.description == ''
     assert result.label_position == LabelPosition.TOP
     assert result.layout == FieldSetLayout.VERTICAL

--- a/backend/src/processes/tests/test_views/test_fieldsets/test_clone.py
+++ b/backend/src/processes/tests/test_views/test_fieldsets/test_clone.py
@@ -83,6 +83,7 @@ def test_clone__ok(api_client, mocker):
     assert response.data['label_position'] == clone.label_position
     assert response.data['layout'] == clone.layout
     assert response.data['api_name'] == clone.api_name
+    assert response.data['usage'] == []
 
     assert len(response.data['fields']) == 1
     assert response.data['fields'][0]['name'] == clone_field.name

--- a/backend/src/processes/tests/test_views/test_fieldsets/test_create.py
+++ b/backend/src/processes/tests/test_views/test_fieldsets/test_create.py
@@ -127,6 +127,7 @@ def test_create_fieldset__all_fields__ok(api_client, mocker):
     assert response.data['label_position'] == data['label_position']
     assert response.data['layout'] == data['layout']
     assert response.data['api_name'] == data['api_name']
+    assert response.data['usage'] == []
 
     assert len(response.data['fields']) == 1
     assert response.data['fields'][0]['name'] == 'Field 1'

--- a/backend/src/processes/tests/test_views/test_fieldsets/test_list.py
+++ b/backend/src/processes/tests/test_views/test_fieldsets/test_list.py
@@ -13,6 +13,7 @@ from src.processes.tests.fixtures import (
     create_test_account,
     create_test_admin,
     create_test_shared_fieldset,
+    create_test_fieldset_template,
     create_test_not_admin,
     create_test_owner,
     create_test_template,
@@ -29,10 +30,6 @@ def test_list_fieldsets__all_data__ok(api_client):
     # arrange
     account = create_test_account()
     user = create_test_owner(account=account)
-    create_test_template(
-        user=user,
-        tasks_count=1,
-    )
     rule_type = FieldSetRuleType.SUM_EQUAL
     rule_value = '10'
     fieldset = create_test_shared_fieldset(
@@ -53,24 +50,25 @@ def test_list_fieldsets__all_data__ok(api_client):
     # assert
     assert response.status_code == 200
     assert len(response.data) == 1
-    item_1 = response.data[0]
-    assert item_1['id'] == fieldset.id
-    assert item_1['api_name'] == fieldset.api_name
-    assert item_1['name'] == fieldset.name
-    assert item_1['title'] == 'Fieldset Title'
-    assert item_1['order'] == 3
-    assert item_1['description'] == ''
-    assert item_1['layout'] == fieldset.layout
-    assert item_1['label_position'] == fieldset.label_position
+    fieldset_data = response.data[0]
+    assert fieldset_data['id'] == fieldset.id
+    assert fieldset_data['api_name'] == fieldset.api_name
+    assert fieldset_data['name'] == fieldset.name
+    assert fieldset_data['title'] == 'Fieldset Title'
+    assert fieldset_data['order'] == 3
+    assert fieldset_data['description'] == ''
+    assert fieldset_data['layout'] == fieldset.layout
+    assert fieldset_data['label_position'] == fieldset.label_position
+    assert fieldset_data['usage'] == []
 
-    assert len(item_1['rules']) == 1
-    rules_data = item_1['rules']
+    assert len(fieldset_data['rules']) == 1
+    rules_data = fieldset_data['rules']
     assert rules_data[0]['type'] == rule_type
     assert rules_data[0]['value'] == rule_value
     assert rules_data[0]['api_name'] == rule.api_name
 
-    assert len(item_1['fields']) == 1
-    fields_data = item_1['fields']
+    assert len(fieldset_data['fields']) == 1
+    fields_data = fieldset_data['fields']
     assert fields_data[0]['name'] == field.name
     assert fields_data[0]['type'] == field.type
     assert fields_data[0]['api_name'] == field.api_name
@@ -80,6 +78,165 @@ def test_list_fieldsets__all_data__ok(api_client):
     assert fields_data[0]['default'] == ''
     assert 'dataset' not in fields_data[0]
     assert 'selections' not in fields_data[0]
+
+
+def test_list_fieldsets__used_in_tasks__return_usage(
+    api_client,
+):
+
+    # arrange
+    account = create_test_account()
+    user = create_test_owner(account=account)
+    rule_type = FieldSetRuleType.SUM_EQUAL
+    rule_value = '10'
+    shared_fieldset = create_test_shared_fieldset(
+        account=account,
+        title='Fieldset Title',
+        order=3,
+        rule_type=rule_type,
+        rule_value=rule_value,
+    )
+    template_1 = create_test_template(
+        user=user,
+        tasks_count=1,
+    )
+    task_11 = template_1.tasks.get(number=1)
+    create_test_fieldset_template(
+        account=account,
+        template=template_1,
+        task=task_11,
+        shared_fieldset=shared_fieldset,
+    )
+    template_2 = create_test_template(
+        user=user,
+        tasks_count=1,
+    )
+    task_21 = template_2.tasks.get(number=1)
+    create_test_fieldset_template(
+        account=account,
+        template=template_2,
+        task=task_21,
+        shared_fieldset=shared_fieldset,
+    )
+    api_client.token_authenticate(user=user)
+
+    # act
+    response = api_client.get('/fieldsets')
+
+    # assert
+    assert response.status_code == 200
+    assert len(response.data) == 1
+    shared_fieldset_data = response.data[0]
+    assert shared_fieldset_data['id'] == shared_fieldset.id
+    assert len(shared_fieldset_data['usage']) == 2
+    assert shared_fieldset_data['usage'][0]['id'] == template_1.id
+    assert shared_fieldset_data['usage'][0]['name'] == template_1.name
+    assert shared_fieldset_data['usage'][1]['id'] == template_2.id
+    assert shared_fieldset_data['usage'][1]['name'] == template_2.name
+
+
+def test_list_fieldsets__used_in_kickoff_and_tasks__return_usage(
+    api_client,
+):
+
+    # arrange
+    account = create_test_account()
+    user = create_test_owner(account=account)
+    rule_type = FieldSetRuleType.SUM_EQUAL
+    rule_value = '10'
+    shared_fieldset = create_test_shared_fieldset(
+        account=account,
+        title='Fieldset Title',
+        order=3,
+        rule_type=rule_type,
+        rule_value=rule_value,
+    )
+    template_1 = create_test_template(
+        user=user,
+        tasks_count=1,
+    )
+    kickoff = template_1.kickoff_instance
+    create_test_fieldset_template(
+        account=account,
+        template=template_1,
+        kickoff=kickoff,
+        shared_fieldset=shared_fieldset,
+    )
+    template_2 = create_test_template(
+        user=user,
+        tasks_count=1,
+    )
+    task_21 = template_2.tasks.get(number=1)
+    create_test_fieldset_template(
+        account=account,
+        template=template_2,
+        task=task_21,
+        shared_fieldset=shared_fieldset,
+    )
+    api_client.token_authenticate(user=user)
+
+    # act
+    response = api_client.get('/fieldsets')
+
+    # assert
+    assert response.status_code == 200
+    assert len(response.data) == 1
+    shared_fieldset_data = response.data[0]
+    assert shared_fieldset_data['id'] == shared_fieldset.id
+    assert len(shared_fieldset_data['usage']) == 2
+    assert shared_fieldset_data['usage'][0]['id'] == template_1.id
+    assert shared_fieldset_data['usage'][0]['name'] == template_1.name
+    assert shared_fieldset_data['usage'][1]['id'] == template_2.id
+    assert shared_fieldset_data['usage'][1]['name'] == template_2.name
+
+
+def test_list_fieldsets__used_twice_in_one_template__return_usage(
+    api_client,
+):
+
+    # arrange
+    account = create_test_account()
+    user = create_test_owner(account=account)
+    rule_type = FieldSetRuleType.SUM_EQUAL
+    rule_value = '10'
+    shared_fieldset = create_test_shared_fieldset(
+        account=account,
+        title='Fieldset Title',
+        order=3,
+        rule_type=rule_type,
+        rule_value=rule_value,
+    )
+    template = create_test_template(
+        user=user,
+        tasks_count=1,
+    )
+    kickoff = template.kickoff_instance
+    task = template.tasks.get(number=1)
+    create_test_fieldset_template(
+        account=account,
+        template=template,
+        task=task,
+        shared_fieldset=shared_fieldset,
+    )
+    create_test_fieldset_template(
+        account=account,
+        template=template,
+        kickoff=kickoff,
+        shared_fieldset=shared_fieldset,
+    )
+    api_client.token_authenticate(user=user)
+
+    # act
+    response = api_client.get('/fieldsets')
+
+    # assert
+    assert response.status_code == 200
+    assert len(response.data) == 1
+    shared_fieldset_data = response.data[0]
+    assert shared_fieldset_data['id'] == shared_fieldset.id
+    assert len(shared_fieldset_data['usage']) == 1
+    assert shared_fieldset_data['usage'][0]['id'] == template.id
+    assert shared_fieldset_data['usage'][0]['name'] == template.name
 
 
 def test_list_fieldsets__shared_fieldset_has_rules_and_fields__ok(api_client):
@@ -120,10 +277,6 @@ def test_list_fieldsets__pagination__ok(api_client):
     # arrange
     account = create_test_account()
     user = create_test_owner(account=account)
-    create_test_template(
-        user=user,
-        tasks_count=1,
-    )
     fieldset_1 = create_test_shared_fieldset(
         account=account,
     )
@@ -147,8 +300,8 @@ def test_list_fieldsets__pagination__ok(api_client):
     assert response.data['count'] == 3
     assert len(response.data['results']) == 2
 
-    item_1 = response.data['results'][0]
-    assert item_1['id'] == fieldset_2.id
+    fieldset_data = response.data['results'][0]
+    assert fieldset_data['id'] == fieldset_2.id
 
     item_2 = response.data['results'][1]
     assert item_2['id'] == fieldset_1.id
@@ -160,10 +313,6 @@ def test_list_fieldsets__different_accounts__ok(api_client):
     # arrange
     account_1 = create_test_account(name='Account 1')
     user_1 = create_test_owner(account=account_1)
-    create_test_template(
-        user=user_1,
-        tasks_count=1,
-    )
     fieldset_1 = create_test_shared_fieldset(
         account=account_1,
     )
@@ -194,10 +343,6 @@ def test_list_fieldsets__rule_with_fields__ok(api_client):
     # arrange
     account = create_test_account()
     user = create_test_owner(account=account)
-    create_test_template(
-        user=user,
-        tasks_count=1,
-    )
     rule_type = FieldSetRuleType.SUM_EQUAL
     rule_value = '10'
     fieldset = create_test_shared_fieldset(
@@ -217,10 +362,10 @@ def test_list_fieldsets__rule_with_fields__ok(api_client):
     # assert
     assert response.status_code == 200
     assert len(response.data) == 1
-    item_1 = response.data[0]
+    fieldset_data = response.data[0]
 
-    assert len(item_1['rules']) == 1
-    rules_data = item_1['rules']
+    assert len(fieldset_data['rules']) == 1
+    rules_data = fieldset_data['rules']
     assert rules_data[0]['fields'] == [field.api_name]
 
 
@@ -321,10 +466,6 @@ def test_list_fieldsets__admin__ok(api_client):
     account = create_test_account()
     create_test_owner(account=account)
     user = create_test_admin(account=account)
-    create_test_template(
-        user=user,
-        tasks_count=1,
-    )
     fieldset = create_test_shared_fieldset(
         account=account,
     )
@@ -347,10 +488,6 @@ def test_list_fieldsets__no_ordering__ok(api_client):
     # arrange
     account = create_test_account()
     user = create_test_owner(account=account)
-    create_test_template(
-        user=user,
-        tasks_count=1,
-    )
     now = timezone.now()
     fieldset_1 = create_test_shared_fieldset(
         account=account,
@@ -381,8 +518,8 @@ def test_list_fieldsets__no_ordering__ok(api_client):
     # assert
     assert response.status_code == 200
     assert len(response.data) == 3
-    item_1 = response.data[0]
-    assert item_1['id'] == fieldset_3.id
+    fieldset_data = response.data[0]
+    assert fieldset_data['id'] == fieldset_3.id
     item_2 = response.data[1]
     assert item_2['id'] == fieldset_2.id
     item_3 = response.data[2]
@@ -396,10 +533,6 @@ def test_list_fieldsets__ordering_name_asc__ok(api_client):
     # arrange
     account = create_test_account()
     user = create_test_owner(account=account)
-    create_test_template(
-        user=user,
-        tasks_count=1,
-    )
     fieldset_1 = create_test_shared_fieldset(
         account=account,
         name='Alpha',
@@ -423,9 +556,9 @@ def test_list_fieldsets__ordering_name_asc__ok(api_client):
     # assert
     assert response.status_code == 200
     assert len(response.data) == 3
-    item_1 = response.data[0]
-    assert item_1['id'] == fieldset_1.id
-    assert item_1['name'] == 'Alpha'
+    fieldset_data = response.data[0]
+    assert fieldset_data['id'] == fieldset_1.id
+    assert fieldset_data['name'] == 'Alpha'
     item_2 = response.data[1]
     assert item_2['id'] == fieldset_2.id
     assert item_2['name'] == 'Beta'
@@ -441,10 +574,6 @@ def test_list_fieldsets__ordering_name_desc__ok(api_client):
     # arrange
     account = create_test_account()
     user = create_test_owner(account=account)
-    create_test_template(
-        user=user,
-        tasks_count=1,
-    )
     fieldset_1 = create_test_shared_fieldset(
         account=account,
         name='Alpha',
@@ -468,9 +597,9 @@ def test_list_fieldsets__ordering_name_desc__ok(api_client):
     # assert
     assert response.status_code == 200
     assert len(response.data) == 3
-    item_1 = response.data[0]
-    assert item_1['id'] == fieldset_3.id
-    assert item_1['name'] == 'Gamma'
+    fieldset_data = response.data[0]
+    assert fieldset_data['id'] == fieldset_3.id
+    assert fieldset_data['name'] == 'Gamma'
     item_2 = response.data[1]
     assert item_2['id'] == fieldset_2.id
     assert item_2['name'] == 'Beta'
@@ -486,10 +615,7 @@ def test_list_fieldsets__ordering_date_asc__ok(api_client):
     # arrange
     account = create_test_account()
     user = create_test_owner(account=account)
-    create_test_template(
-        user=user,
-        tasks_count=1,
-    )
+
     now = timezone.now()
     fieldset_1 = create_test_shared_fieldset(
         account=account,
@@ -523,8 +649,8 @@ def test_list_fieldsets__ordering_date_asc__ok(api_client):
     # assert
     assert response.status_code == 200
     assert len(response.data) == 3
-    item_1 = response.data[0]
-    assert item_1['id'] == fieldset_1.id
+    fieldset_data = response.data[0]
+    assert fieldset_data['id'] == fieldset_1.id
     item_2 = response.data[1]
     assert item_2['id'] == fieldset_2.id
     item_3 = response.data[2]
@@ -538,10 +664,7 @@ def test_list_fieldsets__ordering_date_desc__ok(api_client):
     # arrange
     account = create_test_account()
     user = create_test_owner(account=account)
-    create_test_template(
-        user=user,
-        tasks_count=1,
-    )
+
     now = timezone.now()
     fieldset_1 = create_test_shared_fieldset(
         account=account,
@@ -575,8 +698,8 @@ def test_list_fieldsets__ordering_date_desc__ok(api_client):
     # assert
     assert response.status_code == 200
     assert len(response.data) == 3
-    item_1 = response.data[0]
-    assert item_1['id'] == fieldset_3.id
+    fieldset_data = response.data[0]
+    assert fieldset_data['id'] == fieldset_3.id
     item_2 = response.data[1]
     assert item_2['id'] == fieldset_2.id
     item_3 = response.data[2]
@@ -590,10 +713,7 @@ def test_list_fieldsets__no_pagination__ok(api_client):
     # arrange
     account = create_test_account()
     user = create_test_owner(account=account)
-    create_test_template(
-        user=user,
-        tasks_count=1,
-    )
+
     create_test_shared_fieldset(
         account=account,
         name='First',
@@ -620,10 +740,7 @@ def test_list_fieldsets__ordering_invalid__validation_error(api_client):
     # arrange
     account = create_test_account()
     user = create_test_owner(account=account)
-    create_test_template(
-        user=user,
-        tasks_count=1,
-    )
+
     create_test_shared_fieldset(
         account=account,
         name='First',
@@ -650,10 +767,7 @@ def test_list_fieldsets__ordering_empty__ok(api_client):
     # arrange
     account = create_test_account()
     user = create_test_owner(account=account)
-    create_test_template(
-        user=user,
-        tasks_count=1,
-    )
+
     now = timezone.now()
     fieldset_1 = create_test_shared_fieldset(
         account=account,
@@ -682,8 +796,8 @@ def test_list_fieldsets__ordering_empty__ok(api_client):
     assert len(response.data) == 2
 
     # default ordering is -date_created (newest first)
-    item_1 = response.data[0]
-    assert item_1['id'] == fieldset_2.id
+    fieldset_data = response.data[0]
+    assert fieldset_data['id'] == fieldset_2.id
     item_2 = response.data[1]
     assert item_2['id'] == fieldset_1.id
 
@@ -695,10 +809,7 @@ def test_list_fieldsets__soft_deleted__ok(api_client):
     # arrange
     account = create_test_account()
     user = create_test_owner(account=account)
-    create_test_template(
-        user=user,
-        tasks_count=1,
-    )
+
     fieldset = create_test_shared_fieldset(
         account=account,
         name='Deleted Fieldset',

--- a/backend/src/processes/tests/test_views/test_fieldsets/test_partial_update.py
+++ b/backend/src/processes/tests/test_views/test_fieldsets/test_partial_update.py
@@ -22,7 +22,8 @@ from src.processes.tests.fixtures import (
     create_test_account,
     create_test_not_admin,
     create_test_owner,
-    create_test_shared_fieldset,
+    create_test_shared_fieldset, create_test_template,
+    create_test_fieldset_template,
 )
 from src.utils.validation import ErrorCode
 
@@ -100,6 +101,7 @@ def test_partial_update__all_fields__ok(api_client, mocker):
     assert response.data['label_position'] == data['label_position']
     assert response.data['layout'] == data['layout']
     assert response.data['api_name'] == data['api_name']
+    assert response.data['usage'] == []
 
     assert len(response.data['fields']) == 1
     assert response.data['fields'][0]['name'] == field.name
@@ -163,6 +165,64 @@ def test_partial_update__name__ok(api_client, mocker):
     fieldset_service_init_mock.assert_called_once_with(
         user=user,
         instance=fieldset,
+        is_superuser=False,
+        auth_type=AuthTokenType.USER,
+    )
+    fieldset_partial_update_mock.assert_called_once_with(
+        name=data['name'],
+    )
+
+
+def test_partial_update_fieldset_is_used__return_usage(api_client, mocker):
+
+    """ Partial update with minimal request data """
+
+    # arrange
+    account = create_test_account()
+    user = create_test_owner(account=account)
+    shared_fieldset = create_test_shared_fieldset(
+        account=account,
+    )
+    data = {
+        'name': 'Updated Name',
+    }
+    template = create_test_template(
+        user=user,
+        tasks_count=1,
+    )
+    task = template.tasks.get(number=1)
+    create_test_fieldset_template(
+        account=account,
+        template=template,
+        task=task,
+        shared_fieldset=shared_fieldset,
+    )
+    fieldset_service_init_mock = mocker.patch.object(
+        FieldSetTemplateService,
+        attribute='__init__',
+        return_value=None,
+    )
+    fieldset_partial_update_mock = mocker.patch(
+        'src.processes.views.fieldset.FieldSetTemplateService.partial_update',
+        return_value=shared_fieldset,
+    )
+    api_client.token_authenticate(user=user)
+
+    # act
+    response = api_client.patch(
+        f'/fieldsets/{shared_fieldset.id}',
+        data=data,
+    )
+
+    # assert
+    assert response.status_code == 200
+    assert response.data['id'] == shared_fieldset.id
+    assert len(response.data['usage']) == 1
+    assert response.data['usage'][0]['id'] == template.id
+    assert response.data['usage'][0]['name'] == template.name
+    fieldset_service_init_mock.assert_called_once_with(
+        user=user,
+        instance=shared_fieldset,
         is_superuser=False,
         auth_type=AuthTokenType.USER,
     )

--- a/backend/src/processes/tests/test_views/test_fieldsets/test_retrieve.py
+++ b/backend/src/processes/tests/test_views/test_fieldsets/test_retrieve.py
@@ -10,7 +10,7 @@ from src.processes.tests.fixtures import (
     create_test_account,
     create_test_shared_fieldset,
     create_test_not_admin,
-    create_test_owner,
+    create_test_owner, create_test_template, create_test_fieldset_template,
 )
 
 pytestmark = pytest.mark.django_db
@@ -47,6 +47,7 @@ def test_retrieve__fieldset_all_data__ok(api_client):
     assert response.data['order'] == fieldset.order
     assert response.data['layout'] == fieldset.layout
     assert response.data['label_position'] == fieldset.label_position
+    assert response.data['usage'] == []
 
     assert len(response.data['rules']) == 1
     assert response.data['rules'][0]['type'] == rule.type
@@ -63,6 +64,42 @@ def test_retrieve__fieldset_all_data__ok(api_client):
     assert response.data['fields'][0]['api_name'] == field.api_name
     assert response.data['fields'][0]['default'] == field.default
     assert response.data['fields'][0]['order'] == field.order
+
+
+def test_retrieve__fieldset_is_used__return_usage(api_client):
+
+    # arrange
+    account = create_test_account()
+    user = create_test_owner(account=account)
+    rule_type = FieldSetRuleType.SUM_EQUAL
+    rule_value = '10'
+    shared_fieldset = create_test_shared_fieldset(
+        account=account,
+        rule_type=rule_type,
+        rule_value=rule_value,
+    )
+    template = create_test_template(
+        user=user,
+        tasks_count=1,
+    )
+    task = template.tasks.get(number=1)
+    create_test_fieldset_template(
+        account=account,
+        template=template,
+        task=task,
+        shared_fieldset=shared_fieldset,
+    )
+    api_client.token_authenticate(user=user)
+
+    # act
+    response = api_client.get(f'/fieldsets/{shared_fieldset.id}')
+
+    # assert
+    assert response.status_code == 200
+    assert response.data['id'] == shared_fieldset.id
+    assert len(response.data['usage']) == 1
+    assert response.data['usage'][0]['id'] == template.id
+    assert response.data['usage'][0]['name'] == template.name
 
 
 def test_retrieve__fieldset_rule_with_fields__ok(api_client):

--- a/backend/src/processes/views/fieldset.py
+++ b/backend/src/processes/views/fieldset.py
@@ -1,3 +1,6 @@
+from typing import List, Optional
+
+from django.db.models import Prefetch
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import (
     OpenApiParameter,
@@ -30,6 +33,7 @@ from src.processes.filters import FieldSetFilter
 from src.processes.models.templates.fieldset import (
     FieldsetTemplate,
 )
+from src.processes.models.templates.template import Template
 from src.processes.serializers.templates.fieldset import (
     SharedFieldsetTemplateSerializer,
 )
@@ -76,11 +80,29 @@ class SharedFieldsetTemplateViewSet(
         if getattr(self, 'swagger_fake_view', False):
             return FieldsetTemplate.objects.none()
         user = self.request.user
-        return (
+        qst = (
             FieldsetTemplate.objects
             .select_related('template')
             .shared()
             .on_account(user.account_id)
+        )
+        return self.prefetch_queryset(qst)
+
+    def prefetch_queryset(
+        self,
+        queryset,
+        extra_fields: Optional[List[str]] = None,
+    ):
+        if self.action == 'list':
+            queryset = queryset.prefetch_related(
+                Prefetch(
+                    'child_fieldsets__template',
+                    queryset=Template.objects.only('id', 'name'),
+                ),
+            )
+        return super().prefetch_queryset(
+            queryset=queryset,
+            extra_fields=extra_fields,
         )
 
     @extend_schema(


### PR DESCRIPTION
# Problem

Shared field groups often showed up without a clear display title: if nobody set a title by hand, the title stayed empty even though the group already had a name. That made field groups harder to recognize in the product.

Separately, when managing shared field groups, it was not obvious which workflow templates already use a given group. Admins had to open templates one by one to find dependencies, which slowed down cleanup and safe editing.

# Fix / Solution

1. When a fieldset is created without an explicit title, set the title from the fieldset name by default.
2. Backfill existing fieldsets so empty titles are filled from the name.
3. Add a read-only `usage` property to shared fieldset API responses: a deduplicated list of templates (id + name) that already attach this shared fieldset (via kickoff or tasks), sorted by template id.

# Release notes

Shared fieldsets now default their display title to the fieldset name when no title is provided, and existing empty titles are filled in. Fieldset list, detail, create, update, and clone responses include a read-only `usage` list of templates that use the shared fieldset.

# Changes

## API

**`/fieldsets`**

- `POST /fieldsets` — if `title` is omitted or empty, response `title` equals `name`; response includes `usage: []` for a newly created fieldset
- `GET /fieldsets` — each item includes read-only `usage`: unique templates that use the shared fieldset (`[{ "id", "name" }]`, sorted by `id`; `[]` if unused). Multiple attachments in one template count as one usage entry
- `GET /fieldsets/{id}` — response includes `usage` with the same semantics
- `PATCH /fieldsets/{id}` — success response includes `usage` (updated fieldset still reports templates that use it)
- `POST /fieldsets/{id}/clone` — clone response includes `usage: []` (clone is not yet attached to templates)

**Data migration**

- Existing fieldset / fieldset template rows: `title` populated from `name` where applicable

## Web-client

No web-client changes in this branch.

# Test cases

## API

### `POST /fieldsets`

| Authorization | Test case | Expected result |
| --- | --- | --- |
| Admin / owner token | Create shared fieldset with only required field `name` (no `title`) | **201**; `title` equals `name`; other optional fields use defaults; `usage` is `[]` |
| Admin / owner token | Create shared fieldset with all fields including explicit `title` | **201**; response `title` matches the sent value (not overwritten by `name`); `usage` is `[]` |
| None | Create without authentication | **401** |
| Non-admin user token | Create as regular (non-admin) user | **403** |
| Owner token, expired subscription | Create with expired subscription | **403** |
| Owner token, no billing plan | Create without billing plan | **403** |
| Owner token, users over limit | Create when account exceeds user limit | **403** |
| Admin / owner token | Create with blank `name` | **400**; validation error on `name` |

### `GET /fieldsets`

| Authorization | Test case | Expected result |
| --- | --- | --- |
| Admin / owner token | List when fieldset is unused | **200**; item has `usage: []` |
| Admin / owner token | List when fieldset is attached to two different templates (task on each) | **200**; `usage` has 2 items; ids/names match those templates; order by template `id` ascending |
| Admin / owner token | List when fieldset is attached to kickoff of template A and task of template B | **200**; `usage` has 2 items (both templates) |
| Admin / owner token | List when fieldset is attached twice in one template (kickoff + task) | **200**; `usage` has **1** item for that template |
| Admin / owner token | `ordering=name` / `-name` / `date` / `-date` | **200**; order of fieldsets matches ordering; each item still includes `usage` |
| Admin / owner token | `limit` + `offset` pagination | **200**; page size/offset match; each result includes `usage` |
| None | List without authentication | **401** |
| Non-admin user token | List as non-admin | **403** |
| Owner token, expired subscription / no plan / users over limit | List when corresponding permission fails | **403** |
| Admin / owner token | Invalid `ordering` value | **400**; validation error |

### `GET /fieldsets/{id}`

| Authorization | Test case | Expected result |
| --- | --- | --- |
| Admin / owner token | Retrieve unused shared fieldset | **200**; full payload; `usage: []` |
| Admin / owner token | Retrieve fieldset used in one template | **200**; `usage` length 1; `id`/`name` match that template |
| None | Retrieve without authentication | **401** |
| Non-admin user token | Retrieve as non-admin | **403** |
| Owner token, expired subscription / no plan / users over limit | Retrieve when permission fails | **403** |
| Admin / owner token | Retrieve non-existent or non-shared / other-account fieldset | **404** |

### `PATCH /fieldsets/{id}`

| Authorization | Test case | Expected result |
| --- | --- | --- |
| Admin / owner token | Patch only `name` on unused fieldset | **200**; name updated; `usage: []` |
| Admin / owner token | Patch only `name` on fieldset used in one template | **200**; name updated; `usage` still lists that template |
| Admin / owner token | Patch with all updatable fields (name, description, layout, label_position, fields, rules) | **200**; response reflects new values; includes `usage` |
| None | Patch without authentication | **401** |
| Non-admin user token | Patch as non-admin | **403** |
| Owner token, expired subscription / no plan / users over limit | Patch when permission fails | **403** |
| Admin / owner token | Patch with blank `name` | **400**; validation error on `name` |
| Admin / owner token | Patch with invalid `layout` / `label_position` | **400**; validation error on the field |
| Admin / owner token | Patch when service rejects update (e.g. fieldset used in templates and change is blocked) | **400**; validation error body with service message |
| Admin / owner token | Patch non-existent or non-shared fieldset | **404** |

### `POST /fieldsets/{id}/clone`

| Authorization | Test case | Expected result |
| --- | --- | --- |
| Admin / owner token | Clone a shared fieldset (source may already be used in templates) | **201**; clone has new `api_name`; `usage` is `[]` |
| None | Clone without authentication | **401** |
| Non-admin user token | Clone as non-admin | **403** |
| Owner token, expired subscription / no plan / users over limit | Clone when permission fails | **403** |
| Admin / owner token | Clone non-existent fieldset | **404** |

## Web-client

| Browser | Device | Authorization | Test scenario | Expected result |
| --- | --- | --- | --- | --- |
| Chrome | Desktop browser | Logged-in admin / owner | Create a shared fieldset with a name only (no separate title) via UI that calls `POST /fieldsets` | Fieldset is created; displayed title matches the name (or API returns `title` = `name`) |
| Chrome | Desktop browser | Logged-in admin / owner | Open fieldset library / list after attaching a shared fieldset to one or more templates | If UI reads `usage`, templates that use the fieldset are shown; unused fieldsets show empty usage |
| Chrome | Desktop browser | Logged-in admin / owner | Open detail of a shared fieldset used in two templates | Usage shows both templates once each |
| Chrome | Desktop browser | Logged-in admin / owner | Attach the same shared fieldset to kickoff and a task of one template → open fieldset detail/list | Usage shows that template once |
| Chrome | Desktop browser | Logged-in admin / owner | Clone a shared fieldset that is already used elsewhere | Clone opens with no usage / not linked to the source templates |
| Chrome | Desktop browser | Logged-in non-admin | Attempt to open fieldset management if UI exposes it | Access denied / no admin actions (unchanged) |
| Chrome | Desktop browser | Logged-in admin / owner | Regression: create fieldset with explicit custom title | Custom title is kept and shown; not replaced by name |
