### PR TITLE
49259 frontend [ UI ] In the RichEditor component, if there is no attachment functionality, do not display the separate

### DIFF
--- a/frontend/src/public/components/RichEditor/components/EditorToolbar/EditorToolbar.tsx
+++ b/frontend/src/public/components/RichEditor/components/EditorToolbar/EditorToolbar.tsx
@@ -146,38 +146,39 @@ export function EditorToolbar({
         onKeyDown={(e: React.KeyboardEvent<HTMLDivElement>) => e.preventDefault()}
       >
         {!isMobile && (
-          <>
-            <div className={styles['toolbar-format']}>
-              {formatButtons.map(({ Icon, labels, isActive, onMouseDown, ref: btnRef }) => (
-                <ToolbarButton
-                  key={labels.aria}
-                  ref={btnRef}
-                  isActive={isActive}
-                  tooltipText={labels.tooltip}
-                  ariaLabel={labels.aria}
-                  isModal={isModal}
-                  onMouseDown={onMouseDown}
-                >
-                  <Icon />
-                </ToolbarButton>
-              ))}
-            </div>
-            <div className={styles['separator']} aria-hidden />
-          </>
+          <div className={styles['toolbar-format']}>
+            {formatButtons.map(({ Icon, labels, isActive, onMouseDown, ref: btnRef }) => (
+              <ToolbarButton
+                key={labels.aria}
+                ref={btnRef}
+                isActive={isActive}
+                tooltipText={labels.tooltip}
+                ariaLabel={labels.aria}
+                isModal={isModal}
+                onMouseDown={onMouseDown}
+              >
+                <Icon />
+              </ToolbarButton>
+            ))}
+          </div>
         )}
         {showAttachmentButtons &&
-          attachmentButtons.map(({ Icon, labels, accept }) => (
-          <AttachmentToolbarButton
-            key={labels.aria}
-            tooltipText={labels.tooltip}
-            ariaLabel={labels.aria}
-            accept={accept}
-            isModal={isModal}
-            onFileChange={handleAttachmentUpload}
-          >
-            <Icon />
-          </AttachmentToolbarButton>
+        <>
+          <div className={styles['separator']} aria-hidden />
+          {attachmentButtons.map(({ Icon, labels, accept }) => (
+            <AttachmentToolbarButton
+              key={labels.aria}
+              tooltipText={labels.tooltip}
+              ariaLabel={labels.aria}
+              accept={accept}
+              isModal={isModal}
+              onFileChange={handleAttachmentUpload}
+            >
+              <Icon />
+            </AttachmentToolbarButton>
           ))}
+        </>}
+
       </div>
     </div>
   );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Toolbar layout/conditional rendering only; no changes to upload handling or editor commands.
> 
> **Overview**
> **RichEditor toolbar** no longer shows the divider between formatting controls and attachment actions when attachments are disabled (`onUploadAttachments` is absent).
> 
> The separator is moved out of the desktop-only format block and rendered only alongside attachment buttons when `showAttachmentButtons` is true, so editors without upload support avoid a stray visual separator after the format row (or on mobile when only file attach is shown).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddf6cba792d81653e41d733191c6349823eecce8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hide `RichEditor` toolbar separator when no attachment buttons are shown
> Moves the separator `<div>` in `EditorToolbar` from the non-mobile block into the `showAttachmentButtons` block so it only renders when attachment buttons are visible. Removes the surrounding fragment from the non-mobile section.
> - Behavioral Change: on non-mobile without attachments, the separator no longer appears; on mobile with attachments, a separator now appears before the attachment buttons.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ddf6cba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->