### PR TITLE
48741 resolve linting issues and format localization

### DIFF
--- a/frontend/src/public/components/Fieldsets/FieldsetDetails/FieldsetDetails.tsx
+++ b/frontend/src/public/components/Fieldsets/FieldsetDetails/FieldsetDetails.tsx
@@ -3,7 +3,6 @@ import { useEffect, useState, useMemo, useCallback, useRef, ChangeEvent } from '
 import classnames from 'classnames';
 import { useIntl } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
-import classNames from 'classnames';
 
 import TextareaAutosize from 'react-textarea-autosize';
 
@@ -59,16 +58,16 @@ import {
   FIELDSET_RULE_VALUE_PLACEHOLDER_BY_TYPE,
 } from '../constants';
 
+import { useCheckDevice } from '../../../hooks/useCheckDevice';
+
+import { TFieldsetDetailsProps, TDetailFieldsetState, TDetailFieldsetChanges } from './types';
+import styles from './FieldsetDetails.css';
+
 const READONLY_FIELD_ICONS: Partial<Record<EExtraFieldType, React.FC<React.SVGAttributes<SVGElement>>>> = {
   [EExtraFieldType.User]: ArrowDropdownIcon,
   [EExtraFieldType.Date]: DateIcon,
   [EExtraFieldType.Url]: LinkIcon,
 };
-
-import { useCheckDevice } from '../../../hooks/useCheckDevice';
-
-import { TFieldsetDetailsProps, TDetailFieldsetState, TDetailFieldsetChanges } from './types';
-import styles from './FieldsetDetails.css';
 
 const EMPTY_DETAIL_FIELDSET: TDetailFieldsetState = {
   title: '',
@@ -294,7 +293,9 @@ const FieldsetDetails = ({
   }
 
   const isLinked = fieldset.usage.length > 0;
-  const readOnlyBadge = isLinked ? <span className={styles['readonly-badge']}>{formatMessage({ id: 'fieldsets.readonly-badge' })}</span> : null;
+  const readOnlyBadge = isLinked ? (
+    <span className={styles['readonly-badge']}>{formatMessage({ id: 'fieldsets.readonly-badge' })}</span>
+  ) : null;
 
   const handleCloneFieldset = () => {
     if (isChanged) {
@@ -408,7 +409,7 @@ const FieldsetDetails = ({
               <input
                 id="fieldset-title"
                 type="text"
-                className={classNames(
+                className={classnames(
                   styles['settings-title'],
                   Boolean(validateFieldsetTitle(detailFieldset.title)) && styles['settings-title_error'],
                 )}
@@ -452,8 +453,15 @@ const FieldsetDetails = ({
 
           <div className={styles['settings-field']}>
             <span
+              role="button"
+              tabIndex={0}
               className={styles['settings-label']}
               onClick={() => labelPositionRef.current?.querySelector<HTMLButtonElement>('button')?.focus()}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  labelPositionRef.current?.querySelector<HTMLButtonElement>('button')?.focus();
+                }
+              }}
             >
               {formatMessage({ id: 'fieldsets.settings.label-position' })}
             </span>

--- a/frontend/src/public/lang/locales/ru_RU.ts
+++ b/frontend/src/public/lang/locales/ru_RU.ts
@@ -1467,7 +1467,8 @@ export const ruMessages = {
   'template.fieldset-picker.empty': 'Нет доступных наборов полей. Сначала создайте один.',
   'fieldset.group-title': 'Набор полей: {name}',
   'fieldset.validation-error.sum-max': 'Сумма числовых полей в «{name}» не должна превышать {value}.',
-  'fieldsets.usage.linked': 'Используется в {count} {count, plural, one {шаблоне} few {шаблонах} other {шаблонах}}. Редактирование заблокировано.',
+  'fieldsets.usage.linked':
+    'Используется в {count} {count, plural, one {шаблоне} few {шаблонах} other {шаблонах}}. Редактирование заблокировано.',
   'fieldsets.usage.not-linked': 'Не используется ни в одном шаблоне',
   'fieldsets.readonly-badge': 'Только чтение',
   'fieldsets.usage.show': 'Показать',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only lint, formatting, and minor accessibility; no business logic or API changes.
> 
> **Overview**
> **Fieldset details** cleanup: drops the duplicate `classnames` import, reorders imports, uses `classnames` consistently on the title input, and reformats the read-only badge JSX.
> 
> The **label position** control label is now keyboard-accessible (`role="button"`, `tabIndex`, Enter/Space focuses the `FilterSelect` toggle), matching typical a11y lint rules.
> 
> **Russian locale** only reformats the `fieldsets.usage.linked` string across lines; no copy change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4f3e2e3b0e89a19df8a0719b589ac04aef47955. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add keyboard accessibility to the 'Label position' control in `FieldsetDetails`
> - Adds `role="button"`, `tabIndex=0`, and an `onKeyDown` handler to the label position text so it is keyboard-focusable and activates on Enter/Space, moving focus to the underlying control.
> - Removes a duplicate `classnames` import alias and reformats the `readOnlyBadge` conditional into a multiline expression without logic changes.
> - Reformats the `fieldsets.usage.linked` message in [ru_RU.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/345/files#diff-3313e21aeb4edafb8e8b0e64a8103f6b264a45622abee8c7c10a89bb7539ee40) across two lines without changing content.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b4f3e2e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->