### PR TITLE
docker: change filesesrvice docker image name

### DIFF
--- a/.github/workflows/file-service-latest-push.yml
+++ b/.github/workflows/file-service-latest-push.yml
@@ -30,7 +30,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: "pneumaticworkflow/file-service"
+          images: "pneumaticworkflow/pneumatic-file-service"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -41,12 +41,12 @@ jobs:
           driver: cloud
           endpoint: "pneumaticworkflow/pneumatic-release-builder"
 
-      - name: Build and push pneumaticworkflow/file-service
+      - name: Build and push pneumaticworkflow/pneumatic-file-service
         uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
           context: storage
           file: "storage/Dockerfile"
           push: true
-          tags: "pneumaticworkflow/file-service:latest"
+          tags: "pneumaticworkflow/pneumatic-file-service:latest"
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/new-tag-push.yml
+++ b/.github/workflows/new-tag-push.yml
@@ -24,7 +24,7 @@ jobs:
           - image: pneumaticworkflow/pneumatic-celery-beat
             dockerfile: backend/Dockerfile
             build_context: backend
-          - image: pneumaticworkflow/file-service
+          - image: pneumaticworkflow/pneumatic-file-service
             dockerfile: storage/Dockerfile
             build_context: storage
     permissions:

--- a/docker-compose.src.yml
+++ b/docker-compose.src.yml
@@ -507,7 +507,7 @@ services:
   file-service:
     build:
       context: ./storage
-    image: pneumaticworkflow/file-service:${TAG:-src}
+    image: pneumaticworkflow/pneumatic-file-service:${TAG:-src}
     container_name: pneumatic-file-service
     environment:
       BACKEND_PRIVATE_URL: ${BACKEND_PRIVATE_URL:-http://pneumatic-nginx/}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -504,7 +504,7 @@ services:
   file-service:
     build:
       context: ./storage
-    image: pneumaticworkflow/file-service:${TAG:-stable}
+    image: pneumaticworkflow/pneumatic-file-service:${TAG:-stable}
     container_name: pneumatic-file-service
     environment:
       DEBUG: ${FILE_DEBUG:-false}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 286f251ccb4259b8819fa508e265021a01bbfbdb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename file service Docker image to `pneumaticworkflow/pneumatic-file-service`
> Updates all references to the file service Docker image from `pneumaticworkflow/file-service` to `pneumaticworkflow/pneumatic-file-service` across CI workflows and Compose files.
>
> - [file-service-latest-push.yml](.github/workflows/file-service-latest-push.yml) and [new-tag-push.yml](.github/workflows/new-tag-push.yml) now build and push to the new repository name.
> - [docker-compose.yml](docker-compose.yml) and [docker-compose.src.yml](docker-compose.src.yml) pull from the renamed image on deploy.
> - Risk: any external system or deployment pulling `pneumaticworkflow/file-service` will no longer receive updates.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 286f251.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->