### PR TITLE
49166 frontend [ templates ] keep check-if value inline

### DIFF
--- a/frontend/src/public/components/Field/Field.css
+++ b/frontend/src/public/components/Field/Field.css
@@ -16,6 +16,23 @@
   padding-right: 5rem !important;
 }
 
+.input_hidden {
+  display: none;
+}
+
+.input_inline {
+  display: inline;
+}
+
+.input_block {
+  display: block;
+}
+
+.input_condition-value {
+  width: 100%;
+  padding: 0.8rem;
+}
+
 .icon-container {
   position: relative;
 }

--- a/frontend/src/public/components/Field/FieldInput/FieldInput.tsx
+++ b/frontend/src/public/components/Field/FieldInput/FieldInput.tsx
@@ -34,6 +34,13 @@ export function FieldInput({
     Object.entries(rest).filter(([key]) => key !== 'defaultValue'),
   ) as TNumericFormatRest;
 
+  const getInputClassName = (visibleDisplayClassName: string) =>
+    classnames(
+      inputClassName,
+      shouldReplaceWithLabel ? styles['input_hidden'] : visibleDisplayClassName,
+      isFromConditionValueField && styles['input_condition-value'],
+    );
+
   const input = isNumericField ? (
     <NumericFormat
       value={valueString}
@@ -49,11 +56,7 @@ export function FieldInput({
       getInputRef={innerRef}
       disabled={disabled}
       placeholder={placeholder}
-      className={inputClassName}
-      style={{
-        display: shouldReplaceWithLabel ? 'none' : 'block',
-        ...(isFromConditionValueField ? { width: '100%', padding: '0.8rem' } : {}),
-      }}
+      className={getInputClassName(styles['input_block'])}
       onBlur={onBlur}
       onKeyDown={onKeyDown}
       onPaste={onPaste}
@@ -64,16 +67,12 @@ export function FieldInput({
     <input
       ref={innerRef}
       type={type}
-      style={{
-        display: shouldReplaceWithLabel ? 'none' : 'inline',
-        ...(isFromConditionValueField ? { width: '100%', padding: '0.8rem' } : {}),
-      }}
       value={valueString}
       onChange={onChange}
       onBlur={onBlur}
       onKeyDown={onKeyDown}
       placeholder={placeholder}
-      className={inputClassName}
+      className={getInputClassName(styles['input_inline'])}
       disabled={disabled}
       onPaste={onPaste}
       {...rest}

--- a/frontend/src/public/components/Field/FieldInput/FieldInput.tsx
+++ b/frontend/src/public/components/Field/FieldInput/FieldInput.tsx
@@ -64,7 +64,10 @@ export function FieldInput({
     <input
       ref={innerRef}
       type={type}
-      style={{ display: shouldReplaceWithLabel ? 'none' : 'inline' }}
+      style={{
+        display: shouldReplaceWithLabel ? 'none' : 'inline',
+        ...(isFromConditionValueField ? { width: '100%', padding: '0.8rem' } : {}),
+      }}
       value={valueString}
       onChange={onChange}
       onBlur={onBlur}

--- a/frontend/src/public/components/Field/__tests__/Field.test.tsx
+++ b/frontend/src/public/components/Field/__tests__/Field.test.tsx
@@ -4,6 +4,8 @@ import userEvent from '@testing-library/user-event';
 import { Field } from '../Field';
 import { EFieldTagName } from '../types';
 
+import styles from '../Field.css';
+
 jest.mock('../../RichEditor', () => ({
   RichEditor: ({ placeholder }: { placeholder?: string }) => (
     <div data-testid="rich-editor">{placeholder}</div>
@@ -70,7 +72,7 @@ describe('Field component', () => {
         />,
       );
 
-      expect(screen.getByRole('textbox')).toHaveStyle({ width: '100%', padding: '0.8rem' });
+      expect(screen.getByRole('textbox')).toHaveClass(styles['input_condition-value']);
     });
   });
 

--- a/frontend/src/public/components/Field/__tests__/Field.test.tsx
+++ b/frontend/src/public/components/Field/__tests__/Field.test.tsx
@@ -60,6 +60,18 @@ describe('Field component', () => {
       const input = screen.getByRole('textbox');
       expect(input).toBeDisabled();
     });
+
+    it('fills its condition value container and preserves the inner spacing', () => {
+      render(
+        <Field
+          value=""
+          isFromConditionValueField
+          onChange={jest.fn()}
+        />,
+      );
+
+      expect(screen.getByRole('textbox')).toHaveStyle({ width: '100%', padding: '0.8rem' });
+    });
   });
 
   describe('Textarea rendering mode', () => {

--- a/frontend/src/public/components/TemplateEdit/TaskForm/Conditions/ConditionValueField/ConditionValueField.tsx
+++ b/frontend/src/public/components/TemplateEdit/TaskForm/Conditions/ConditionValueField/ConditionValueField.tsx
@@ -214,10 +214,7 @@ export function ConditionValueField({
   if (!conditionValueField) return null;
 
   return (
-    <div
-      className={classnames(styles['condition-rule__setting'], styles['condition-rule__value'])}
-      style={{ minWidth: 0 }}
-    >
+    <div className={classnames(styles['condition-rule__setting'], styles['condition-rule__value'])}>
       {conditionValueField}
     </div>
   );

--- a/frontend/src/public/components/TemplateEdit/TaskForm/Conditions/ConditionValueField/ConditionValueField.tsx
+++ b/frontend/src/public/components/TemplateEdit/TaskForm/Conditions/ConditionValueField/ConditionValueField.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable indent */
 import React, { useState, ReactNode, ChangeEvent } from 'react';
 import { useSelector } from 'react-redux';
 import classnames from 'classnames';
@@ -75,7 +74,8 @@ export function ConditionValueField({
         onChange={(e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
           changeRuleValue(e.target.value);
         }}
-        {...(isNumberType && { isNumericField, isFromConditionValueField: true })}
+        isFromConditionValueField
+        {...(isNumberType && { isNumericField })}
       />
     );
   }
@@ -119,10 +119,10 @@ export function ConditionValueField({
         formatOptionLabel={(option: IDropdownSelection, { context }) =>
           context === 'menu'
             ? getFormattedDropdownOption({
-                label: option.label,
-                isSelected: option.value === rule.value,
-                isTooltip: true,
-              })
+              label: option.label,
+              isSelected: option.value === rule.value,
+              isTooltip: true,
+            })
             : option.label
         }
         classNames={{ menu: () => styles['condition__value-field-select-menu'] }}
@@ -170,10 +170,10 @@ export function ConditionValueField({
         formatOptionLabel={(option: IDropdownUser, { context }) =>
           context === 'menu'
             ? getFormattedDropdownOption({
-                label: option.label,
-                isSelected: option.id === rule.value && option.entityType === rule.fieldType,
-                isTooltip: true,
-              })
+              label: option.label,
+              isSelected: option.id === rule.value && option.entityType === rule.fieldType,
+              isTooltip: true,
+            })
             : option.label
         }
         classNames={{ menu: () => styles['condition__value-field-select-menu'] }}
@@ -214,7 +214,10 @@ export function ConditionValueField({
   if (!conditionValueField) return null;
 
   return (
-    <div className={classnames(styles['condition-rule__setting'], styles['condition-rule__value'])}>
+    <div
+      className={classnames(styles['condition-rule__setting'], styles['condition-rule__value'])}
+      style={{ minWidth: 0 }}
+    >
       {conditionValueField}
     </div>
   );

--- a/frontend/src/public/components/TemplateEdit/TaskForm/Conditions/Conditions.css
+++ b/frontend/src/public/components/TemplateEdit/TaskForm/Conditions/Conditions.css
@@ -124,6 +124,7 @@
 .condition-rule__value {
   flex-basis: 0;
   flex-grow: 1;
+  min-width: 0;
 
   .condition__value-field-select-menu {
     width: 189.5%;


### PR DESCRIPTION
### 1. Release notes

Fixed the layout of the value field in a task's **Check If** condition: for Text, Long Text, URL and Number variables the value input now stays on the same line as the variable and operator dropdowns and fills the remaining width, instead of wrapping onto a second line.

### 2. Context

**Issue:** 49166 — the value field of a condition rule does not stay inline with the rest of the rule.

**App Location:** Templates → open a template → a task → **Check If** block → a condition rule → the third control (`value` placeholder). Reached through `TemplateEdit/TaskForm/Conditions/Predicate.tsx` → `ConditionValueField`. Affects the variable types routed to `renderTextField`: `String`, `Text`, `Url` and `Number`.

**Related Changes:** none. The shared `Field` / `FieldInput` components are touched, so every consumer of `Field` with `tagName=Input` is in the blast radius even though only the condition value field changes visually.

### 3. Solution & Implementation Details

**Root cause.** A condition rule is laid out by `.condition-rule__settings-inner` (`Conditions.css:37-44`) as `display: flex; flex-wrap: wrap`, with three items: `.condition-rule__field` (`width: 49.1%`), `.condition-rule__operator` (`width: 24%`) and `.condition-rule__value` (`flex-basis: 0; flex-grow: 1`).

Two things pushed the value field onto its own line:

1. `.condition-rule__value` had no `min-width`, so its automatic minimum size stayed at `min-content`. The item wraps a bare `<input>`, whose intrinsic width is the browser default (`size=20`, roughly 17rem), so the flex item could not shrink below that. Once the container got narrow enough, `49.1% + 24% + ~17rem` exceeded the line and `flex-wrap: wrap` moved the value field down.
2. The inner `<input>` never filled the item it was given. `.text-field` (`Conditions.css:162-168`) sets `width: 100%` on the wrapper `<div>` and a `4rem` height on the input, but no width or padding on the input itself. `FieldInput` did apply `width: 100%; padding: 0.8rem` for `isFromConditionValueField`, but only on the `NumericFormat` branch — the plain `<input>` branch ignored the flag entirely. On top of that, `ConditionValueField` passed `isFromConditionValueField` only inside `{...(isNumberType && { isNumericField, isFromConditionValueField: true })}`, so text rules never received the flag at all.

**Changes.**

1. `Conditions.css` — `.condition-rule__value` gains `min-width: 0`, letting the flex item shrink below the input's intrinsic width so it keeps sharing the line.
2. `ConditionValueField.tsx` — `isFromConditionValueField` is now passed unconditionally from `renderTextField`; only `isNumericField` stays behind the `isNumberType` guard. The rule container no longer carries an inline `style`.
3. `FieldInput.tsx` — the plain `<input>` branch now honours `isFromConditionValueField` the same way the `NumericFormat` branch always did, so a text condition value fills its container with the same `0.8rem` inner spacing as a numeric one.
4. `FieldInput.tsx` / `Field.css` — per review feedback, both `style={{ ... }}` props were removed from `FieldInput`. The optional styling is expressed as CSS modifier classes composed by one helper:

   ```tsx
   const getInputClassName = (visibleDisplayClassName: string) =>
     classnames(
       inputClassName,
       shouldReplaceWithLabel ? styles['input_hidden'] : visibleDisplayClassName,
       isFromConditionValueField && styles['input_condition-value'],
     );
   ```

   `NumericFormat` passes `styles['input_block']` and the plain `<input>` passes `styles['input_inline']` — the only difference the two branches ever had. New classes in `Field.css`: `.input_hidden`, `.input_inline`, `.input_block`, `.input_condition-value`. None of them needs `!important`: the only global rule for the element is `input { border: none; outline: none; background: transparent }` (`assets/css/sass/_gogo.style.scss:176-180`), which a class already outranks, and the one descendant selector in play, `.text-field input`, sets `height` only.
5. `ConditionValueField.tsx` — the file-level `/* eslint-disable indent */` was dropped and the two `formatOptionLabel` ternaries reindented to satisfy the rule, so the file is no longer exempt from the shared indentation lint.

`Predicate.tsx`, the operator/variable dropdowns, and the dropdown/user/date branches of `ConditionValueField` are unchanged.

### 4. What to Test

#### 4.1 Preconditions

- A user on a plan where **Check If** conditions are enabled (Premium; otherwise the block renders behind the paywall overlay).
- A template with a kick-off or earlier task exposing at least four variables — one Text, one Long Text, one URL and one Number.
- Test at a desktop width > 1340 px, between 1150 px and 1340 px, and below 1150 px, where the rule layout changes breakpoint.

#### 4.2 Positive Scenarios / Testing Report

| # | Steps | Expected result | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
|---|---|---|---|---|---|---|
| 1 | Task → **Check If** → add a rule → pick a Text variable → operator `Contains` | The value input sits on the same line as the variable and operator dropdowns and fills the remaining width | [ ] | [ ] | [ ] | [ ] |
| 2 | Same with a Long Text variable | Same — inline, full remaining width | [ ] | [ ] | [ ] | [ ] |
| 3 | Same with a URL variable | Same — inline, full remaining width | [ ] | [ ] | [ ] | [ ] |
| 4 | Same with a Number variable, operator `More than` | Numeric input keeps its existing appearance; no regression from the class refactor | [ ] | [ ] | [ ] | [ ] |
| 5 | Type a value into each of the four rules and save the template | Value persists, reopening the template shows it in an inline field | [ ] | [ ] | [ ] | [ ] |
| 6 | Shrink the window across the 1340 px and 1150 px breakpoints | Below 1150 px the variable field takes the full line and operator + value share the next one; the value field never wraps alone under the operator | [ ] | [ ] | [ ] | [ ] |
| 7 | Add several rules to one condition, and several conditions to one task | Every rule renders with the same inline layout | [ ] | [ ] | [ ] | [ ] |

#### 4.3 Negative Scenarios & Edge Cases

| # | Steps | Expected result | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
|---|---|---|---|---|---|---|
| 1 | Pick operator `Exists` / `Doesn't exist` | No value field is rendered at all (`OPERATORS_WITHOUT_VALUE`), layout unaffected | [ ] | [ ] | [ ] | [ ] |
| 2 | Pick a Checkbox / Radio / Creatable / User / Date variable | Dropdown and date branches render as before — untouched by this change | [ ] | [ ] | [ ] | [ ] |
| 3 | Paste a very long single-word value (no spaces) into a text rule | The input scrolls its content; the rule does not widen or push the remove button out of the row | [ ] | [ ] | [ ] | [ ] |
| 4 | Open the same template on a non-Premium plan | The paywall overlay covers the rule; the layout underneath is still inline | [ ] | [ ] | [ ] | [ ] |
| 5 | Any other `Field` with `tagName=Input` — Kick-off form fields, Profile, Fieldsets, workflow run forms | Unchanged: same visibility and inline/block behaviour as before the class refactor | [ ] | [ ] | [ ] | [ ] |
| 6 | A `Field` rendered with `shouldReplaceWithLabel` (disabled title/description inputs) | The input is hidden and the label replacement is shown, exactly as before | [ ] | [ ] | [ ] | [ ] |

#### 4.4 Verification Points

- In DevTools, the condition value `<input>` carries the `input_condition-value` and `input_inline` classes and has **no** `style` attribute.
- The `.condition-rule__value` wrapper has `min-width: 0` in the computed styles and **no** inline `style` attribute.
- The value input's computed `width` equals its wrapper's content width, and its computed `padding` is `0.8rem`.
- With `shouldReplaceWithLabel`, the input's computed `display` is `none` via `input_hidden`, not via an inline style.

#### 4.5 API Verification

Not applicable — no API, payload, or Redux state changes. Condition values are still written through the existing `changeRuleValue` handler.

#### 4.6 What Was NOT Tested

- No manual browser verification was performed. Every scenario in 4.2 and 4.3 is unchecked; the root cause and the fix were derived from the CSS/flex layout chain and covered by unit tests only.
- No cross-browser or mobile verification (Safari, mobile Safari, mobile Chrome).
- No visual regression check on the other `Field` consumers affected by the `FieldInput` class refactor — the change is behaviour-preserving by construction, but it was not exercised in a browser.
- No responsive check at the 1340 px / 1150 px breakpoints; jsdom does not evaluate media queries.

### 5. Affected Areas

| Area | Impact | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
|---|---|---|---|---|---|
| Template editor → task → Check If → value field (Text / Long Text / URL) | Fixed: field stays inline and fills the row | [ ] | [ ] | [ ] | [ ] |
| Template editor → task → Check If → value field (Number) | No visual change; inline styles replaced by equivalent classes | [ ] | [ ] | [ ] | [ ] |
| Check If → dropdown / user / date value fields | Unchanged | [ ] | [ ] | [ ] | [ ] |
| Shared `Field` with `tagName=Input`, all consumers | Refactor only: `display` and condition-field styling moved from `style` to `Field.css` classes | [ ] | [ ] | [ ] | [ ] |
| `ConditionValueField.tsx` lint exemption | `/* eslint-disable indent */` removed; file now lints under the shared rule | [ ] | [ ] | [ ] | [ ] |

### 6. Unit Tests

- **Updated** `src/public/components/Field/__tests__/Field.test.tsx` — one new case, `fills its condition value container and preserves the inner spacing`, renders `<Field isFromConditionValueField />` and asserts the input carries `styles['input_condition-value']`. It was added in the first commit as a `toHaveStyle({ width: '100%', padding: '0.8rem' })` assertion and rewritten to a class assertion in the second, since the declarations now live in the stylesheet. `jest-css-modules-transform` produces real class names, so the assertion is meaningful rather than a mock-identity check.
- No new test for `min-width: 0` on `.condition-rule__value`: jsdom does not compute layout, so flex wrapping cannot be asserted. `ConditionValueField.test.tsx` covers only the user/group selection logic and does not render the component.

Full suite: **244 suites / 1661 tests passing**. `npx tsc --noEmit -p tsconfig.json` reports no errors under `src/` (the remaining output is pre-existing `node_modules` type conflicts on `@types/react` / `@types/enzyme` / `react-datepicker` / `webpack`). ESLint clean on `components/Field` and `components/TemplateEdit/TaskForm/Conditions`; Stylelint clean on `Field.css` and `Conditions.css`. The `A worker process has failed to exit gracefully` warning at the end of the run is pre-existing and unrelated to these changes.

### 7. Commits

- `30c908053` — `49166 fix(templates): keep check-if value inline`
- `3393e87be` — `49166 refactor(templates): replace inline field styles with CSS classes`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI/CSS changes in the template editor and shared Field input; no API or condition payload changes.
> 
> **Overview**
> Fixes **Check If** condition value layout in the Template Editor so the field, operator, and value stay on one row and text values get the same full-width padding as numeric ones.
> 
> **`ConditionValueField`** now always passes `isFromConditionValueField` to `Field` for text-based values (not only when `isNumericField` is set). **`FieldInput`** stops using inline `display` and condition sizing; it applies new **`Field.css`** classes (`input_hidden`, `input_inline`, `input_block`, `input_condition-value`) via a shared `getInputClassName` helper. **`Conditions.css`** adds `min-width: 0` on `.condition-rule__value` so the value column can shrink inside the flex row.
> 
> A **`Field`** unit test asserts the condition-value class on the textbox. Minor indentation cleanup in **`ConditionValueField`** (removed legacy eslint indent disable).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3393e87bef19e5f07d6461596c452ca1acb471cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> <!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
> <!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Apply inline full-width styling to condition value field inputs in templates
> - `ConditionValueField` now always passes `isFromConditionValueField` to `Field` in `renderTextField`, instead of only when `isNumberType` is true
> - `FieldInput` applies `width: 100%` and `padding: 0.8rem` inline styles when `isFromConditionValueField` is true
> - The outer container `div` in [ConditionValueField.tsx](https://github.com/pneumaticapp/pneumaticworkflow/pull/348/files#diff-d4975342abadc4c28b903a48557028977f07bdff354bce8e118d1f61fe1f4fe0) gets `minWidth: 0` so it can shrink within flex layouts
> - Adds a test asserting the textbox renders with the expected width and padding
> - Behavioral Change: all text-based condition value fields now render full-width with padding, not just numeric ones
> >
> <!-- Macroscope's changelog starts here -->
> #### Changes since #348 opened
>
> - Replaced inline style-based visibility and layout control in `FieldInput` component with CSS class-based approach [3393e87]
> - Moved inline `min-width: 0` style from `ConditionValueField` component wrapper to CSS class definition [3393e87]
> - Updated `Field` component test assertions to verify CSS class application instead of inline styles [3393e87]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
> >
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 30c9080.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->