### PR TITLE
48712 frontend [ profile ] Update account logo previews before save

### DIFF
--- a/frontend/src/public/components/ProfileAccount/ProfileAccount.tsx
+++ b/frontend/src/public/components/ProfileAccount/ProfileAccount.tsx
@@ -95,7 +95,7 @@ export function ProfileAccount({
           <AttachmentField
             title={formatMessage({ id: 'user-info.logo-sm' })}
             accountId={accountId!}
-            uploadedFiles={logoSm ? [getFileByUrl(logoSm)] : []}
+            uploadedFiles={state.logoSm ? [getFileByUrl(state.logoSm)] : []}
             setUploadedFiles={(files) => changeField('logoSm')(getUrlByFile(files[0]))}
             description={formatMessage({ id: 'user-info.logo-sm-desc' })}
             containerClassName={styles['field']}
@@ -107,7 +107,7 @@ export function ProfileAccount({
           <AttachmentField
             title={formatMessage({ id: 'user-info.logo-lg' })}
             accountId={accountId!}
-            uploadedFiles={logoLg ? [getFileByUrl(logoLg)] : []}
+            uploadedFiles={state.logoLg ? [getFileByUrl(state.logoLg)] : []}
             setUploadedFiles={(files) => changeField('logoLg')(getUrlByFile(files[0]))}
             description={formatMessage({ id: 'user-info.logo-lg-desc' })}
             containerClassName={styles['field']}

--- a/frontend/src/public/components/ProfileAccount/__tests__/ProfileAccount.test.tsx
+++ b/frontend/src/public/components/ProfileAccount/__tests__/ProfileAccount.test.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import { act, render } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+
+import { enMessages } from '../../../lang/locales/en_US';
+import { ESubscriptionPlan } from '../../../types/account';
+import { TUploadedFile } from '../../../utils/uploadFiles';
+import { AttachmentField, IAttachmentFieldProps } from '../../UI/Fields/AttachmentField';
+import { ProfileAccount } from '../ProfileAccount';
+
+jest.mock('../../UI/Fields/AttachmentField', () => ({
+  AttachmentField: jest.fn(() => null),
+}));
+
+const attachmentFieldMock = AttachmentField as unknown as jest.Mock;
+const getLogoProps = (expectedImageWidth: number) => (
+  [...attachmentFieldMock.mock.calls]
+    .reverse()
+    .find(([props]) => props.expectedImageWidth === expectedImageWidth)?.[0] as IAttachmentFieldProps
+);
+
+const renderProfileAccount = () => render(
+  <IntlProvider locale="en" messages={enMessages}>
+    <ProfileAccount
+      accountId={1}
+      name="Acme"
+      logoSm="https://example.com/old-small.png"
+      logoLg="https://example.com/old-large.png"
+      loading={false}
+      leaseLevel="standard"
+      billingPlan={ESubscriptionPlan.Premium}
+      isAdmin
+      editCurrentAccount={jest.fn()}
+      onChangeTab={jest.fn()}
+    />
+  </IntlProvider>,
+);
+
+describe('ProfileAccount', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each([
+    ['small', 80],
+    ['large', 340],
+  ])('updates the %s logo preview before the form is saved', (_, expectedImageWidth) => {
+    const uploadedLogo: TUploadedFile = {
+      id: 'new-logo',
+      name: 'new-logo.png',
+      size: 100,
+      url: 'https://example.com/new-logo.png',
+      thumbnailUrl: 'https://example.com/new-logo.png',
+    };
+
+    renderProfileAccount();
+
+    act(() => getLogoProps(expectedImageWidth).setUploadedFiles([uploadedLogo]));
+
+    expect(getLogoProps(expectedImageWidth).uploadedFiles[0]?.url).toBe(uploadedLogo.url);
+
+    act(() => getLogoProps(expectedImageWidth).setUploadedFiles([{ ...uploadedLogo, isRemoved: true }]));
+
+    expect(getLogoProps(expectedImageWidth).uploadedFiles).toEqual([]);
+  });
+});


### PR DESCRIPTION
### 1. Release notes

Fixed account logo previews in Account Settings. Newly uploaded small and large logos now appear immediately, and removed logos disappear immediately, without waiting for Save.

---

### 2. Context

- **Issue:** #48712
- **App Location:** Profile -> Account Settings -> Personalization.
- **Related Changes:** Corrected the logo values supplied to the shared attachment widget and added regression coverage for both account logo sizes.

---

### 3. Solution & Implementation Details

* **Root cause:** `ProfileAccount` stored unsaved logo changes in local form state but continued passing the saved Redux props to `AttachmentField`.
* **Immediate upload preview:** Small and large logo widgets now receive `state.logoSm` and `state.logoLg`, so the uploaded file URL is rendered during the unsaved form state.
* **Immediate removal preview:** Removing a logo sets the corresponding local value to `null`, and the widget immediately receives an empty file list.
* **Save behavior preserved:** The form still submits the complete local account state only when Save is clicked.
* **Shared widget unchanged:** No special-case state or duplicate preview logic was added to `AttachmentField`.

---

### 4. What to Test

#### 4.1 Preconditions

1. Log in as an account administrator.
2. Use a non-tenant account with an active billing plan.
3. Open Profile -> Account Settings.
4. Prepare images with the required dimensions:
   - Small logo: 80 × 80.
   - Large logo: 340 × 96.

#### 4.2 Positive Scenarios / Testing Report

| Scenario | Description (Steps & Expected Result) | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| :--- | :--- | :---: | :---: | :---: | :---: |
| **Upload small logo** | Select a valid 80 × 80 image.<br>**Result:** The new thumbnail appears immediately before Save and the Save button becomes enabled. | [ ] | [ ] | [ ] | [ ] |
| **Upload large logo** | Select a valid 340 × 96 image.<br>**Result:** The new thumbnail appears immediately before Save and the Save button becomes enabled. | [ ] | [ ] | [ ] | [ ] |
| **Remove small logo** | Click the remove icon on the small logo.<br>**Result:** The thumbnail disappears immediately before Save. | [ ] | [ ] | [ ] | [ ] |
| **Remove large logo** | Click the remove icon on the large logo.<br>**Result:** The thumbnail disappears immediately before Save. | [ ] | [ ] | [ ] | [ ] |
| **Save uploaded logos** | Upload valid logos and click Save.<br>**Result:** The previews remain visible after the account update completes and after page reload. | [ ] | [ ] | [ ] | [ ] |
| **Save removed logos** | Remove the logos and click Save.<br>**Result:** They remain absent after the account update completes and after page reload. | [ ] | [ ] | [ ] | [ ] |

#### 4.3 Negative Scenarios & Edge Cases

| Scenario | Description (Steps & Expected Result) | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| :--- | :--- | :---: | :---: | :---: | :---: |
| **Wrong image dimensions** | Select an image with dimensions other than the required size.<br>**Result:** Validation is shown, no invalid preview replaces the current logo, and Save state remains correct. | [ ] | [ ] | [ ] | [ ] |
| **Upload then remove before Save** | Upload a valid logo and immediately remove it.<br>**Result:** The new preview appears and then disappears without saving. | [ ] | [ ] | [ ] | [ ] |
| **Replace existing logo** | Upload a new image while an existing logo is present.<br>**Result:** The new preview replaces the old one immediately, with no duplicate thumbnail. | [ ] | [ ] | [ ] | [ ] |
| **Upload failure** | Simulate a failed file-service request.<br>**Result:** The existing preview is retained and an upload error is shown. | [ ] | [ ] | [ ] | [ ] |
| **Non-admin account** | Open Account Settings without admin permissions.<br>**Result:** Existing permission behavior remains unchanged. | [ ] | [ ] | [ ] | [ ] |

#### 4.4 Verification Points

- **UI:** Upload and removal are reflected before Save for both logo sizes.
- **UI:** Only one preview is displayed per logo field.
- **State:** Save becomes enabled only when local account content differs and remains valid.
- **Persistence:** Saved logo URLs survive a reload; saved removals remain absent.
- **Console:** No attachment-state or React rendering warnings.

#### 4.5 API Verification

- **File upload:** Verify the existing file-service `POST` request contains the selected file as multipart field `file` and returns `publicUrl` and `fileId`.
- **Before Save:** Uploading/removing updates only local form state; no account update should be sent until Save is clicked.
- **Account update:** Verify Save sends the current `logoSm` and `logoLg` URLs, or `null` for removed logos, through the existing account update request.
- No backend API contract changes are included.

#### 4.6 What Was NOT Tested

- Manual browser matrix testing remains unchecked.
- Real file-service upload and account update requests were not executed during automated testing.
- Tenant personalization visibility and billing entitlement changes.
- Sidebar/logo cache behavior across multiple browser sessions.

---

### 5. Affected Areas

| Scenario | Description | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| :--- | :--- | :---: | :---: | :---: | :---: |
| **Small Account Logo** | Immediate upload, replacement, and removal preview. | [ ] | [ ] | [ ] | [ ] |
| **Large Account Logo** | Immediate upload, replacement, and removal preview. | [ ] | [ ] | [ ] | [ ] |
| **Account Settings Save** | Existing persistence of local form values. | [ ] | [ ] | [ ] | [ ] |

---

### 6. Unit Tests

- `ProfileAccount/__tests__/ProfileAccount.test.tsx`:
  - Verifies the 80 × 80 small-logo preview updates immediately after upload and removal.
  - Verifies the 340 × 96 large-logo preview updates immediately after upload and removal.
- Automated result: 2 tests passed.
- ESLint passed for the modified component and regression test.
- Full standalone TypeScript compilation was not used as a pass criterion because the repository currently reports pre-existing duplicate React type declarations under Enzyme dependencies.

---

### 7. Commits

- `21c91c82` — `48712 fix(profile): update account logo previews before save`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Show account logo previews from local state before saving in ProfileAccount
The `AttachmentField` components for small and large logos in [ProfileAccount.tsx](https://github.com/pneumaticapp/pneumaticworkflow/pull/332/files#diff-680843dbe1ea5ab540c5388698446b40e8bd0812419edfd2317687b65f2f1f1e) now derive `uploadedFiles` from local component state (`state.logoSm`/`state.logoLg`) instead of the initial props, so logo previews update immediately when a user selects or removes a file without waiting for a save. A Jest test is added to verify that file selection and removal correctly update the `uploadedFiles` prop for both logo sizes.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 21c91c8.</sup>
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->