### PR TITLE
 49254 frontend [ UI ] Align the “Send” button in the comments vertically

### DIFF
--- a/frontend/src/public/components/RichEditor/components/EditorToolbar/EditorToolbar.css
+++ b/frontend/src/public/components/RichEditor/components/EditorToolbar/EditorToolbar.css
@@ -3,7 +3,6 @@
 }
 
 .toolbar {
-  margin-top: 1rem;
   display: flex;
   align-items: center;
   gap: 0.8rem;

--- a/frontend/src/public/components/RichEditor/components/LexicalEditorContent/LexicalEditorContent.css
+++ b/frontend/src/public/components/RichEditor/components/LexicalEditorContent/LexicalEditorContent.css
@@ -22,6 +22,7 @@
 }
 
 .controls-wrapper {
+  margin-top: 1rem;
   display: flex;
   align-items: center;
   justify-content: space-between;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CSS-only layout adjustment in the RichEditor comment UI with no logic or data changes.
> 
> **Overview**
> Moves the **1rem top spacing** from the rich-editor **toolbar** (`EditorToolbar.css` `.toolbar`) to the parent **controls row** (`LexicalEditorContent.css` `.controls-wrapper`).
> 
> That row holds both the formatting toolbar and **EditorControls** (e.g. Send), so spacing is applied to the whole bottom control strip instead of only the toolbar—matching the PR goal of **vertical alignment** for the Send button in comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 347a02eea1ada7175ecedc12df95a8770075ed78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move `margin-top` from `.toolbar` to `.controls-wrapper` in RichEditor
> Shifts the `1rem` top margin from the `.toolbar` selector in [EditorToolbar.css](https://github.com/pneumaticapp/pneumaticworkflow/pull/351/files#diff-ad24dff227d0302db533eec881d4bb2cf77738e322951312c118b2b5aed79593) to the `.controls-wrapper` selector in [LexicalEditorContent.css](https://github.com/pneumaticapp/pneumaticworkflow/pull/351/files#diff-d8a268dff8834c0ad586bcfe07f957ff0f138b203f76169c58db6eb95aea7b12). This aligns the “Send” button vertically within the comments editor.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 347a02e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->