### PR TITLE
39477 frontend [ integrations ] Fix scroll hash targets inside the app scroll container

### DIFF
--- a/frontend/src/public/hooks/__tests__/useHashLink.test.tsx
+++ b/frontend/src/public/hooks/__tests__/useHashLink.test.tsx
@@ -91,6 +91,36 @@ describe('useHashLink', () => {
     expect(scrollToElementWhenStableMock).toHaveBeenCalledTimes(2);
   });
 
+  it('cancels the pending scroll when navigating to a hash it does not own', () => {
+    render(<Probe handleApi={jest.fn()} />);
+    history.push('/templates/1#api');
+
+    history.push('/templates/1#zap-manager');
+
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(scrollToElementWhenStableMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels the pending scroll when navigating away from the hash entirely', () => {
+    render(<Probe handleApi={jest.fn()} />);
+    history.push('/templates/1#api');
+
+    history.push('/templates/1');
+
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(scrollToElementWhenStableMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not re-cancel an already superseded scroll', () => {
+    render(<Probe handleApi={jest.fn()} />);
+    history.push('/templates/1#api');
+
+    history.push('/templates/1');
+    history.push('/templates/1?a=1');
+
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
   it('cancels the pending scroll and stops listening on unmount', () => {
     history.replace('/templates/1#api');
     const { unmount } = render(<Probe handleApi={jest.fn()} />);

--- a/frontend/src/public/hooks/__tests__/useHashLink.test.tsx
+++ b/frontend/src/public/hooks/__tests__/useHashLink.test.tsx
@@ -1,0 +1,117 @@
+import * as React from 'react';
+import { render, cleanup } from '@testing-library/react';
+
+import { useHashLink } from '../useHashLink';
+import { scrollToElementWhenStable } from '../../utils/scroll';
+import { history } from '../../utils/history';
+
+jest.mock('../../utils/scroll', () => ({
+  scrollToElementWhenStable: jest.fn(),
+}));
+
+const scrollToElementWhenStableMock = scrollToElementWhenStable as jest.Mock;
+
+type TProbeProps = {
+  handleApi?(): void;
+  handleShare?(): void;
+};
+
+function Probe({ handleApi, handleShare }: TProbeProps) {
+  const containerRef = React.useRef<HTMLDivElement | null>(null);
+
+  useHashLink([
+    { element: containerRef, hash: 'api', handle: handleApi },
+    { element: containerRef, hash: 'share', handle: handleShare },
+  ]);
+
+  return <div ref={containerRef} data-testid="section" />;
+}
+
+describe('useHashLink', () => {
+  let cancel: jest.Mock;
+
+  beforeEach(() => {
+    cancel = jest.fn();
+    scrollToElementWhenStableMock.mockReset();
+    scrollToElementWhenStableMock.mockReturnValue(cancel);
+    history.replace('/templates/1');
+  });
+
+  afterEach(cleanup);
+
+  it('expands the matching section and scrolls to it on mount', () => {
+    history.replace('/templates/1#api');
+    const handleApi = jest.fn();
+
+    const { getByTestId } = render(<Probe handleApi={handleApi} />);
+
+    expect(handleApi).toHaveBeenCalledTimes(1);
+    expect(scrollToElementWhenStableMock).toHaveBeenCalledWith(getByTestId('section'));
+  });
+
+  it('does nothing without a hash', () => {
+    const handleApi = jest.fn();
+
+    render(<Probe handleApi={handleApi} />);
+
+    expect(handleApi).not.toHaveBeenCalled();
+    expect(scrollToElementWhenStableMock).not.toHaveBeenCalled();
+  });
+
+  it('ignores a hash it does not own', () => {
+    history.replace('/templates/1#zapier');
+    const handleApi = jest.fn();
+
+    render(<Probe handleApi={handleApi} />);
+
+    expect(handleApi).not.toHaveBeenCalled();
+    expect(scrollToElementWhenStableMock).not.toHaveBeenCalled();
+  });
+
+  it('reacts to a hash pushed while the page is already open', () => {
+    const handleApi = jest.fn();
+    render(<Probe handleApi={handleApi} />);
+
+    history.push('/templates/1#api');
+
+    expect(handleApi).toHaveBeenCalledTimes(1);
+    expect(scrollToElementWhenStableMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels the pending scroll before starting a new one', () => {
+    const handleApi = jest.fn();
+    const handleShare = jest.fn();
+    render(<Probe handleApi={handleApi} handleShare={handleShare} />);
+
+    history.push('/templates/1#api');
+    history.push('/templates/1#share');
+
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(handleShare).toHaveBeenCalledTimes(1);
+    expect(scrollToElementWhenStableMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('cancels the pending scroll and stops listening on unmount', () => {
+    history.replace('/templates/1#api');
+    const { unmount } = render(<Probe handleApi={jest.fn()} />);
+
+    unmount();
+    scrollToElementWhenStableMock.mockClear();
+    history.push('/templates/1#share');
+
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(scrollToElementWhenStableMock).not.toHaveBeenCalled();
+  });
+
+  it('uses the handlers from the latest render, not the ones captured on mount', () => {
+    const firstHandle = jest.fn();
+    const secondHandle = jest.fn();
+    const { rerender } = render(<Probe handleApi={firstHandle} />);
+
+    rerender(<Probe handleApi={secondHandle} />);
+    history.push('/templates/1#api');
+
+    expect(firstHandle).not.toHaveBeenCalled();
+    expect(secondHandle).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/public/hooks/useHashLink.ts
+++ b/frontend/src/public/hooks/useHashLink.ts
@@ -16,6 +16,11 @@ export function useHashLink(settings: THashLinkHandler[]) {
 
   useEffect(() => {
     const handleHashLinkUrl = () => {
+      // any navigation supersedes a scroll that is still settling, even one that
+      // lands on a hash nobody here owns, otherwise it drags the user back later
+      cancelScrollRef.current?.();
+      cancelScrollRef.current = null;
+
       const { hash } = history.location;
       if (!hash) {
         return;
@@ -35,7 +40,6 @@ export function useHashLink(settings: THashLinkHandler[]) {
 
       // the target section is still expanding and its content is still loading,
       // so the scroll has to wait until its position stops moving
-      cancelScrollRef.current?.();
       cancelScrollRef.current = scrollToElementWhenStable(element.current);
     };
 

--- a/frontend/src/public/hooks/useHashLink.ts
+++ b/frontend/src/public/hooks/useHashLink.ts
@@ -1,39 +1,51 @@
-import { useEffect } from 'react';
-import { scrollToElement } from '../utils/helpers';
+import { MutableRefObject, useEffect, useRef } from 'react';
+import { scrollToElementWhenStable } from '../utils/scroll';
 import { history } from '../utils/history';
 
 type THashLinkHandler = {
   hash: string;
-  element: React.MutableRefObject<HTMLDivElement | null>;
+  element: MutableRefObject<HTMLDivElement | null>;
   handle?(): void;
 };
 
 export function useHashLink(settings: THashLinkHandler[]) {
+  const settingsRef = useRef(settings);
+  settingsRef.current = settings;
+
+  const cancelScrollRef = useRef<(() => void) | null>(null);
+
   useEffect(() => {
     const handleHashLinkUrl = () => {
-      const {hash} = history.location;
+      const { hash } = history.location;
       if (!hash) {
         return;
       }
 
-      const currentSetting = settings.find(
-        (setting) => `#${setting.hash}` === hash
-      );
+      const currentSetting = settingsRef.current.find((setting) => `#${setting.hash}` === hash);
       if (!currentSetting) {
         return;
       }
 
       const { element, handle } = currentSetting;
       handle?.();
-      if (element.current) {
-        scrollToElement(element.current);
+
+      if (!element.current) {
+        return;
       }
-    }
+
+      // the target section is still expanding and its content is still loading,
+      // so the scroll has to wait until its position stops moving
+      cancelScrollRef.current?.();
+      cancelScrollRef.current = scrollToElementWhenStable(element.current);
+    };
 
     handleHashLinkUrl();
 
     const unregister = history.listen(handleHashLinkUrl);
 
-    return unregister;
+    return () => {
+      cancelScrollRef.current?.();
+      unregister();
+    };
   }, []);
 }

--- a/frontend/src/public/utils/__tests__/scroll.test.ts
+++ b/frontend/src/public/utils/__tests__/scroll.test.ts
@@ -1,0 +1,318 @@
+import {
+  getNavbarOffset,
+  getScrollParent,
+  getScrollTargetTop,
+  scrollToElement,
+  scrollToElementWhenStable,
+} from '../scroll';
+
+type TRectOverrides = { top: number };
+
+const setRect = (node: HTMLElement, { top }: TRectOverrides) => {
+  node.getBoundingClientRect = jest.fn(() => ({ top } as DOMRect));
+};
+
+const setBox = (node: HTMLElement, { scrollHeight, clientHeight }: { scrollHeight: number; clientHeight: number }) => {
+  Object.defineProperty(node, 'scrollHeight', { value: scrollHeight, configurable: true });
+  Object.defineProperty(node, 'clientHeight', { value: clientHeight, configurable: true });
+};
+
+const mockOverflow = (overflowMap: Map<HTMLElement, string>) => {
+  jest
+    .spyOn(window, 'getComputedStyle')
+    .mockImplementation((node) => ({ overflowY: overflowMap.get(node as HTMLElement) || 'visible' } as CSSStyleDeclaration));
+};
+
+const setWindowWidth = (width: number) => {
+  Object.defineProperty(window, 'innerWidth', { value: width, configurable: true });
+};
+
+const buildTree = () => {
+  const container = document.createElement('div');
+  const inner = document.createElement('div');
+  const element = document.createElement('div');
+
+  container.appendChild(inner);
+  inner.appendChild(element);
+  document.body.appendChild(container);
+
+  container.scrollTo = jest.fn();
+  setBox(container, { scrollHeight: 5000, clientHeight: 800 });
+  setRect(container, { top: 0 });
+
+  return { container, inner, element };
+};
+
+describe('scroll utils', () => {
+  let frames: FrameRequestCallback[] = [];
+
+  const flushFrame = () => {
+    const pending = frames;
+    frames = [];
+    pending.forEach((frame) => frame(0));
+  };
+
+  beforeEach(() => {
+    frames = [];
+    document.body.innerHTML = '';
+    setWindowWidth(1200);
+
+    window.requestAnimationFrame = jest.fn((callback: FrameRequestCallback) => {
+      frames.push(callback);
+
+      return frames.length;
+    });
+    window.cancelAnimationFrame = jest.fn();
+    window.scrollTo = jest.fn();
+    setRect(document.body, { top: 0 });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  describe('getNavbarOffset', () => {
+    it('insets by the navbar height on desktop', () => {
+      setWindowWidth(1200);
+
+      expect(getNavbarOffset()).toBe(104);
+    });
+
+    it('does not inset on mobile, where the navbar is not sticky', () => {
+      setWindowWidth(500);
+
+      expect(getNavbarOffset()).toBe(0);
+    });
+  });
+
+  describe('getScrollParent', () => {
+    it('returns the nearest ancestor that actually scrolls', () => {
+      const { container, element } = buildTree();
+      mockOverflow(new Map([[container, 'scroll']]));
+
+      expect(getScrollParent(element)).toBe(container);
+    });
+
+    it('skips a scrollable ancestor that has nothing to scroll', () => {
+      const { container, element } = buildTree();
+      setBox(container, { scrollHeight: 800, clientHeight: 800 });
+      mockOverflow(new Map([[container, 'scroll']]));
+
+      expect(getScrollParent(element)).toBeNull();
+    });
+
+    it('skips ancestors whose overflow is toggled off', () => {
+      const { container, element } = buildTree();
+      mockOverflow(new Map([[container, 'hidden']]));
+
+      expect(getScrollParent(element)).toBeNull();
+    });
+
+    it('returns null when nothing between the element and body scrolls', () => {
+      const { element } = buildTree();
+      mockOverflow(new Map());
+
+      expect(getScrollParent(element)).toBeNull();
+    });
+  });
+
+  describe('getScrollTargetTop', () => {
+    it('offsets the element against the container scroll position', () => {
+      const { container, element } = buildTree();
+      setRect(container, { top: 100 });
+      setRect(element, { top: 900 });
+      Object.defineProperty(container, 'scrollTop', { value: 300, configurable: true });
+
+      expect(getScrollTargetTop(element, container, 104)).toBe(996);
+    });
+
+    it('ignores body padding, which the container geometry already accounts for', () => {
+      const { container, element } = buildTree();
+      document.body.style.paddingTop = '40px';
+      setRect(container, { top: 0 });
+      setRect(element, { top: 500 });
+      Object.defineProperty(container, 'scrollTop', { value: 0, configurable: true });
+
+      expect(getScrollTargetTop(element, container, 104)).toBe(396);
+    });
+
+    it('clamps to the top when the target sits above the container', () => {
+      const { container, element } = buildTree();
+      setRect(container, { top: 0 });
+      setRect(element, { top: 10 });
+      Object.defineProperty(container, 'scrollTop', { value: 0, configurable: true });
+
+      expect(getScrollTargetTop(element, container, 104)).toBe(0);
+    });
+
+    it('clamps to the maximum reachable offset for the last section on the page', () => {
+      const { container, element } = buildTree();
+      setBox(container, { scrollHeight: 1000, clientHeight: 800 });
+      setRect(container, { top: 0 });
+      setRect(element, { top: 950 });
+      Object.defineProperty(container, 'scrollTop', { value: 0, configurable: true });
+
+      expect(getScrollTargetTop(element, container, 104)).toBe(200);
+    });
+  });
+
+  describe('scrollToElement', () => {
+    it('scrolls the container rather than the window', () => {
+      const { container, element } = buildTree();
+      mockOverflow(new Map([[container, 'scroll']]));
+      setRect(container, { top: 0 });
+      setRect(element, { top: 904 });
+      Object.defineProperty(container, 'scrollTop', { value: 0, configurable: true });
+
+      scrollToElement(element);
+      flushFrame();
+
+      expect(container.scrollTo).toHaveBeenCalledWith({ top: 800, left: 0, behavior: 'smooth' });
+      expect(window.scrollTo).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the window when no ancestor scrolls', () => {
+      const { element } = buildTree();
+      mockOverflow(new Map());
+      setRect(element, { top: 604 });
+      Object.defineProperty(document.documentElement, 'scrollHeight', { value: 5000, configurable: true });
+      Object.defineProperty(document.documentElement, 'clientHeight', { value: 800, configurable: true });
+
+      scrollToElement(element);
+      flushFrame();
+
+      expect(window.scrollTo).toHaveBeenCalledWith({ top: 500, left: 0, behavior: 'smooth' });
+    });
+
+    it('defers the scroll by the given delay', () => {
+      // modern fake timers also replace requestAnimationFrame, so re-install the stub after enabling them
+      jest.useFakeTimers();
+      window.requestAnimationFrame = jest.fn((callback: FrameRequestCallback) => {
+        frames.push(callback);
+
+        return frames.length;
+      });
+
+      const { container, element } = buildTree();
+      mockOverflow(new Map([[container, 'scroll']]));
+      setRect(element, { top: 104 });
+      Object.defineProperty(container, 'scrollTop', { value: 0, configurable: true });
+
+      scrollToElement(element, 300);
+      flushFrame();
+
+      expect(container.scrollTo).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(300);
+
+      expect(container.scrollTo).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('scrollToElementWhenStable', () => {
+    const setUp = (tops: number[]) => {
+      const { container, element } = buildTree();
+      mockOverflow(new Map([[container, 'scroll']]));
+      setRect(container, { top: 0 });
+      Object.defineProperty(container, 'scrollTop', { value: 0, configurable: true });
+
+      let index = 0;
+      element.getBoundingClientRect = jest.fn(() => {
+        const top = tops[Math.min(index, tops.length - 1)];
+        index += 1;
+
+        return { top } as DOMRect;
+      });
+
+      return { container, element };
+    };
+
+    it('waits for the moving target to settle before scrolling once', () => {
+      const { container, element } = setUp([604, 804, 1004, 1004, 1004, 1004]);
+
+      scrollToElementWhenStable(element);
+
+      flushFrame();
+      flushFrame();
+      flushFrame();
+      expect(container.scrollTo).not.toHaveBeenCalled();
+
+      flushFrame();
+      flushFrame();
+
+      expect(container.scrollTo).toHaveBeenCalledTimes(1);
+      expect(container.scrollTo).toHaveBeenCalledWith({ top: 900, left: 0, behavior: 'smooth' });
+    });
+
+    it('corrects once, without animation, when late content shifts the target', () => {
+      const { container, element } = setUp([604, 604, 604, 604, 1204]);
+
+      scrollToElementWhenStable(element);
+
+      flushFrame();
+      flushFrame();
+      flushFrame();
+      expect(container.scrollTo).toHaveBeenCalledWith({ top: 500, left: 0, behavior: 'smooth' });
+
+      flushFrame();
+      flushFrame();
+
+      expect(container.scrollTo).toHaveBeenLastCalledWith({ top: 1100, left: 0, behavior: 'auto' });
+      expect(container.scrollTo).toHaveBeenCalledTimes(2);
+    });
+
+    it('ignores sub-pixel drift below the threshold', () => {
+      const { container, element } = setUp([604, 604, 604, 604, 606]);
+
+      scrollToElementWhenStable(element);
+
+      flushFrame();
+      flushFrame();
+      flushFrame();
+      flushFrame();
+      flushFrame();
+
+      expect(container.scrollTo).toHaveBeenCalledTimes(1);
+    });
+
+    it('scrolls anyway once the settle window expires on never-stable content', () => {
+      const nowSpy = jest.spyOn(Date, 'now');
+      nowSpy.mockReturnValueOnce(0).mockReturnValue(1000);
+
+      const { container, element } = setUp([604, 804, 1004, 1204]);
+
+      scrollToElementWhenStable(element, { settleTimeout: 250, timeout: 2000 });
+      flushFrame();
+
+      expect(container.scrollTo).toHaveBeenCalledTimes(1);
+    });
+
+    it('stops on cancel', () => {
+      const { container, element } = setUp([604]);
+
+      const cancel = scrollToElementWhenStable(element);
+      cancel();
+      flushFrame();
+      flushFrame();
+      flushFrame();
+
+      expect(container.scrollTo).not.toHaveBeenCalled();
+    });
+
+    it('aborts as soon as the user scrolls', () => {
+      const { container, element } = setUp([604, 804, 1004, 1004, 1004]);
+
+      scrollToElementWhenStable(element);
+      flushFrame();
+
+      window.dispatchEvent(new Event('wheel'));
+
+      flushFrame();
+      flushFrame();
+      flushFrame();
+
+      expect(container.scrollTo).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/public/utils/helpers.ts
+++ b/frontend/src/public/utils/helpers.ts
@@ -3,9 +3,8 @@ import { diff } from 'deep-object-diff';
 
 import { EPayPeriod } from '../types/pricing';
 import { TAX_RATES } from '../constants/taxRates';
-import { NAVBAR_HEIGHT, MOBILE_NAVBAR_HEIGHT } from '../constants/defaultValues';
 
-const { MOBILE_MAX_WIDTH_BREAKPOINT } = require('../constants/breakpoints');
+export { scrollToElement } from './scroll';
 
 export const isClient = (): boolean => typeof window !== 'undefined';
 
@@ -187,10 +186,6 @@ export const copyToClipboard = (str: string) => {
 
 export const deepCopy = <T>(o: T) => JSON.parse(JSON.stringify(o)) as T;
 
-export const scrollToTop = () => {
-  window.scroll({ top: 0, behavior: 'smooth' });
-};
-
 export const convertEnumToObject = (e: object): { [key: string]: string } => {
   return Object(e);
 };
@@ -224,41 +219,6 @@ export const getTruncatedText = (source: string, size = 50) => {
 };
 
 export const getPairedArrayItems = (arr: any[]) => arr.slice(1).map((item, index) => [arr[index], item]);
-
-export const scrollToElement = (
-  element: HTMLElement,
-  delay: number | null = null,
-  behavior: 'auto' | 'smooth' = 'smooth',
-) => {
-  window.requestAnimationFrame(() => {
-    const elementTopOffset = window.innerWidth > MOBILE_MAX_WIDTH_BREAKPOINT ? NAVBAR_HEIGHT : MOBILE_NAVBAR_HEIGHT;
-
-    let offset = element.offsetTop - elementTopOffset;
-
-    try {
-      const bodyRect = document.body.getBoundingClientRect();
-      const bodyStyle = window.getComputedStyle(document.body, null);
-
-      // need to handle the padding for the top of the body
-      const paddingTop = parseFloat(bodyStyle.getPropertyValue('padding-top'));
-
-      const elementRect = element.getBoundingClientRect();
-      offset = elementRect.top - paddingTop - bodyRect.top - elementTopOffset;
-    } catch (err) {
-      element.scrollIntoView({ behavior });
-
-      return;
-    }
-
-    if (delay) {
-      setTimeout(() => {
-        window.scrollTo({ top: offset, left: 0, behavior });
-      }, delay);
-    } else {
-      window.scrollTo({ top: offset, left: 0, behavior });
-    }
-  });
-};
 
 export const omit = <T, U extends keyof T>(obj: T, keys: U[]): Omit<T, U> => {
   return (Object.keys(obj as {}) as U[]).reduce(

--- a/frontend/src/public/utils/scroll.ts
+++ b/frontend/src/public/utils/scroll.ts
@@ -1,0 +1,184 @@
+import { NAVBAR_HEIGHT, MOBILE_NAVBAR_HEIGHT } from '../constants/defaultValues';
+
+const { MOBILE_MAX_WIDTH_BREAKPOINT } = require('../constants/breakpoints');
+
+export type TScrollBehavior = 'auto' | 'smooth';
+
+const SCROLLABLE_OVERFLOW = ['auto', 'scroll', 'overlay'];
+
+/**
+ * The app does not scroll the window: MainLayout renders #app-container with
+ * `overflow: scroll; height: 100%`, so the document itself never overflows.
+ * Every scroll helper has to target the nearest scrolling ancestor instead.
+ */
+export const getScrollParent = (element: HTMLElement): HTMLElement | null => {
+  let current = element.parentElement;
+
+  while (current && current !== document.body) {
+    const { overflowY } = window.getComputedStyle(current);
+
+    if (SCROLLABLE_OVERFLOW.includes(overflowY) && current.scrollHeight > current.clientHeight) {
+      return current;
+    }
+
+    current = current.parentElement;
+  }
+
+  return null;
+};
+
+export const getNavbarOffset = (): number => {
+  return window.innerWidth > MOBILE_MAX_WIDTH_BREAKPOINT ? NAVBAR_HEIGHT : MOBILE_NAVBAR_HEIGHT;
+};
+
+const clampScrollTop = (value: number, maxValue: number) => Math.max(0, Math.min(value, maxValue));
+
+export const getScrollTargetTop = (
+  element: HTMLElement,
+  container: HTMLElement | null,
+  topOffset: number = getNavbarOffset(),
+): number => {
+  const elementTop = element.getBoundingClientRect().top;
+
+  if (container) {
+    const target =
+      elementTop - container.getBoundingClientRect().top - container.clientTop + container.scrollTop - topOffset;
+
+    return clampScrollTop(target, container.scrollHeight - container.clientHeight);
+  }
+
+  const scroller = document.scrollingElement || document.documentElement;
+  const target = elementTop - document.body.getBoundingClientRect().top - topOffset;
+
+  return clampScrollTop(target, scroller.scrollHeight - scroller.clientHeight);
+};
+
+const scrollContainerTo = (container: HTMLElement | null, top: number, behavior: TScrollBehavior) => {
+  if (container) {
+    container.scrollTo({ top, left: 0, behavior });
+
+    return;
+  }
+
+  window.scrollTo({ top, left: 0, behavior });
+};
+
+export const scrollToElement = (
+  element: HTMLElement,
+  delay: number | null = null,
+  behavior: TScrollBehavior = 'smooth',
+) => {
+  window.requestAnimationFrame(() => {
+    const scroll = () => {
+      const container = getScrollParent(element);
+
+      scrollContainerTo(container, getScrollTargetTop(element, container), behavior);
+    };
+
+    if (delay) {
+      setTimeout(scroll, delay);
+
+      return;
+    }
+
+    scroll();
+  });
+};
+
+export type TScrollWhenStableOptions = {
+  behavior?: TScrollBehavior;
+  topOffset?: number;
+  timeout?: number;
+  settleFrames?: number;
+  settleTimeout?: number;
+  driftThreshold?: number;
+};
+
+const SETTLE_FRAMES = 2;
+const SETTLE_TIMEOUT = 250;
+const SCROLL_TIMEOUT = 2000;
+const DRIFT_THRESHOLD = 4;
+const STABLE_TOLERANCE = 1;
+const ABORT_EVENTS = ['wheel', 'touchstart', 'keydown'];
+
+/**
+ * Scrolls to an element whose position is still moving: an accordion is expanding,
+ * lazy data is arriving, third party embeds are mounting. Waits for the target to
+ * settle, scrolls once, then corrects a single time if late content shifts it.
+ * Returns a cancel function; aborts on any user scroll input.
+ */
+export const scrollToElementWhenStable = (element: HTMLElement, options: TScrollWhenStableOptions = {}) => {
+  const {
+    behavior = 'smooth',
+    topOffset,
+    timeout = SCROLL_TIMEOUT,
+    settleFrames = SETTLE_FRAMES,
+    settleTimeout = SETTLE_TIMEOUT,
+    driftThreshold = DRIFT_THRESHOLD,
+  } = options;
+
+  const startedAt = Date.now();
+
+  let frameId: number | null = null;
+  let stableFrames = 0;
+  let previousTop: number | null = null;
+  let scrolledTop: number | null = null;
+  let isCancelled = false;
+
+  const cancel = () => {
+    if (isCancelled) {
+      return;
+    }
+
+    isCancelled = true;
+
+    if (frameId !== null) {
+      window.cancelAnimationFrame(frameId);
+      frameId = null;
+    }
+
+    ABORT_EVENTS.forEach((eventName) => window.removeEventListener(eventName, cancel));
+  };
+
+  const scroll = (top: number, scrollBehavior: TScrollBehavior) => {
+    scrolledTop = top;
+    scrollContainerTo(getScrollParent(element), top, scrollBehavior);
+  };
+
+  const tick = () => {
+    if (isCancelled) {
+      return;
+    }
+
+    const container = getScrollParent(element);
+    const top = getScrollTargetTop(element, container, topOffset);
+    const elapsed = Date.now() - startedAt;
+
+    if (scrolledTop === null) {
+      stableFrames = previousTop !== null && Math.abs(top - previousTop) <= STABLE_TOLERANCE ? stableFrames + 1 : 0;
+      previousTop = top;
+
+      if (stableFrames >= settleFrames || elapsed >= settleTimeout || elapsed >= timeout) {
+        scroll(top, behavior);
+      }
+    } else if (Math.abs(top - scrolledTop) > driftThreshold) {
+      scroll(top, 'auto');
+      cancel();
+
+      return;
+    }
+
+    if (elapsed >= timeout && scrolledTop !== null) {
+      cancel();
+
+      return;
+    }
+
+    frameId = window.requestAnimationFrame(tick);
+  };
+
+  ABORT_EVENTS.forEach((eventName) => window.addEventListener(eventName, cancel, { passive: true }));
+  frameId = window.requestAnimationFrame(tick);
+
+  return cancel;
+};


### PR DESCRIPTION
### 1. Release notes

Fixed auto-scroll for the Integrate button section links: choosing `Share Kick-off`, `Zapier`, `API`, or `Webhooks` now scrolls the template editor to the corresponding section instead of only changing the URL.

### 2. Context

**Issue:** 39477 — "Fix the auto-scroll when clicking sections in the integration button. The url status changes, but autoscroll does not work."

**App Location:** Dashboard → Breakdown card → **Integrate** menu, and any direct `/templates/{id}#share|#zapier|#api|#webhook` URL. Targets are the Kick-off section (`KickoffRedux`) and the Integrations section (`TemplateIntegrations`) of the template editor.

**Related Changes:** none. Note that the Integrate button was removed from the template editor sidebar in v3.2.1 (`467543542`, "2.2 Removed the Integrate button from the template editor"); this PR does not restore it. `IntegrateButton` is rendered only from `Dashboard/Breakdowns/BreakdownItem.tsx`.

### 3. Solution & Implementation Details

**Root cause.** `scrollToElement` scrolled `window`, but the app never scrolls the document. `MainLayout` renders `#app-container` with `.main-layout { overflow: scroll; height: 100% }` (`layout/MainLayout/MainLayout.css:1-7`), and `html` / `body` are both pinned to `height: 100%` with `html { overflow-x: hidden }` (`assets/css/style.css:61-76`). Because the root's used overflow is no longer `visible`, `body`'s `overflow: auto` is not propagated to the viewport, so `window.scrollY` is permanently `0` and `window.scrollTo({ top })` is a silent no-op. The rest of the codebase already treats `#app-container` as the scroller (`scrollableTarget="app-container"` in `Tasks`, `Datasets`, `Fieldsets`, `HighlightsFeed`, `WorkflowsGridPage`, `TemplatesSystem`; `WorkflowsTable` toggles its `overflow` directly).

A second defect in the same function: `offset = elementRect.top - paddingTop - bodyRect.top - elementTopOffset` assumed `body` moves with document scroll (`bodyRect.top === -scrollY`). With a nested scroller `body` never moves, so the value was a viewport-relative delta passed as an absolute scroll position. The `paddingTop` term also double-counted, since `elementRect.top - bodyRect.top` already includes body padding. The `catch` → `scrollIntoView` fallback never ran, because neither `getBoundingClientRect` nor `getComputedStyle` throws.

A third, timing defect surfaces once the scroller is fixed: `useHashLink` called `handle()` (which expands the collapsed section) and `scrollToElement` in the same tick, so the target was measured before the panel expanded and before `loadApiKeys` / `loadWebhooks` / the Zapier embeds rendered. Because the Integrations section is the last child of the task list, the desired `scrollTop` while collapsed exceeds `scrollHeight - clientHeight` and gets clamped, leaving the header pinned at the bottom of the viewport instead of under the navbar.

**Changes.**

1. New `src/public/utils/scroll.ts`:
   - `getScrollParent(element)` — nearest ancestor with `overflow-y: auto | scroll | overlay` that actually overflows; `null` means the viewport. Kept generic rather than hard-coding `#app-container`, so it survives the `WorkflowsTable` overflow toggle and any future nested scroller.
   - `getNavbarOffset()` — `NAVBAR_HEIGHT` (104) above the mobile breakpoint, `MOBILE_NAVBAR_HEIGHT` (0) below it. `TopNav` is `position: sticky` inside the scroller, so the inset is still correct.
   - `getScrollTargetTop(element, container, topOffset)` — container-relative target, clamped to `[0, scrollHeight - clientHeight]`; the erroneous body-padding term is gone.
   - `scrollToElement(element, delay, behavior)` — same signature as before, now scrolling the resolved container and falling back to `window` only when nothing else scrolls.
   - `scrollToElementWhenStable(element, options)` — polls the target via `requestAnimationFrame` until it stops moving (2 stable frames or a 250 ms settle window), issues one smooth scroll, then corrects once with `behavior: 'auto'` if late content shifts it by more than 4 px. Hard-bounded by a 2000 ms deadline, returns a `cancel()`, and aborts on `wheel` / `touchstart` / `keydown` so it never fights the user.
2. `src/public/utils/helpers.ts` re-exports `scrollToElement` from `./scroll`, so `TaskForm` and `Delay` import paths are untouched. Removed the now-dead `scrollToTop` (zero call sites, broken for the same reason).
3. `src/public/hooks/useHashLink.ts` uses `scrollToElementWhenStable`, cancels a pending scroll as the first action of every navigation — before the hash is even read, so that navigating to an empty or unowned hash also supersedes it rather than letting the old loop drag the user back — and on unmount (the template editor unmounts and remounts this subtree during `Saved → Loading → Saved`, which would otherwise leave two rAF loops racing), and reads `settings` through a ref so the `[]` effect never calls stale handlers.

`TemplateIntegrations`, `KickoffRedux`, `IntegrateButton`, `BreakdownItem` and `getIntegrationsSettings` are unchanged — expand and tab-selection behaviour is preserved exactly.

### 4. What to Test

#### 4.1 Preconditions

- A user with an active template that has at least 10 tasks, so the Integrations section sits well below the fold.
- Zapier embeds reachable (App Directory / Zap Templates tabs load third-party custom elements).
- Test at a desktop width > 999 px and a mobile width < 1000 px.

#### 4.2 Positive Scenarios / Testing Report

| # | Steps | Expected result | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
|---|---|---|---|---|---|---|
| 1 | Dashboard → active Breakdown card → **Integrate** → `API` | Template editor opens, Integrations expands on the API tab, page scrolls so the section header sits ~104 px below the navbar | [ ] | [ ] | [ ] | [ ] |
| 2 | Same, `Webhooks` | Integrations expands on the Webhooks tab and stays in place after the webhook list loads | [ ] | [ ] | [ ] | [ ] |
| 3 | Same, `Zapier` | Integrations expands on Zap Templates; position is corrected once the Zapier embed renders | [ ] | [ ] | [ ] | [ ] |
| 4 | Same, `Share Kick-off` | Kick-off section expands and scrolls into view without over-scrolling past it | [ ] | [ ] | [ ] | [ ] |
| 5 | Open `/templates/{id}#api` directly with a hard reload | Scrolls after the template finishes loading, not before | [ ] | [ ] | [ ] | [ ] |
| 6 | While already on the editor, push a second hash (browser Back/Forward between `#api` and `#share`) | Each navigation re-scrolls to the right section | [ ] | [ ] | [ ] | [ ] |

#### 4.3 Negative Scenarios & Edge Cases

| # | Steps | Expected result | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
|---|---|---|---|---|---|---|
| 1 | Start scrolling manually right after clicking an Integrate item | Auto-scroll aborts; the page follows the user, no snap-back | [ ] | [ ] | [ ] | [ ] |
| 2 | Open `/templates/{id}#zap-manager` (no such hash mapping) | Nothing expands, no scroll, no console error | [ ] | [ ] | [ ] | [ ] |
| 3 | Open `/templates/{id}` with no hash | No scroll on load | [ ] | [ ] | [ ] | [ ] |
| 4 | Integrate → `API` on a template with 1 task (page barely scrolls) | Scroll clamps to the bottom of the container, no jitter or infinite correction | [ ] | [ ] | [ ] | [ ] |
| 5 | Navigate away while the scroll is still settling | No console error, no orphan animation frame | [ ] | [ ] | [ ] | [ ] |
| 6 | Integrate → `API`, then immediately hit Back (or open a hash with no mapping) | The superseded scroll is dropped; the page is never dragged back to the old section | [ ] | [ ] | [ ] | [ ] |

#### 4.4 Verification Points

- `document.getElementById('app-container').scrollTop` changes while `window.scrollY` stays `0` — confirms the container is the scroller.
- The section header lands `NAVBAR_HEIGHT` (104 px) below the sticky `TopNav` on desktop, and flush at the container top on mobile, where `TopNav` is `position: unset`.
- Exactly one smooth scroll per hash change, at most one follow-up `auto` correction.

#### 4.5 API Verification

Not applicable — no API or payload changes. Expanding the Integrations section still dispatches `loadApiKeys` and `loadWebhooks`, unchanged.

#### 4.6 What Was NOT Tested

- No manual browser verification was performed in this change; the root cause and the fix were established from the CSS/layout chain and covered by unit tests only. All scenarios in 4.2 and 4.3 remain unchecked.
- No cross-browser verification (Safari, mobile Safari, mobile Chrome).
- Zapier third-party embed timing was not exercised — jsdom cannot load the custom elements.
- The two other `scrollToElement` callers (`TaskForm`, `Delay`) were not manually re-verified; they were silently broken before this change and now actually scroll, which is a behaviour change worth a QA pass.

### 5. Affected Areas

| Area | Impact | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
|---|---|---|---|---|---|
| Integrate menu → template editor sections | Fixed: hash links now scroll | [ ] | [ ] | [ ] | [ ] |
| Template editor — Kick-off `#share` anchor | Fixed: same mechanism | [ ] | [ ] | [ ] | [ ] |
| Template editor — adding/expanding a task (`TaskForm`) | Behaviour change: scroll now works where it previously did nothing | [ ] | [ ] | [ ] | [ ] |
| Template editor — adding/expanding a delay (`Delay`) | Behaviour change: same | [ ] | [ ] | [ ] | [ ] |
| `helpers.scrollToTop` | Removed (dead code, zero call sites) | [ ] | [ ] | [ ] | [ ] |

### 6. Unit Tests

- **New** `src/public/utils/__tests__/scroll.test.ts` — 19 tests covering `getNavbarOffset` (desktop/mobile), `getScrollParent` (nearest scroller, non-overflowing ancestor, `overflow: hidden` ancestor, no scroller), `getScrollTargetTop` (container math, body-padding regression guard, clamping at both ends), `scrollToElement` (container over window, window fallback, `delay` branch), and `scrollToElementWhenStable` (settle-then-scroll-once, drift correction, sub-threshold drift ignored, deadline, `cancel()`, abort on user input).
- **New** `src/public/hooks/__tests__/useHashLink.test.tsx` — 10 tests covering mount with a matching hash, no hash, unowned hash, hash pushed while mounted, cancellation of a superseded scroll, cancellation when navigating to an unowned hash or away from the hash entirely, no double-cancel of an already superseded scroll, cleanup on unmount, and reading handlers from the latest render. The three cancellation-on-navigation tests were confirmed to fail against the previous handler ordering.

Full suite: **246 suites / 1689 tests passing**. `npx tsc --noEmit --skipLibCheck -p tsconfig.json` clean; ESLint clean on all changed source files.

### 7. Commits

- `0ea84fe1a` — `39477 fix(integrations): scroll hash targets inside the app scroll container`
- `5411a3a48` — `39477 fix(integrations): cancel a settling hash scroll on any navigation`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Shared scroll behavior affects TaskForm and Delay as well as integration hash links; incorrect scroll-parent detection could mis-scroll nested layouts, though changes are localized to frontend scrolling with broad test coverage.
> 
> **Overview**
> Fixes Integrate menu and direct `#share` / `#api` / etc. links so the template editor actually scrolls to the right section, not just updates the URL.
> 
> **Scroll targeting** moves from `window` to the nearest overflowing ancestor (e.g. `#app-container`), with navbar-aware offsets and clamping. `scrollToElement` keeps the same public API but is implemented in new `scroll.ts`; `helpers` re-exports it and drops dead `scrollToTop`.
> 
> **Hash navigation** (`useHashLink`) now calls `scrollToElementWhenStable`, which waits for expanding sections and async content to settle before scrolling, cancels in-flight scrolls on any route change or unmount, and reads handlers via a ref so stale closures are avoided.
> 
> Unit tests cover the scroll helpers and hook cancellation / edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5411a3a48526c1ae15cf7f2134778dc1709f4d01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix hash link scrolling to target app scroll container and wait for stable layout
> - `scrollToElement` now finds the nearest scrollable container ancestor and scrolls it, instead of scrolling the window, using computed positions with navbar offsets.
> - Adds `scrollToElementWhenStable` which waits for the target element's position to stop drifting before scrolling, and aborts on user input or cancellation.
> - Refactors `useHashLink` to use the stable scroll utility, cancel any pending scroll on new navigation or unmount, and use the latest render handlers.
> - Risk: Removes `helpers.scrollToTop`; `helpers.scrollToElement` delegates to [scroll.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/352/files#diff-d4c7690e83c14112987fe4ae6626d7ba9295879cf49ed169528dced4525a10e8), changing the default scroll target from window to nearest scrollable container.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5411a3a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->