### PR TITLE
49260 frontend [ UI ] Extra indentation in the performer list for groups

### DIFF
--- a/frontend/src/public/components/UI/Avatar/Avatar.tsx
+++ b/frontend/src/public/components/UI/Avatar/Avatar.tsx
@@ -94,11 +94,7 @@ export function Avatar({
     }
 
     if (user?.type === 'group') {
-      return (
-        <div className={containerClassName}>
-          <GroupIcon className={classnames(styles['avatar'], styles['is-group'], ...sizeClasses, className)} />
-        </div>
-      );
+      return <GroupIcon className={classnames(styles['avatar'], styles['is-group'], ...sizeClasses, className)} />;
     }
 
     const notRegistratedStatues = [EUserStatus.Invited, EUserStatus.External];

--- a/frontend/src/public/components/UI/Avatar/__tests__/Avatar.test.tsx
+++ b/frontend/src/public/components/UI/Avatar/__tests__/Avatar.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 
+import { GroupIcon } from '../../../icons';
 import { Avatar } from '../Avatar';
 import styles from '../Avatar.css';
 
@@ -54,5 +55,20 @@ describe('Avatar', () => {
     const avatarElement = wrapper.find(`.${styles['avatar']}`);
 
     expect(avatarElement.text()).toEqual('');
+  });
+
+  it('does not nest container for group avatar', () => {
+    const user = {
+      firstName: '',
+      lastName: '',
+      photo: '',
+      email: '',
+      type: 'group' as const,
+    };
+    const wrapper = shallow(<Avatar user={user} containerClassName="avatar-container" />);
+
+    expect(wrapper.hasClass('avatar-container')).toBe(true);
+    expect(wrapper.find(GroupIcon).parents('.avatar-container')).toHaveLength(1);
+    expect(wrapper.find(GroupIcon)).toHaveLength(1);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small UI markup change in Avatar for group type only, covered by a new test.
> 
> **Overview**
> Fixes **extra indentation for group performers** by changing how group avatars render inside `Avatar`.
> 
> Group users no longer wrap `GroupIcon` in an **additional** `containerClassName` div inside `renderImage()`. The icon is returned directly, consistent with guest and external avatar icons, so only the component’s outer container applies—avoiding **double nesting** that misaligned group rows in lists such as the performer list.
> 
> A unit test asserts that with `containerClassName` set, the wrapper is not nested around `GroupIcon` and a single `GroupIcon` still renders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5ac993c146b3c853ebf0cff4dd89e50d8f51cab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove extra wrapping `<div>` for `GroupIcon` in `Avatar.renderImage`
> For users with type `group`, the `Avatar.renderImage` helper no longer wraps `GroupIcon` in an extra `<div className={containerClassName}>`. The `GroupIcon` is now a direct child of the Avatar's outer container, which retains `containerClassName`. Adds a test verifying `GroupIcon` renders exactly once with only one ancestor carrying the container class.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a5ac993.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->