### PR TITLE
49258 frontend [ task ] Change the filter value on the tasks page from “old” to “new”.

### DIFF
--- a/frontend/src/public/components/Tasks/container.ts
+++ b/frontend/src/public/components/Tasks/container.ts
@@ -107,7 +107,7 @@ const SyncedTasks = withSyncedQueryString<TTasksStoreProps>(
     {
       propName: 'taskSorting',
       queryParamName: 'sorting',
-      defaultAction: changeTaskListSorting(ETaskListSorting.DateAsc),
+      defaultAction: changeTaskListSorting(ETaskListSorting.DateDesc),
       createAction: changeTaskListSorting,
       getQueryParamByProp: (value) => value,
     },

--- a/frontend/src/public/redux/tasks/slice.ts
+++ b/frontend/src/public/redux/tasks/slice.ts
@@ -28,7 +28,7 @@ const initFilterValues = {
 const initTasksSettings: ITasksSettings = {
   isHasFilter: false,
   completionStatus: ETaskListCompletionStatus.Active,
-  sorting: ETaskListSorting.DateAsc,
+  sorting: ETaskListSorting.DateDesc,
   filterValues: initFilterValues,
   templateList: {
     items: [],


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only default for list ordering; no auth, API contract, or data-handling changes.
> 
> **Overview**
> The tasks page now defaults to **newest-first** date sorting instead of oldest-first.
> 
> This updates both the Redux initial `tasksSettings.sorting` and the URL-sync default for the `sorting` query param so first load and filter resets behave consistently without a `sorting` in the URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6f6af53024b5379092544d5948691f6545ad280. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Change default task list sorting from `DateAsc` to `DateDesc`
> Updates the default sorting order on the Tasks page so newest tasks appear first when no `sorting` query parameter is present. Changes the `defaultAction` in the `Tasks.SyncedTasks` component config and the `initTasksSettings` initial Redux state constant.
> - Risk: existing URLs without a `sorting` param will now render tasks in descending date order instead of ascending; verify dependent logic in [slice.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/355/files#diff-23574686d42630f229c8b0c986733402c3e86ed6d5641925ddadb5b28320eacf) and [container.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/355/files#diff-42f9c74eb1bc39e7b56a1cf0ced0b07678ab9b18a31921167a93d6dea419c3a7).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d6f6af5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->