### PR TITLE
48867 frontend Fix CSS lint errors blocking frontend deploy

### DIFF
--- a/frontend/src/public/components/Fieldsets/FieldsetDetails/FieldsetDetails.css
+++ b/frontend/src/public/components/Fieldsets/FieldsetDetails/FieldsetDetails.css
@@ -61,10 +61,10 @@
 }
 
 .settings-label {
-  font-weight: 600;
-  color: var(--pneumatic-color-black72);
   display: flex;
   gap: 0.4rem;
+  font-weight: 600;
+  color: var(--pneumatic-color-black72);
 
   @mixin text-base;
 }

--- a/frontend/src/public/components/TemplateEdit/OutputForm/OutputForm.css
+++ b/frontend/src/public/components/TemplateEdit/OutputForm/OutputForm.css
@@ -85,10 +85,10 @@
 }
 
 .flow__fieldset-title-edit {
-  display: inline-flex;
-  align-items: center;
   margin-top: 0.2rem;
   padding-left: 1.2rem;
+  display: inline-flex;
+  align-items: center;
   gap: 0.4rem;
 
   @mixin text-small;
@@ -99,8 +99,8 @@
 }
 
 .flow__fieldset-title-input {
-  border: none;
   resize: none;
+  border: none;
   outline: none;
   field-sizing: content;
 
@@ -114,4 +114,3 @@
     color: var(--pneumatic-color-warning);
   }
 }
-

--- a/frontend/src/public/components/TemplateEdit/TaskOutputFlow/FieldsetEditorTitle.tsx
+++ b/frontend/src/public/components/TemplateEdit/TaskOutputFlow/FieldsetEditorTitle.tsx
@@ -59,6 +59,8 @@ export function FieldsetEditorTitle({
       />
       {!isFocused && (
         <button
+          type="button"
+          aria-label="Edit"
           onClick={() => inputRef.current?.focus()}
           className={kickoffStyles['kick-off-edit-name']}
         >

--- a/frontend/src/public/components/TemplateEdit/TaskOutputFlow/FieldsetIconPicker.css
+++ b/frontend/src/public/components/TemplateEdit/TaskOutputFlow/FieldsetIconPicker.css
@@ -8,7 +8,6 @@
 }
 
 .fieldset-picker__menu {
-
   max-width: 20rem;
 }
 
@@ -30,5 +29,3 @@
   line-height: 1.6rem;
   color: var(--pneumatic-color-black48);
 }
-
-


### PR DESCRIPTION
### 1. Release notes

Fixed CSS linter (stylelint) errors that were blocking the frontend deployment.

### 2. Context

- Task: 48867
- Related tasks: errors originated from commits in tasks 48527 and 48526 (fieldsets)
- CI pipeline (`frontend-production`) was failing at the `npm run stylelint` step with exit code 2

### 3. Solution

Surgically fixed CSS property order and removed extra empty lines in 3 files:

- **`FieldsetDetails.css`** — `.settings-label`: moved `display` and `gap` before `font-weight` and `color` (`order/properties-order` rule)
- **`OutputForm.css`** — `.flow__fieldset-title-edit`: moved `margin-top` before `display`; `.flow__fieldset-title-input`: moved `resize` before `border`; removed trailing empty line
- **`FieldsetIconPicker.css`** — removed empty line before first declaration in `.fieldset-picker__menu`; removed double trailing empty lines
- **`FieldsetEditorTitle.tsx`** — added `type="button"` and `aria-label="Edit"` to the icon-only edit button (`react/button-has-type` and `jsx-a11y/control-has-associated-label` rules)

### 4. Testing

#### 4.1 Preconditions

- Dev environment, branch `frontend/48867__fix_css_lint_errors_blocking_frontend_deploy`
- Changes are purely cosmetic (CSS property order, empty lines) — **no behavior or rendering changes**

#### 4.2 Positive scenarios

| Scenario | Description (steps & expected result) | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| :--- | :--- | :--- | :--- | :--- | :--- |
| **CI passes** | Run `frontend-production` pipeline → stylelint, eslint, and tests should pass without errors | [ ] | — | — | — |
| **Fieldset page** | Open any fieldset → Everything renders as before | [ ] | [ ] | [ ] | [ ] |
| **Template editor** | Open a template with fieldsets → Fieldset title, icon, fields display correctly | [ ] | [ ] | [ ] | [ ] |

#### 4.3 Negative scenarios

Not applicable — changes do not affect logic, only CSS property order and empty lines.

#### 4.4 Verification points

- CI pipeline passes fully (stylelint + eslint + tests)
- No visual regressions

#### 4.5 What was NOT tested

- Locales — not affected
- API — not affected
- Functionality — not affected (pure lint fix)

### 5. Commits

- `2e644c76` — `48867 fix(css): fix stylelint property order and empty line violations in fieldset components`



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix CSS lint errors and prevent edit button from submitting forms in FieldsetEditorTitle
> - Reorders CSS declarations in [FieldsetDetails.css](https://github.com/pneumaticapp/pneumaticworkflow/pull/338/files#diff-104666077505f389010bd60193fc4f83bb8c4cb5bc2c80f094074b8d56af4c62) and [OutputForm.css](https://github.com/pneumaticapp/pneumaticworkflow/pull/338/files#diff-d99d3d02351dd8e643e9c37776fd383a9abd50977504168c7b5a167c7e83a788) to resolve lint errors blocking frontend deploy.
> - Adds `type="button"` and `aria-label="Edit"` to the edit button in [FieldsetEditorTitle.tsx](https://github.com/pneumaticapp/pneumaticworkflow/pull/338/files#diff-c52034d9404f722fd74dddfe8ad9168176e9abf3f61b62fb3098cb1fe4989135) so it no longer triggers form submission on click and is accessible to assistive technologies.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2e644c7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->