### PR TITLE
docker: allow versioning of local images

### DIFF
--- a/docker-compose.src.yml
+++ b/docker-compose.src.yml
@@ -61,6 +61,7 @@ services:
   backend:
     build:
       context: ./backend
+    image: pneumaticworkflow/pneumatic-backend:${TAG:-src}
     container_name: pneumatic-backend
     command: >
       sh -c "python manage.py migrate &&
@@ -193,6 +194,7 @@ services:
   celery:
     build:
       context: ./backend
+    image: pneumaticworkflow/pneumatic-celery:${TAG:-src}
     container_name: pneumatic-celery
     environment:
       BACKEND_URL: ${BACKEND_URL:-http://localhost:8001}
@@ -312,6 +314,7 @@ services:
   celery-beat:
     build:
       context: ./backend
+    image: pneumaticworkflow/pneumatic-celery-beat:${TAG:-src}
     container_name: pneumatic-celery-beat
     environment:
       BACKEND_URL: ${BACKEND_URL:-http://localhost:8001}
@@ -430,6 +433,7 @@ services:
   frontend:
     build:
       context: ./frontend
+    image: pneumaticworkflow/pneumatic-frontend:${TAG:-src}
     container_name: pneumatic-frontend
     environment:
       BACKEND_PRIVATE_URL: ${BACKEND_PRIVATE_URL:-http://pneumatic-nginx/}
@@ -503,6 +507,7 @@ services:
   file-service:
     build:
       context: ./storage
+    image: pneumaticworkflow/file-service:${TAG:-src}
     container_name: pneumatic-file-service
     environment:
       BACKEND_PRIVATE_URL: ${BACKEND_PRIVATE_URL:-http://pneumatic-nginx/}

--- a/scripts/create_backup.sh
+++ b/scripts/create_backup.sh
@@ -1,2 +1,2 @@
 # Create a new backup of the postgresql pneumatic database in the "postgres/backups" directory
-docker exec -it pneumatic-postgres sh -c "pg_dump -U postgres_user postgres_db > /backups/pneumatic-backup-$(date +%Y-%m-%d[%Hh:%Mm]%ZTZ).sql"
+docker exec -it pneumatic-postgres sh -c "pg_dump -U postgres_user postgres_db > /backups/pneumatic-postgres-$(date +%Y-%m-%d).sql"

--- a/start.sh
+++ b/start.sh
@@ -172,7 +172,7 @@ if [ ! -f ".env" ]; then
     FORM_DOMAIN=""
     if [ "$ADDRESS_IS_DOMAIN" = true ]; then
         echo ""
-        read -rp "Use default address for Sharable kickoff forms ($SERVER_ADDRESS/forms)? [Y/n]: " forms_choice
+        read -rp "Use default address for Sharable kickoff forms ($SERVER_ADDRESS/forms)? [y/n]: " forms_choice
         forms_choice=$(strip_invisible "$forms_choice")
         case "$forms_choice" in
             [Nn]|[Nn][Oo])


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> DevOps and setup-script tweaks only; no application runtime or security logic changes.
> 
> **Overview**
> **Source compose** now tags locally built services with named images (`pneumaticworkflow/pneumatic-backend`, `pneumatic-celery`, `pneumatic-celery-beat`, `pneumatic-frontend`, `file-service`) using **`${TAG:-src}`**, so you can pin or override image versions when running from sources (aligned with how `start.sh` passes `TAG` for stable/latest).
> 
> **`scripts/create_backup.sh`** writes dumps as `pneumatic-postgres-YYYY-MM-DD.sql` instead of the longer timestamped `pneumatic-backup-...` filename.
> 
> **`start.sh`** updates the sharable kickoff forms prompt from `[Y/n]` to `[y/n]` for consistency with other yes/no prompts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f556e6ad3eb5bac3d5b25a0e6b790204ec433ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add explicit versioned image names to local Docker Compose services
> - Adds `image` fields to backend, celery, celery-beat, frontend, and file-service in [docker-compose.src.yml](https://github.com/pneumaticapp/pneumaticworkflow/pull/343/files#diff-f11168a69acca5524406d63f8be3493d9ca6df2b7f36502a45741fa7eee098aa), using `${TAG:-src}` so built images can be tagged and versioned without losing build context.
> - Simplifies the backup filename in [scripts/create_backup.sh](https://github.com/pneumaticapp/pneumaticworkflow/pull/343/files#diff-bd3b494336d20f54937b905eaedf456227783e7dc40a710e1fe4282ef779230d) from a timestamp-and-timezone pattern to `pneumatic-postgres-YYYY-MM-DD.sql`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 2f556e6. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->