### PR TITLE
48742 backend [ fieldsets ] Use the api_name from the request when creating rules and fields

### DIFF
--- a/backend/src/processes/services/fieldsets/fieldset.py
+++ b/backend/src/processes/services/fieldsets/fieldset.py
@@ -223,7 +223,7 @@ class FieldSetTemplateService(BaseModelService):
         }
         fields_api_names = set()
         for field_data in fields_data:
-            field_api_name = field_data.pop('api_name', None)
+            field_api_name = field_data.get('api_name')
             if field_api_name and field_api_name in existing_fields:
                 service = FieldTemplateService(
                     user=self.user,
@@ -409,7 +409,7 @@ class FieldSetTemplateService(BaseModelService):
         }
         rule_api_names = set()
         for rule_data in rules_data:
-            rule_api_name = rule_data.pop('api_name', None)
+            rule_api_name = rule_data.get('api_name')
             if rule_api_name and rule_api_name in existing_rules:
                 service = FieldsetTemplateRuleService(
                     user=self.user,

--- a/backend/src/processes/tests/test_services/test_fieldsets/test_fieldset_template_service.py
+++ b/backend/src/processes/tests/test_services/test_fieldsets/test_fieldset_template_service.py
@@ -572,6 +572,7 @@ def test__update_fields__existing_field__ok(mocker):
     )
     field_template_service_partial_update_mock.assert_called_once_with(
         name='Updated Field 1',
+        api_name=field_1.api_name,
         force_save=True,
     )
     field_template_service_create_mock.assert_not_called()
@@ -600,7 +601,11 @@ def test__update_fields__new_field__ok(mocker):
         instance=fieldset,
     )
     fields_data = [
-        {'name': 'New Field', 'type': 'number', 'order': 1},
+        {
+            'name': 'New Field',
+            'type': 'number', 'order': 1,
+            'api_name': 'field-api-name',
+        },
     ]
 
     # mock
@@ -633,6 +638,7 @@ def test__update_fields__new_field__ok(mocker):
     field_template_service_create_mock.assert_called_once_with(
         fieldset_id=fieldset.id,
         template_id=template.id,
+        api_name='field-api-name',
         name='New Field',
         type='number',
         order=1,
@@ -811,6 +817,7 @@ def test_update_rules__existing_rule__ok(mocker):
     )
     fs_rule_update_mock.assert_called_once_with(
         value='200',
+        api_name=rule_1.api_name,
     )
     fieldset_template_rule_service_create_mock.assert_not_called()
 
@@ -837,7 +844,11 @@ def test_update_rules__new_rule__ok(mocker):
         instance=fieldset,
     )
     rules_data = [
-        {'type': FieldSetRuleType.SUM_EQUAL, 'value': '100'},
+        {
+            'type': FieldSetRuleType.SUM_EQUAL,
+            'value': '100',
+            'api_name': 'rule-api-name',
+        },
     ]
 
     # mock
@@ -870,6 +881,7 @@ def test_update_rules__new_rule__ok(mocker):
     fs_rule_create_mock.assert_called_once_with(
         fieldset_id=fieldset.id,
         type=FieldSetRuleType.SUM_EQUAL,
+        api_name='rule-api-name',
         value='100',
     )
     fs_rule_update_mock.assert_not_called()


### PR DESCRIPTION
… rules and fields

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Forward `api_name` from request when updating fieldset rules and fields
> In [`fieldset.py`](https://github.com/pneumaticapp/pneumaticworkflow/pull/333/files#diff-9b6987678d126d968067806273133f46da11ba5b258a1ba6a3a72c4b22cff120), `FieldSetTemplateService.update_fields` and `update_rules` were calling `pop('api_name', None)` on each payload, silently discarding the `api_name` supplied by the caller. Replacing `pop` with `get` preserves `api_name` so it is forwarded to `FieldTemplateService.partial_update` and `FieldsetTemplateRuleService.partial_update` respectively.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 839c243.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->