### PR TITLE
48921 frontend [ workflows ] prevent empty workflow modal

### DIFF
--- a/frontend/src/public/components/Workflows/__tests__/Workflows.test.tsx
+++ b/frontend/src/public/components/Workflows/__tests__/Workflows.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { act, render } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import { useDispatch, useSelector } from 'react-redux';
+import { Route, Router, Switch } from 'react-router-dom';
+
+import { ERoutes } from '../../../constants/routes';
+import { EWorkflowsView } from '../../../types/workflow';
+import { Workflows } from '../Workflows';
+
+jest.mock('react-redux', () => ({
+  useDispatch: jest.fn(),
+  useSelector: jest.fn(),
+}));
+
+jest.mock('../WorkflowsGridPage', () => ({
+  __esModule: true,
+  default: () => <div>Grid view</div>,
+}));
+
+jest.mock('../WorkflowsTablePage', () => ({
+  __esModule: true,
+  default: () => <div>Table view</div>,
+}));
+
+describe('Workflows routing', () => {
+  it('does not remount workflows when replacing the list route with a detail route', () => {
+    const dispatch = jest.fn();
+    const memoryHistory = createMemoryHistory({ initialEntries: [ERoutes.Workflows] });
+    (useDispatch as jest.Mock).mockReturnValue(dispatch);
+    (useSelector as jest.Mock).mockReturnValue(EWorkflowsView.Table);
+
+    render(
+      <Router history={memoryHistory}>
+        <Switch>
+          <Route path={ERoutes.WorkflowDetail} component={Workflows} />
+          <Route path={ERoutes.Workflows} component={Workflows} />
+        </Switch>
+      </Router>,
+    );
+
+    act(() => memoryHistory.replace(ERoutes.WorkflowDetail.replace(':id', '42')));
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/public/redux/workflows/__tests__/saga.test.ts
+++ b/frontend/src/public/redux/workflows/__tests__/saga.test.ts
@@ -1,3 +1,24 @@
+import { runSaga } from 'redux-saga';
+import { call, takeEvery } from 'redux-saga/effects';
+
+import { makeFieldsetRuntime } from '../../../__stubs__/fieldsets.factory';
+import { makeTemplateResponse } from '../../../__stubs__/templates.factory';
+import * as deleteApi from '../../../api/deleteWorkflow';
+import * as finishWorkflowApi from '../../../api/finishWorkflow';
+import { getTemplate } from '../../../api/getTemplate';
+import { getTemplateSteps } from '../../../api/getTemplateSteps';
+import { getWorkflow } from '../../../api/getWorkflow';
+import { NotificationManager } from '../../../components/UI/Notifications';
+import { getClonedKickoff } from '../../../components/Workflows/WorkflowsGridPage/WorkflowCard/utils/getClonedKickoff';
+import {
+  getRunnableWorkflow,
+  loadDatasetsMap,
+} from '../../../components/TemplateEdit/utils/getRunnableWorkflow';
+import { ERoutes } from '../../../constants/routes';
+import { IKickoff } from '../../../types/template';
+import { history } from '../../../utils/history';
+import { mapTemplateFieldsetsToRuntime } from '../../../utils/mapTemplateFieldsetsToRuntime';
+import { handleLoadTemplateVariables } from '../../templates/saga';
 import {
   watchCloneWorkflow,
   cloneWorkflowSaga,
@@ -7,27 +28,16 @@ import {
   returnWorkflowToTaskSaga,
   setWorkflowFinishedSaga,
   fetchFilterSteps,
+  handleOpenWorkflowLogPopup,
 } from '../saga';
-import * as deleteApi from '../../../api/deleteWorkflow';
-import * as finishWorkflowApi from '../../../api/finishWorkflow';
-import { NotificationManager } from '../../../components/UI/Notifications';
-import { cloneWorkflowAction, deleteWorkflowAction, returnWorkflowToTaskAction, setWorkflowFinished } from '../slice';
-import { runSaga } from 'redux-saga';
-import { call } from 'redux-saga/effects';
-import { getWorkflow } from '../../../api/getWorkflow';
-import { getTemplate } from '../../../api/getTemplate';
 import {
-  loadDatasetsMap,
-  getRunnableWorkflow,
-} from '../../../components/TemplateEdit/utils/getRunnableWorkflow';
-import { mapTemplateFieldsetsToRuntime } from '../../../utils/mapTemplateFieldsetsToRuntime';
-import { getClonedKickoff } from '../../../components/Workflows/WorkflowsGridPage/WorkflowCard/utils/getClonedKickoff';
-import { getTemplateSteps } from '../../../api/getTemplateSteps';
-import { handleLoadTemplateVariables } from '../../templates/saga';
-import { IKickoff } from '../../../types/template';
-import { loadFilterSteps } from '../slice';
-import { makeFieldsetRuntime } from '../../../__stubs__/fieldsets.factory';
-import { makeTemplateResponse } from '../../../__stubs__/templates.factory';
+  cloneWorkflowAction,
+  deleteWorkflowAction,
+  loadFilterSteps,
+  openWorkflowLogPopup,
+  returnWorkflowToTaskAction,
+  setWorkflowFinished,
+} from '../slice';
 
 jest.mock('../../../api/getWorkflow', () => ({
   getWorkflow: jest.fn(),
@@ -55,7 +65,9 @@ jest.mock('../../../api/getTemplateSteps', () => ({
 }));
 
 jest.mock('../../templates/saga', () => ({
-  handleLoadTemplateVariables: jest.fn(function* () {}),
+  handleLoadTemplateVariables: jest.fn(function* handleLoadTemplateVariablesMock() {
+    yield undefined;
+  }),
 }));
 
 jest.mock('../../../utils/dateTime', () => ({
@@ -76,6 +88,20 @@ jest.mock('../../../utils/isRequestCanceled', () => ({
 }));
 
 describe('workflows saga', () => {
+  it('updates the workflow detail URL through router history', () => {
+    const replaceHistory = jest.spyOn(history, 'replace').mockImplementation(() => undefined);
+    const expectedUrl = ERoutes.WorkflowDetail.replace(':id', '42') + history.location.search;
+    const saga = handleOpenWorkflowLogPopup(openWorkflowLogPopup({
+      workflowId: 42,
+      shouldSetWorkflowDetailUrl: true,
+    }));
+
+    saga.next();
+
+    expect(replaceHistory).toHaveBeenCalledWith(expectedUrl);
+    replaceHistory.mockRestore();
+  });
+
   it('deleteWorkflowSaga work', () => {
     const saga = deleteWorkflowSaga({ type: deleteWorkflowAction.type, payload: { workflowId: 1 } });
     const deleteApiMock = jest.spyOn(deleteApi, 'deleteWorkflow').mockImplementation(() => Promise.resolve());
@@ -110,9 +136,10 @@ describe('workflows saga', () => {
       [watchReturnWorkflowToTask, returnWorkflowToTaskAction.type, returnWorkflowToTaskSaga],
     ])(
       'for the function %s, calls takeEvery with parameters %s and %s',
-      (testingFn, _action, _expectedFn) => {
+      (testingFn, action, expectedFn) => {
         const result = (testingFn as () => Generator)();
-        result.next();
+
+        expect(result.next().value).toEqual(takeEvery(action, expectedFn));
       },
     );
   });

--- a/frontend/src/public/redux/workflows/__tests__/slice.test.ts
+++ b/frontend/src/public/redux/workflows/__tests__/slice.test.ts
@@ -1,0 +1,16 @@
+import workflowsReducer, {
+  clearWorkflow,
+  openWorkflowLogPopup,
+} from '../slice';
+
+describe('workflows reducer', () => {
+  it('closes the workflow modal when clearing workflow data', () => {
+    const openState = workflowsReducer(undefined, openWorkflowLogPopup({ workflowId: 42 }));
+
+    const clearedState = workflowsReducer(openState, clearWorkflow());
+
+    expect(clearedState.workflow).toBeNull();
+    expect(clearedState.workflowLog.isOpen).toBe(false);
+    expect(clearedState.workflowLog.workflowId).toBeNull();
+  });
+});

--- a/frontend/src/public/redux/workflows/saga.ts
+++ b/frontend/src/public/redux/workflows/saga.ts
@@ -205,13 +205,13 @@ function* fetchWorkflow({ payload: id }: PayloadAction<number>) {
   }
 }
 
-function* handleOpenWorkflowLogPopup({
+export function* handleOpenWorkflowLogPopup({
   payload: { workflowId, shouldSetWorkflowDetailUrl, redirectTo404IfNotFound },
 }: PayloadAction<TOpenWorkflowLogPopupPayload>) {
   try {
     if (shouldSetWorkflowDetailUrl) {
       const newUrl = ERoutes.WorkflowDetail.replace(':id', String(workflowId)) + history.location.search;
-      window.history.replaceState(null, '', newUrl);
+      history.replace(newUrl);
     }
 
     yield handleLoadWorkflow({ workflowId });

--- a/frontend/src/public/redux/workflows/slice.ts
+++ b/frontend/src/public/redux/workflows/slice.ts
@@ -289,6 +289,9 @@ const workflowsSlice = createSlice({
     clearWorkflow: (state) => {
       state.workflow = null;
       state.workflowEdit = initialWorkflowEdit;
+      state.workflowLog.isOpen = false;
+      state.workflowLog.isOnlyAttachmentsShown = false;
+      state.workflowLog.workflowId = null;
     },
     setCurrentPerformersCounters: (state, action: PayloadAction<TUserCounter[]>) => {
       state.workflowsSettings.counters.performersCounters = action.payload;


### PR DESCRIPTION
### 1. Release notes

Fixed an empty workflow modal that could leave a yellow backdrop after navigating between Tasks, Workflows, and Highlights.

### 2. Context

Issue: 48921

App Location: Tasks, Workflows, and Highlights workflow modal navigation

Related Changes: Workflow detail URLs were updated outside React Router, while workflow modal visibility and workflow data could be cleared independently.

### 3. Solution & Implementation Details

Workflow detail URLs are now updated through the shared router `history`, keeping the browser URL and React Router state synchronized. Clearing workflow data now also closes the workflow modal and resets its workflow ID and attachment-only state, preventing an open modal with no workflow content.

### 4. What to Test

#### 4.1 Preconditions

1. Sign in as a user with access to Tasks, Workflows, and Highlights.
2. Ensure at least one workflow and related task are available.

#### 4.2 Positive Scenarios / Testing Report

| Scenario | Steps | Expected result | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| --- | --- | --- | --- | --- | --- | --- |
| Workflow to task navigation | Open a workflow modal, navigate to a related task, and use browser Back. | The destination page and workflow modal render normally. | [ ] | [ ] | [ ] | [ ] |
| Task to Workflows | Open a task, navigate to Workflows, and use browser Back/Forward. | No empty workflow modal or yellow backdrop remains. | [ ] | [ ] | [ ] | [ ] |
| Highlights workflow modal | Open a workflow from Highlights and navigate between supported pages. | Modal state does not survive after workflow data is cleared. | [ ] | [ ] | [ ] | [ ] |

#### 4.3 Negative Scenarios & Edge Cases

| Scenario | Steps | Expected result | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| --- | --- | --- | --- | --- | --- | --- |
| Repeated Back/Forward | Navigate repeatedly between workflow detail and task detail routes. | Router history remains synchronized and no empty modal appears. | [ ] | [ ] | [ ] | [ ] |
| Attachment-only view | Enable attachment-only workflow log view, leave the page, and return. | Attachment-only state is reset when workflow data is cleared. | [ ] | [ ] | [ ] | [ ] |

#### 4.4 Verification Points

1. No persistent yellow modal backdrop remains after navigation.
2. Workflow detail URLs use the expected `/workflows/:id/` route.
3. Clearing workflow data also closes the workflow modal and clears its workflow ID.

#### 4.5 API Verification

No API changes. Existing workflow and workflow log requests remain unchanged.

#### 4.6 What Was NOT Tested

Manual browser and cross-browser verification were not performed.

### 5. Affected Areas

- Workflow routing: Uses shared React Router history.
- Workflow modal state: Closes atomically when workflow data is cleared.
- Tasks, Workflows, and Highlights: Shared workflow modal navigation.

### 6. Unit Tests

`frontend/src/public/redux/workflows/__tests__/saga.test.ts`

Verifies workflow detail URL replacement through shared router history.

`frontend/src/public/redux/workflows/__tests__/slice.test.ts`

Verifies that clearing workflow data closes the modal and clears its workflow ID.

`frontend/src/public/components/Workflows/__tests__/Workflows.test.tsx`

Verifies that replacing `/workflows/` with `/workflows/:id/` keeps the existing Workflows component mounted and does not dispatch its `resetWorkflows` cleanup.

Executed successfully:

`npm test -- --runInBand src/public/components/Workflows/__tests__/Workflows.test.tsx src/public/redux/workflows/__tests__/saga.test.ts src/public/redux/workflows/__tests__/slice.test.ts` (10 tests passed)

`npx eslint --no-ignore src/public/components/Workflows/__tests__/Workflows.test.tsx src/public/redux/workflows/saga.ts src/public/redux/workflows/slice.ts src/public/redux/workflows/__tests__/saga.test.ts src/public/redux/workflows/__tests__/slice.test.ts`

### 7. Commits

`c73dd5c65` 48921 fix(workflows): prevent empty workflow modal

`60ee91cc0` 48921 test(workflows): cover detail route replacement


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized workflows UI/state and routing behavior with no auth or data-layer changes.
> 
> **Overview**
> Fixes the workflow log modal staying open with stale/empty data by resetting **`workflowLog`** when **`clearWorkflow`** runs (`isOpen`, attachment-only flag, and `workflowId`).
> 
> When opening a workflow from a detail URL, **`handleOpenWorkflowLogPopup`** now calls **`history.replace`** instead of **`window.history.replaceState`**, so URL updates go through the app router and are easier to test. **`handleOpenWorkflowLogPopup`** is exported for saga tests.
> 
> Adds coverage for the reducer close behavior, saga URL replacement, and a **`Workflows`** routing test that list→detail **`history.replace`** does not remount the page or dispatch again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60ee91cc0b9f88a5dae8156b366c6323257af417. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent empty workflow modal by closing it when workflow state is cleared
> - Extends the `clearWorkflow` reducer in [slice.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/341/files#diff-b05173541754598216ccf5c792b59351a62a39a78fe89074965f6c742959f8a3) to also reset `workflowLog` state (`isOpen: false`, `workflowId: null`), preventing the modal from remaining open with stale data.
> - Replaces direct `window.history.replaceState` with `history.replace` in [saga.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/341/files#diff-33f0f5384094add22dcaa819b1d9d7b784f406bc8781f39b2b67f57bd0938da8) so URL updates go through the app router.
> - Exports `handleOpenWorkflowLogPopup` from the saga to support the new unit tests added for both the saga and slice.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 60ee91c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->