### PR TITLE
48914 frontend [ kick-off-form ] Wrap file field name

### DIFF
--- a/frontend/src/public/components/TemplateEdit/ExtraFields/File/ExtraFieldFileTemplate.tsx
+++ b/frontend/src/public/components/TemplateEdit/ExtraFields/File/ExtraFieldFileTemplate.tsx
@@ -1,5 +1,4 @@
 import React, { useRef, useState } from 'react';
-import AutosizeInput from 'react-input-autosize';
 import classnames from 'classnames';
 import { useIntl } from 'react-intl';
 
@@ -23,7 +22,7 @@ export function ExtraFieldFileTemplate({
   editField,
 }: IExtraFieldFileTemplateProps) {
   const { formatMessage } = useIntl();
-  const fieldNameInputRef = useRef<HTMLInputElement | null>(null);
+  const fieldNameInputRef = useRef<HTMLTextAreaElement | null>(null);
   const [isFocused, setIsFocused] = useState(false);
   const fieldNameErrorMessage = validateKickoffFieldName(field.name) || '';
 
@@ -45,19 +44,17 @@ export function ExtraFieldFileTemplate({
         />
       ) : (
       <div className={styles['extra-field-file__input--template']}>
-        <AutosizeInput
-          inputRef={(ref) => {
-            fieldNameInputRef.current = ref;
-          }}
-          inputClassName={classnames(
+        <textarea
+          ref={fieldNameInputRef}
+          className={classnames(
             styles['extra-field-file__input-name--template'],
             fieldNameErrorMessage && styles['extra-field-file__input-name-error--template'],
           )}
           onChange={(event) => editField({ name: event.target.value })}
           placeholder={namePlaceholder}
-          type="text"
           value={field.name}
           disabled={isDisabled}
+          rows={1}
           onFocus={() => setIsFocused(true)}
           onBlur={() => setIsFocused(false)}
           onKeyDown={(event) => {

--- a/frontend/src/public/components/TemplateEdit/ExtraFields/File/ExtraFieldFileTemplate.tsx
+++ b/frontend/src/public/components/TemplateEdit/ExtraFields/File/ExtraFieldFileTemplate.tsx
@@ -50,7 +50,7 @@ export function ExtraFieldFileTemplate({
             styles['extra-field-file__input-name--template'],
             fieldNameErrorMessage && styles['extra-field-file__input-name-error--template'],
           )}
-          onChange={(event) => editField({ name: event.target.value })}
+          onChange={(event) => editField({ name: event.target.value.replace(/[\r\n]+/g, ' ') })}
           placeholder={namePlaceholder}
           value={field.name}
           disabled={isDisabled}
@@ -59,6 +59,7 @@ export function ExtraFieldFileTemplate({
           onBlur={() => setIsFocused(false)}
           onKeyDown={(event) => {
             if (event.key === 'Enter') {
+              event.preventDefault();
               setIsFocused(false);
               event.currentTarget.blur();
             }

--- a/frontend/src/public/components/TemplateEdit/ExtraFields/File/__tests__/ExtraFieldFile.test.tsx
+++ b/frontend/src/public/components/TemplateEdit/ExtraFields/File/__tests__/ExtraFieldFile.test.tsx
@@ -183,7 +183,7 @@ describe('ExtraFieldFile', () => {
       expect(screen.getByDisplayValue('Attachments')).toBeInTheDocument();
     });
 
-    it('uses a textarea for a long field name', () => {
+    it('uses a textarea for a long field name without allowing line breaks', () => {
       const fieldName = `AttachmentField${'1'.repeat(100)}`;
 
       render(
@@ -202,6 +202,11 @@ describe('ExtraFieldFile', () => {
       fireEvent.change(fieldNameInput, { target: { value: 'Updated attachments' } });
 
       expect(editFieldMock).toHaveBeenCalledWith({ name: 'Updated attachments' });
+
+      fireEvent.change(fieldNameInput, { target: { value: 'Attachment\r\nfiles' } });
+
+      expect(editFieldMock).toHaveBeenLastCalledWith({ name: 'Attachment files' });
+      expect(fireEvent.keyDown(fieldNameInput, { key: 'Enter' })).toBe(false);
     });
   });
 

--- a/frontend/src/public/components/TemplateEdit/ExtraFields/File/__tests__/ExtraFieldFile.test.tsx
+++ b/frontend/src/public/components/TemplateEdit/ExtraFields/File/__tests__/ExtraFieldFile.test.tsx
@@ -182,6 +182,27 @@ describe('ExtraFieldFile', () => {
 
       expect(screen.getByDisplayValue('Attachments')).toBeInTheDocument();
     });
+
+    it('uses a textarea for a long field name', () => {
+      const fieldName = `AttachmentField${'1'.repeat(100)}`;
+
+      render(
+        React.createElement(ExtraFieldFile as React.FC<any>, {
+          ...baseProps,
+          mode: EExtraFieldMode.Kickoff,
+          field: createFileField({ name: fieldName }),
+        }),
+      );
+
+      const fieldNameInput = screen.getByDisplayValue(fieldName);
+
+      expect(fieldNameInput.tagName).toBe('TEXTAREA');
+      expect(fieldNameInput).toHaveAttribute('rows', '1');
+
+      fireEvent.change(fieldNameInput, { target: { value: 'Updated attachments' } });
+
+      expect(editFieldMock).toHaveBeenCalledWith({ name: 'Updated attachments' });
+    });
   });
 
   describe('upload handling', () => {


### PR DESCRIPTION
### 1. Release notes

File field names in the Kick-off Form now wrap within the form without allowing hard line breaks.

### 2. Context

Issue: 48914

App Location: Template Editor, Kick-off Form, File field name

Related Changes: Regression introduced when task 48107 extracted the File field template and replaced its wrapping textarea with a single-line input.

### 3. Solution & Implementation Details

Replaced the `AutosizeInput` used for the File field name with a native controlled `<textarea rows={1}>`. Existing field-name styles provide the width constraint and word wrapping. Enter is prevented from inserting a hard line break, and pasted CR/LF sequences are normalized to spaces before the name is saved. Existing name editing, validation, focus, required indicator, and pencil-button behavior are retained.

### 4. What to Test

#### 4.1 Preconditions

1. Sign in as a user who can create or edit templates.
2. Open a template in the Template Editor.
3. Open the Kick-off Form and add a File field.

#### 4.2 Positive Scenarios / Testing Report

| Scenario | Steps | Expected result | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| --- | --- | --- | --- | --- | --- | --- |
| Long file field name | Enter a long File field name without spaces. | The name wraps and remains within the Kick-off Form layout. | [ ] | [ ] | [ ] | [ ] |
| Edit pencil | Click outside the File field name after editing it. | The edit pencil is visible beside the wrapped name. | [ ] | [ ] | [ ] | [ ] |
| Finish editing with Enter | Focus the File field name and press Enter. | Editing finishes without adding a line break to the field name. | [ ] | [ ] | [ ] | [ ] |
| Edit field name | Change the File field name and save the template. | The changed name is retained after saving and reopening the template. | [ ] | [ ] | [ ] | [ ] |

#### 4.3 Negative Scenarios & Edge Cases

| Scenario | Steps | Expected result | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| --- | --- | --- | --- | --- | --- | --- |
| Empty field name | Clear the File field name. | Existing validation message is shown and the layout remains intact. | [ ] | [ ] | [ ] | [ ] |
| Required File field | Mark the File field as required and enter a long name. | The required indicator remains visible and the name wraps without overlap. | [ ] | [ ] | [ ] | [ ] |
| Paste multiline text | Paste text containing CR/LF line breaks into the File field name. | Line breaks are replaced with spaces and are not persisted in the field name. | [ ] | [ ] | [ ] | [ ] |

#### 4.4 Verification Points

1. The File field name is rendered as a textarea with one initial row.
2. The edit pencil focuses the field name when it is not focused.
3. Pressing Enter leaves the field and does not insert a line break.
4. Pasted line breaks are normalized to spaces before `editField` receives the name.

#### 4.5 API Verification

No API contract changes. Saving a template continues to send the File field `name` in the existing template payload.

#### 4.6 What Was NOT Tested

Cross-browser verification, template saving, and manual multiline paste behavior were not tested.

### 5. Affected Areas

- Template Editor Kick-off Form: File field name editing and wrapping.
- File field name normalization: Enter and pasted line breaks.
- File field unit tests: Regression coverage for long field names.

### 6. Unit Tests

`frontend/src/public/components/TemplateEdit/ExtraFields/File/__tests__/ExtraFieldFile.test.tsx`

Coverage added for rendering a long Kick-off File field name in a textarea, updating its value, normalizing pasted CR/LF sequences, and preventing Enter from inserting a line break.

Executed successfully:

`npm test -- --runInBand src/public/components/TemplateEdit/ExtraFields/File/__tests__/ExtraFieldFile.test.tsx` (12 tests passed)

`npx eslint --no-ignore src/public/components/TemplateEdit/ExtraFields/File/ExtraFieldFileTemplate.tsx src/public/components/TemplateEdit/ExtraFields/File/__tests__/ExtraFieldFile.test.tsx`

### 7. Commits

`653593863` 48914 fix(kick-off-form): wrap file field name

`eb8303871` 48914 fix(kick-off-form): prevent multiline file field names



<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small UI-only change in template kick-off field editing with no backend or security impact.
> 
> **Overview**
> In the kick-off **file** extra field template editor (non–left-label layout), the editable field name control is switched from **`react-input-autosize`** to a native **`textarea`** with **`rows={1}`**, so long names **wrap vertically** instead of growing horizontally.
> 
> **`onChange`** now strips carriage returns/newlines (replaced with a space) so pasted text stays a single-line name. **Enter** calls **`preventDefault`** and still blurs the control. A kick-off mode test covers the textarea, newline normalization, and Enter handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb8303871ae816611409965d1b3cf783d62030e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace file field name input with a single-row textarea in kick-off form
> - Replaces `AutosizeInput` with a native `<textarea rows={1}>` in [`ExtraFieldFileTemplate`](https://github.com/pneumaticapp/pneumaticworkflow/pull/340/files#diff-8d3fd54d70c5f220dd2a22378841b2f611b22b9a18f350243175f2af3a903956) to support text wrapping in the field name editor.
> - Newline characters typed or pasted into the field are converted to a single space before saving, preventing multi-line names.
> - Pressing Enter blurs the field instead of inserting a newline.
> - Adds tests covering the textarea rendering, `onChange` behavior, newline stripping, and Enter key handling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eb83038.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->