### PR TITLE
49256 frontend [ UI ] Display a preview when loading the logo and align the UI with the mockups.

### DIFF
--- a/frontend/src/public/api/editAccount.ts
+++ b/frontend/src/public/api/editAccount.ts
@@ -10,10 +10,14 @@ export interface IUpdateAccountRequest {
 
 export interface IUpdateAccountResponse {
   name: string;
+  logoSm: string | null;
+  logoLg: string | null;
 }
 
 export interface IUpdatedAccount {
   name: string;
+  logoSm: string | null;
+  logoLg: string | null;
 }
 
 export function editAccount(settings: IUpdateAccountRequest, leaseLevel: TAccountLeaseLevel) {

--- a/frontend/src/public/components/ProfileAccount/ProfileAccount.tsx
+++ b/frontend/src/public/components/ProfileAccount/ProfileAccount.tsx
@@ -45,9 +45,8 @@ export function ProfileAccount({
   const { formatMessage } = useIntl();
   const savedState: TEditableFields = { name, logoSm, logoLg };
   const [state, changeState] = React.useState<TEditableFields>(savedState);
-  const isDirty = isContentChanged(savedState, state) && isValidState(state);
+  const savedStateRef = React.useRef(savedState);
   const hasNoData = !accountId && !name;
-  const wasEmptyRef = React.useRef(hasNoData);
 
   React.useEffect(() => {
     document.title = TITLES.AccountSettings;
@@ -56,10 +55,13 @@ export function ProfileAccount({
     onChangeTab(ESettingsTabs.AccountSettings);
   }, []);
 
-  if (wasEmptyRef.current && !hasNoData) {
-    wasEmptyRef.current = false;
-    changeState({ name, logoSm, logoLg });
+  // Account data is hydrated after the first render and refreshed after every save
+  if (isContentChanged(savedStateRef.current, savedState)) {
+    savedStateRef.current = savedState;
+    changeState(savedState);
   }
+
+  const isDirty = isContentChanged(savedState, state) && isValidState(state);
 
   const logoSmFiles = React.useMemo(
     () => (state.logoSm ? [getFileByUrl(state.logoSm)] : EMPTY_UPLOADED_FILES),

--- a/frontend/src/public/components/ProfileAccount/ProfileAccount.tsx
+++ b/frontend/src/public/components/ProfileAccount/ProfileAccount.tsx
@@ -28,6 +28,8 @@ export interface IProfileAccountProps {
   onChangeTab(tab: ESettingsTabs): void;
 }
 
+const EMPTY_UPLOADED_FILES: TUploadedFile[] = [];
+
 export function ProfileAccount({
   accountId,
   name,
@@ -40,16 +42,12 @@ export function ProfileAccount({
   onChangeTab,
   editCurrentAccount,
 }: IProfileAccountProps) {
-  const hasNoData = !accountId && !name;
-
   const { formatMessage } = useIntl();
-
-  if (hasNoData) {
-    return loading ? <div className="loading" /> : null;
-  }
-  const initialState: TEditableFields = { name, logoSm, logoLg };
-  const [state, changeState] = React.useState(initialState);
-  const [isDirty, changeDirty] = React.useState(false);
+  const savedState: TEditableFields = { name, logoSm, logoLg };
+  const [state, changeState] = React.useState<TEditableFields>(savedState);
+  const isDirty = isContentChanged(savedState, state) && isValidState(state);
+  const hasNoData = !accountId && !name;
+  const wasEmptyRef = React.useRef(hasNoData);
 
   React.useEffect(() => {
     document.title = TITLES.AccountSettings;
@@ -58,16 +56,40 @@ export function ProfileAccount({
     onChangeTab(ESettingsTabs.AccountSettings);
   }, []);
   React.useEffect(() => {
-    changeDirty(false);
-  }, [name, logoSm, logoLg]);
+    if (!wasEmptyRef.current || hasNoData) {
+      return;
+    }
+
+    wasEmptyRef.current = false;
+    changeState({ name, logoSm, logoLg });
+  }, [hasNoData, name, logoSm, logoLg]);
+
+  const logoSmFiles = React.useMemo(
+    () => (state.logoSm ? [getFileByUrl(state.logoSm)] : EMPTY_UPLOADED_FILES),
+    [state.logoSm],
+  );
+  const logoLgFiles = React.useMemo(
+    () => (state.logoLg ? [getFileByUrl(state.logoLg)] : EMPTY_UPLOADED_FILES),
+    [state.logoLg],
+  );
 
   const changeField = (field: keyof TEditableFields) => (value: TEditableFields[keyof TEditableFields]) => {
-    const newState = { ...state, [field]: value };
-    changeState(newState);
-    changeDirty(isContentChanged(initialState, newState) && isValidState(newState));
+    changeState((prevState) => ({ ...prevState, [field]: value }));
   };
 
+  const handleLogoSmFiles = React.useCallback((files: TUploadedFile[]) => {
+    changeState((prevState) => ({ ...prevState, logoSm: getUrlByFile(files[0]) }));
+  }, []);
+
+  const handleLogoLgFiles = React.useCallback((files: TUploadedFile[]) => {
+    changeState((prevState) => ({ ...prevState, logoLg: getUrlByFile(files[0]) }));
+  }, []);
+
   const handleSubmit = () => editCurrentAccount(state);
+
+  if (hasNoData) {
+    return loading ? <div className="loading" /> : null;
+  }
 
   return (
     <div className={styles['settings-form']}>
@@ -93,10 +115,11 @@ export function ProfileAccount({
           </SectionTitle>
 
           <AttachmentField
+            key={`logo-sm-${accountId}`}
             title={formatMessage({ id: 'user-info.logo-sm' })}
             accountId={accountId!}
-            uploadedFiles={state.logoSm ? [getFileByUrl(state.logoSm)] : []}
-            setUploadedFiles={(files) => changeField('logoSm')(getUrlByFile(files[0]))}
+            uploadedFiles={logoSmFiles}
+            setUploadedFiles={handleLogoSmFiles}
             description={formatMessage({ id: 'user-info.logo-sm-desc' })}
             containerClassName={styles['field']}
             acceptedType="image"
@@ -105,10 +128,11 @@ export function ProfileAccount({
           />
 
           <AttachmentField
+            key={`logo-lg-${accountId}`}
             title={formatMessage({ id: 'user-info.logo-lg' })}
             accountId={accountId!}
-            uploadedFiles={state.logoLg ? [getFileByUrl(state.logoLg)] : []}
-            setUploadedFiles={(files) => changeField('logoLg')(getUrlByFile(files[0]))}
+            uploadedFiles={logoLgFiles}
+            setUploadedFiles={handleLogoLgFiles}
             description={formatMessage({ id: 'user-info.logo-lg-desc' })}
             containerClassName={styles['field']}
             acceptedType="image"
@@ -148,7 +172,7 @@ function isValidState({ name }: TEditableFields) {
 
 const getFileByUrl = (url: string): TUploadedFile => {
   return {
-    id: '-1',
+    id: url,
     url,
     thumbnailUrl: url,
     name: '',

--- a/frontend/src/public/components/ProfileAccount/ProfileAccount.tsx
+++ b/frontend/src/public/components/ProfileAccount/ProfileAccount.tsx
@@ -55,14 +55,11 @@ export function ProfileAccount({
   React.useLayoutEffect(() => {
     onChangeTab(ESettingsTabs.AccountSettings);
   }, []);
-  React.useEffect(() => {
-    if (!wasEmptyRef.current || hasNoData) {
-      return;
-    }
 
+  if (wasEmptyRef.current && !hasNoData) {
     wasEmptyRef.current = false;
     changeState({ name, logoSm, logoLg });
-  }, [hasNoData, name, logoSm, logoLg]);
+  }
 
   const logoSmFiles = React.useMemo(
     () => (state.logoSm ? [getFileByUrl(state.logoSm)] : EMPTY_UPLOADED_FILES),

--- a/frontend/src/public/components/ProfileAccount/__tests__/ProfileAccount.test.tsx
+++ b/frontend/src/public/components/ProfileAccount/__tests__/ProfileAccount.test.tsx
@@ -64,6 +64,46 @@ describe('ProfileAccount', () => {
     expect(getLogoProps(expectedImageWidth).uploadedFiles).toEqual([]);
   });
 
+  it('shows saved logos after account data arrives', () => {
+    const { rerender } = render(
+      <IntlProvider locale="en" messages={enMessages}>
+        <ProfileAccount
+          name=""
+          logoSm={null}
+          logoLg={null}
+          loading
+          leaseLevel="standard"
+          billingPlan={ESubscriptionPlan.Premium}
+          isAdmin
+          editCurrentAccount={jest.fn()}
+          onChangeTab={jest.fn()}
+        />
+      </IntlProvider>,
+    );
+
+    expect(attachmentFieldMock).not.toHaveBeenCalled();
+
+    rerender(
+      <IntlProvider locale="en" messages={enMessages}>
+        <ProfileAccount
+          accountId={1}
+          name="Acme"
+          logoSm="https://example.com/old-small.png"
+          logoLg="https://example.com/old-large.png"
+          loading={false}
+          leaseLevel="standard"
+          billingPlan={ESubscriptionPlan.Premium}
+          isAdmin
+          editCurrentAccount={jest.fn()}
+          onChangeTab={jest.fn()}
+        />
+      </IntlProvider>,
+    );
+
+    expect(getLogoProps(80).uploadedFiles[0]?.url).toBe('https://example.com/old-small.png');
+    expect(getLogoProps(340).uploadedFiles[0]?.url).toBe('https://example.com/old-large.png');
+  });
+
   it('keeps the uploaded logo after an unrelated field change', () => {
     const uploadedLogo: TUploadedFile = {
       id: 'new-logo',

--- a/frontend/src/public/components/ProfileAccount/__tests__/ProfileAccount.test.tsx
+++ b/frontend/src/public/components/ProfileAccount/__tests__/ProfileAccount.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { act, render } from '@testing-library/react';
+import { act, fireEvent, render } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 
 import { enMessages } from '../../../lang/locales/en_US';
@@ -62,5 +62,23 @@ describe('ProfileAccount', () => {
     act(() => getLogoProps(expectedImageWidth).setUploadedFiles([{ ...uploadedLogo, isRemoved: true }]));
 
     expect(getLogoProps(expectedImageWidth).uploadedFiles).toEqual([]);
+  });
+
+  it('keeps the uploaded logo after an unrelated field change', () => {
+    const uploadedLogo: TUploadedFile = {
+      id: 'new-logo',
+      name: 'new-logo.png',
+      size: 100,
+      url: 'https://example.com/new-logo.png',
+      thumbnailUrl: 'https://example.com/new-logo.png',
+    };
+
+    const { getByDisplayValue } = renderProfileAccount();
+
+    act(() => getLogoProps(80).setUploadedFiles([uploadedLogo]));
+
+    fireEvent.change(getByDisplayValue('Acme'), { target: { value: 'Acme Inc' } });
+
+    expect(getLogoProps(80).uploadedFiles[0]?.url).toBe(uploadedLogo.url);
   });
 });

--- a/frontend/src/public/components/ProfileAccount/__tests__/ProfileAccount.test.tsx
+++ b/frontend/src/public/components/ProfileAccount/__tests__/ProfileAccount.test.tsx
@@ -6,7 +6,7 @@ import { enMessages } from '../../../lang/locales/en_US';
 import { ESubscriptionPlan } from '../../../types/account';
 import { TUploadedFile } from '../../../utils/uploadFiles';
 import { AttachmentField, IAttachmentFieldProps } from '../../UI/Fields/AttachmentField';
-import { ProfileAccount } from '../ProfileAccount';
+import { IProfileAccountProps, ProfileAccount } from '../ProfileAccount';
 
 jest.mock('../../UI/Fields/AttachmentField', () => ({
   AttachmentField: jest.fn(() => null),
@@ -19,22 +19,34 @@ const getLogoProps = (expectedImageWidth: number) => (
     .find(([props]) => props.expectedImageWidth === expectedImageWidth)?.[0] as IAttachmentFieldProps
 );
 
-const renderProfileAccount = () => render(
+const defaultProps: IProfileAccountProps = {
+  accountId: 1,
+  name: 'Acme',
+  logoSm: 'https://example.com/old-small.png',
+  logoLg: 'https://example.com/old-large.png',
+  loading: false,
+  leaseLevel: 'standard',
+  billingPlan: ESubscriptionPlan.Premium,
+  isAdmin: true,
+  editCurrentAccount: jest.fn(),
+  onChangeTab: jest.fn(),
+};
+
+const getMarkup = (props: Partial<IProfileAccountProps> = {}) => (
   <IntlProvider locale="en" messages={enMessages}>
-    <ProfileAccount
-      accountId={1}
-      name="Acme"
-      logoSm="https://example.com/old-small.png"
-      logoLg="https://example.com/old-large.png"
-      loading={false}
-      leaseLevel="standard"
-      billingPlan={ESubscriptionPlan.Premium}
-      isAdmin
-      editCurrentAccount={jest.fn()}
-      onChangeTab={jest.fn()}
-    />
-  </IntlProvider>,
+    <ProfileAccount {...defaultProps} {...props} />
+  </IntlProvider>
 );
+
+const renderProfileAccount = (props: Partial<IProfileAccountProps> = {}) => render(getMarkup(props));
+
+const uploadedLogo: TUploadedFile = {
+  id: 'new-logo',
+  name: 'new-logo.png',
+  size: 100,
+  url: 'https://example.com/new-logo.png',
+  thumbnailUrl: 'https://example.com/new-logo.png',
+};
 
 describe('ProfileAccount', () => {
   beforeEach(() => {
@@ -45,14 +57,6 @@ describe('ProfileAccount', () => {
     ['small', 80],
     ['large', 340],
   ])('updates the %s logo preview before the form is saved', (_, expectedImageWidth) => {
-    const uploadedLogo: TUploadedFile = {
-      id: 'new-logo',
-      name: 'new-logo.png',
-      size: 100,
-      url: 'https://example.com/new-logo.png',
-      thumbnailUrl: 'https://example.com/new-logo.png',
-    };
-
     renderProfileAccount();
 
     act(() => getLogoProps(expectedImageWidth).setUploadedFiles([uploadedLogo]));
@@ -65,54 +69,23 @@ describe('ProfileAccount', () => {
   });
 
   it('shows saved logos after account data arrives', () => {
-    const { rerender } = render(
-      <IntlProvider locale="en" messages={enMessages}>
-        <ProfileAccount
-          name=""
-          logoSm={null}
-          logoLg={null}
-          loading
-          leaseLevel="standard"
-          billingPlan={ESubscriptionPlan.Premium}
-          isAdmin
-          editCurrentAccount={jest.fn()}
-          onChangeTab={jest.fn()}
-        />
-      </IntlProvider>,
-    );
+    const { rerender } = renderProfileAccount({
+      accountId: undefined,
+      name: '',
+      logoSm: null,
+      logoLg: null,
+      loading: true,
+    });
 
     expect(attachmentFieldMock).not.toHaveBeenCalled();
 
-    rerender(
-      <IntlProvider locale="en" messages={enMessages}>
-        <ProfileAccount
-          accountId={1}
-          name="Acme"
-          logoSm="https://example.com/old-small.png"
-          logoLg="https://example.com/old-large.png"
-          loading={false}
-          leaseLevel="standard"
-          billingPlan={ESubscriptionPlan.Premium}
-          isAdmin
-          editCurrentAccount={jest.fn()}
-          onChangeTab={jest.fn()}
-        />
-      </IntlProvider>,
-    );
+    rerender(getMarkup());
 
-    expect(getLogoProps(80).uploadedFiles[0]?.url).toBe('https://example.com/old-small.png');
-    expect(getLogoProps(340).uploadedFiles[0]?.url).toBe('https://example.com/old-large.png');
+    expect(getLogoProps(80).uploadedFiles[0]?.url).toBe(defaultProps.logoSm);
+    expect(getLogoProps(340).uploadedFiles[0]?.url).toBe(defaultProps.logoLg);
   });
 
   it('keeps the uploaded logo after an unrelated field change', () => {
-    const uploadedLogo: TUploadedFile = {
-      id: 'new-logo',
-      name: 'new-logo.png',
-      size: 100,
-      url: 'https://example.com/new-logo.png',
-      thumbnailUrl: 'https://example.com/new-logo.png',
-    };
-
     const { getByDisplayValue } = renderProfileAccount();
 
     act(() => getLogoProps(80).setUploadedFiles([uploadedLogo]));
@@ -120,5 +93,19 @@ describe('ProfileAccount', () => {
     fireEvent.change(getByDisplayValue('Acme'), { target: { value: 'Acme Inc' } });
 
     expect(getLogoProps(80).uploadedFiles[0]?.url).toBe(uploadedLogo.url);
+  });
+
+  it('disables the submit button once the saved logo comes back from the server', () => {
+    const savedLogoUrl = 'https://cdn.example.com/new-logo.png';
+    const { getByRole, rerender } = renderProfileAccount();
+
+    act(() => getLogoProps(80).setUploadedFiles([uploadedLogo]));
+
+    expect(getByRole('button', { name: 'Save changes' })).toBeEnabled();
+
+    rerender(getMarkup({ logoSm: savedLogoUrl }));
+
+    expect(getByRole('button', { name: 'Save changes' })).toBeDisabled();
+    expect(getLogoProps(80).uploadedFiles[0]?.url).toBe(savedLogoUrl);
   });
 });

--- a/frontend/src/public/components/UI/Fields/AttachmentField/AttachmentField.css
+++ b/frontend/src/public/components/UI/Fields/AttachmentField/AttachmentField.css
@@ -172,3 +172,7 @@
   line-height: 16px;
   color: var(--pneumatic-color-black48);
 }
+
+.preview-container {
+  margin-top: 8px;
+}

--- a/frontend/src/public/components/UI/Fields/AttachmentField/AttachmentField.tsx
+++ b/frontend/src/public/components/UI/Fields/AttachmentField/AttachmentField.tsx
@@ -76,15 +76,15 @@ export function AttachmentField({
   ...props
 }: IAttachmentFieldProps) {
   const { messages, formatMessage } = useIntl();
-  const inputRef = inputRefProp || React.useRef(null);
+  const fallbackInputRef = React.useRef<HTMLInputElement>(null);
+  const inputRef = inputRefProp || fallbackInputRef;
   const normalizedErrorMessage = errorMessage && (messages[errorMessage] || errorMessage);
-  const uploadFieldRef = React.createRef<HTMLInputElement>();
+  const uploadFieldRef = React.useRef<HTMLInputElement>(null);
   const [isUploading, setUploadingState] = React.useState(false);
   const [filesToUploadState, setFilesToUploadState] = React.useState<TUploadedFile[]>(uploadedFiles);
+  const filesToUploadRef = React.useRef(filesToUploadState);
 
-  React.useEffect(() => {
-    setFilesToUploadState(uploadedFiles);
-  }, [uploadedFiles]);
+  filesToUploadRef.current = filesToUploadState;
 
   React.useEffect(() => {
     // clear file input value after uploading
@@ -147,8 +147,9 @@ export function AttachmentField({
 
       const allFiles =
         isMultiple || !isArrayWithItems(newFileWithThumbnailUrl)
-          ? [...filesToUploadState, ...(newFileWithThumbnailUrl as TUploadedFile[])]
+          ? [...filesToUploadRef.current, ...(newFileWithThumbnailUrl as TUploadedFile[])]
           : [...newFileWithThumbnailUrl];
+      filesToUploadRef.current = allFiles;
       setFilesToUploadState(allFiles);
       setUploadedFiles(allFiles);
     } catch (error) {
@@ -160,7 +161,10 @@ export function AttachmentField({
   };
 
   const handleDeleteFile = (id: string) => () => {
-    const newUploadedFiles = filesToUploadState.map((file) => (file.id === id ? { ...file, isRemoved: true } : file));
+    const newUploadedFiles = filesToUploadRef.current.map((file) => (
+      file.id === id ? { ...file, isRemoved: true } : file
+    ));
+    filesToUploadRef.current = newUploadedFiles;
     setFilesToUploadState(newUploadedFiles);
     setUploadedFiles(newUploadedFiles);
   };
@@ -231,12 +235,14 @@ export function AttachmentField({
       {normalizedErrorMessage && <p className={styles['error-text']}>{normalizedErrorMessage}</p>}
       {description && <p className={styles['field-description']}>{description}</p>}
 
-      <ExtraFieldFilesGrid
-        attachments={filesToUploadState}
-        deleteFile={handleDeleteFile}
-        isUploading={isUploading}
-        isEdit={canDeleteUploadedFiles}
-      />
+      <div className={styles['preview-container']}>
+        <ExtraFieldFilesGrid
+          attachments={filesToUploadState}
+          deleteFile={handleDeleteFile}
+          isUploading={isUploading}
+          isEdit={canDeleteUploadedFiles}
+        />
+      </div>
     </div>
   );
 }

--- a/frontend/src/public/components/UI/Fields/AttachmentField/AttachmentField.tsx
+++ b/frontend/src/public/components/UI/Fields/AttachmentField/AttachmentField.tsx
@@ -271,8 +271,10 @@ export function AttachmentField({
   );
 }
 
+// Ids differ between a freshly uploaded file and the same file rebuilt by the parent, so only urls are compared
 const getFilesSignature = (files: TUploadedFile[]): string => {
   return files
-    .map((file) => `${file.id}:${file.url}:${file.isRemoved ? '1' : '0'}`)
+    .filter((file) => !file.isRemoved)
+    .map((file) => file.url)
     .join('|');
 };

--- a/frontend/src/public/components/UI/Fields/AttachmentField/AttachmentField.tsx
+++ b/frontend/src/public/components/UI/Fields/AttachmentField/AttachmentField.tsx
@@ -83,8 +83,29 @@ export function AttachmentField({
   const [isUploading, setUploadingState] = React.useState(false);
   const [filesToUploadState, setFilesToUploadState] = React.useState<TUploadedFile[]>(uploadedFiles);
   const filesToUploadRef = React.useRef(filesToUploadState);
+  const hasPendingLocalChangeRef = React.useRef(false);
 
   filesToUploadRef.current = filesToUploadState;
+
+  React.useEffect(() => {
+    const parentSignature = getFilesSignature(uploadedFiles);
+    const localSignature = getFilesSignature(filesToUploadRef.current);
+
+    if (hasPendingLocalChangeRef.current) {
+      if (parentSignature === localSignature) {
+        hasPendingLocalChangeRef.current = false;
+      }
+
+      return;
+    }
+
+    if (parentSignature === localSignature) {
+      return;
+    }
+
+    filesToUploadRef.current = uploadedFiles;
+    setFilesToUploadState(uploadedFiles);
+  }, [uploadedFiles]);
 
   React.useEffect(() => {
     // clear file input value after uploading
@@ -94,6 +115,13 @@ export function AttachmentField({
       current.value = '';
     }
   }, [filesToUploadState]);
+
+  const applyLocalFiles = (files: TUploadedFile[]) => {
+    hasPendingLocalChangeRef.current = true;
+    filesToUploadRef.current = files;
+    setFilesToUploadState(files);
+    setUploadedFiles(files);
+  };
 
   const handleOpenUploadWindow = () => {
     if (!uploadFieldRef.current) {
@@ -149,9 +177,7 @@ export function AttachmentField({
         isMultiple || !isArrayWithItems(newFileWithThumbnailUrl)
           ? [...filesToUploadRef.current, ...(newFileWithThumbnailUrl as TUploadedFile[])]
           : [...newFileWithThumbnailUrl];
-      filesToUploadRef.current = allFiles;
-      setFilesToUploadState(allFiles);
-      setUploadedFiles(allFiles);
+      applyLocalFiles(allFiles);
     } catch (error) {
       NotificationManager.warning({ message: 'workflows.tasks-failed-to-upload-files' });
       logger.error(error);
@@ -164,9 +190,7 @@ export function AttachmentField({
     const newUploadedFiles = filesToUploadRef.current.map((file) => (
       file.id === id ? { ...file, isRemoved: true } : file
     ));
-    filesToUploadRef.current = newUploadedFiles;
-    setFilesToUploadState(newUploadedFiles);
-    setUploadedFiles(newUploadedFiles);
+    applyLocalFiles(newUploadedFiles);
   };
 
   const renderInput = () => {
@@ -246,3 +270,9 @@ export function AttachmentField({
     </div>
   );
 }
+
+const getFilesSignature = (files: TUploadedFile[]): string => {
+  return files
+    .map((file) => `${file.id}:${file.url}:${file.isRemoved ? '1' : '0'}`)
+    .join('|');
+};

--- a/frontend/src/public/components/UI/Fields/AttachmentField/__tests__/AttachmentField.test.tsx
+++ b/frontend/src/public/components/UI/Fields/AttachmentField/__tests__/AttachmentField.test.tsx
@@ -144,6 +144,44 @@ describe('AttachmentField', () => {
     expect(screen.getByAltText(savedLogo.name)).toBeInTheDocument();
   });
 
+  it('should show the stored file when the parent saves the upload under another url', async () => {
+    mockedUploadFiles.mockResolvedValue([uploadedLogo]);
+    const storedLogo: TUploadedFile = {
+      id: 'https://cdn.example.com/new-logo.png',
+      name: '',
+      url: 'https://cdn.example.com/new-logo.png',
+      thumbnailUrl: 'https://cdn.example.com/new-logo.png',
+      size: 0,
+    };
+    const { rerender, container } = renderField();
+
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['logo'], 'new-logo.png', { type: 'image/png' });
+
+    await act(async () => {
+      fireEvent.change(fileInput, { target: { files: [file] } });
+    });
+
+    const renderWithFiles = (files: TUploadedFile[]) => rerender(
+      <IntlProvider locale="en" messages={enMessages}>
+        <AttachmentField
+          accountId={1}
+          uploadedFiles={files}
+          setUploadedFiles={jest.fn()}
+          acceptedType="image"
+          expectedImageWidth={80}
+          expectedImageHeight={80}
+        />
+      </IntlProvider>,
+    );
+
+    renderWithFiles([{ ...uploadedLogo, id: uploadedLogo.url, name: '' }]);
+    renderWithFiles([storedLogo]);
+
+    expect(screen.getByAltText(storedLogo.url)).toBeInTheDocument();
+    expect(screen.queryByAltText(uploadedLogo.name)).not.toBeInTheDocument();
+  });
+
   it('should keep the local preview when the parent re-renders with the previously saved file', async () => {
     mockedUploadFiles.mockResolvedValue([uploadedLogo]);
     const { rerender, container } = renderField();

--- a/frontend/src/public/components/UI/Fields/AttachmentField/__tests__/AttachmentField.test.tsx
+++ b/frontend/src/public/components/UI/Fields/AttachmentField/__tests__/AttachmentField.test.tsx
@@ -1,0 +1,154 @@
+import * as React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+
+import { enMessages } from '../../../../../lang/locales/en_US';
+import { TUploadedFile, uploadFiles } from '../../../../../utils/uploadFiles';
+import { AttachmentField } from '../AttachmentField';
+import { getImageDimensions } from '../utils/getImageDimensions';
+
+jest.mock('../../../../../utils/uploadFiles', () => ({
+  uploadFiles: jest.fn(),
+  MAX_FILE_SIZE: 100 * 1024 * 1024,
+}));
+
+jest.mock('../utils/getImageDimensions', () => ({
+  getImageDimensions: jest.fn(),
+}));
+
+jest.mock('../../../../TemplateEdit/ExtraFields/File/ExtraFieldFilesGrid', () => ({
+  ExtraFieldFilesGrid: ({
+    attachments,
+    deleteFile,
+  }: {
+    attachments: TUploadedFile[];
+    deleteFile?(id: string): () => void;
+  }) => (
+    <div>
+      {attachments
+        .filter((file) => !file.isRemoved && file.thumbnailUrl)
+        .map((file) => (
+          <div key={file.id}>
+            <img alt={file.name || file.url} src={file.thumbnailUrl} />
+            {deleteFile && (
+              <button type="button" onClick={deleteFile(file.id)}>
+                remove
+              </button>
+            )}
+          </div>
+        ))}
+    </div>
+  ),
+}));
+
+const mockedUploadFiles = uploadFiles as jest.MockedFunction<typeof uploadFiles>;
+const mockedGetImageDimensions = getImageDimensions as jest.MockedFunction<typeof getImageDimensions>;
+
+const savedLogo: TUploadedFile = {
+  id: 'saved-logo',
+  name: 'old-logo.png',
+  url: 'https://example.com/old-logo.png',
+  thumbnailUrl: 'https://example.com/old-logo.png',
+  size: 10,
+};
+
+const uploadedLogo: TUploadedFile = {
+  id: 'new-logo',
+  name: 'new-logo.png',
+  url: 'https://example.com/new-logo.png',
+  thumbnailUrl: 'https://example.com/new-logo.png',
+  size: 20,
+};
+
+const renderField = (
+  props: Partial<React.ComponentProps<typeof AttachmentField>> = {},
+) => {
+  const setUploadedFiles = props.setUploadedFiles || jest.fn();
+
+  return {
+    setUploadedFiles,
+    ...render(
+      <IntlProvider locale="en" messages={enMessages}>
+        <AttachmentField
+          accountId={1}
+          uploadedFiles={[savedLogo]}
+          setUploadedFiles={setUploadedFiles}
+          acceptedType="image"
+          expectedImageWidth={80}
+          expectedImageHeight={80}
+          {...props}
+        />
+      </IntlProvider>,
+    ),
+  };
+};
+
+describe('AttachmentField', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedGetImageDimensions.mockResolvedValue({ width: 80, height: 80 });
+  });
+
+  it('should show the uploaded image before the parent saves the new url', async () => {
+    mockedUploadFiles.mockResolvedValue([uploadedLogo]);
+    const { setUploadedFiles, container } = renderField();
+
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['logo'], 'new-logo.png', { type: 'image/png' });
+
+    await act(async () => {
+      fireEvent.change(fileInput, { target: { files: [file] } });
+    });
+
+    expect(await screen.findByAltText(uploadedLogo.name)).toBeInTheDocument();
+    expect(screen.queryByAltText(savedLogo.name)).not.toBeInTheDocument();
+    expect(setUploadedFiles).toHaveBeenCalledWith([
+      expect.objectContaining({ url: uploadedLogo.url, thumbnailUrl: uploadedLogo.url }),
+    ]);
+  });
+
+  it('should hide the image after delete before the parent saves', async () => {
+    const { setUploadedFiles } = renderField();
+
+    expect(screen.getByAltText(savedLogo.name)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'remove' }));
+
+    await waitFor(() => {
+      expect(screen.queryByAltText(savedLogo.name)).not.toBeInTheDocument();
+    });
+    expect(setUploadedFiles).toHaveBeenCalledWith([
+      expect.objectContaining({ id: savedLogo.id, isRemoved: true }),
+    ]);
+  });
+
+  it('should keep the local preview when the parent re-renders with the previously saved file', async () => {
+    mockedUploadFiles.mockResolvedValue([uploadedLogo]);
+    const { rerender, container } = renderField();
+
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['logo'], 'new-logo.png', { type: 'image/png' });
+
+    await act(async () => {
+      fireEvent.change(fileInput, { target: { files: [file] } });
+    });
+
+    expect(await screen.findByAltText(uploadedLogo.name)).toBeInTheDocument();
+
+    rerender(
+      <IntlProvider locale="en" messages={enMessages}>
+        <AttachmentField
+          accountId={1}
+          uploadedFiles={[{ ...savedLogo }]}
+          setUploadedFiles={jest.fn()}
+          acceptedType="image"
+          expectedImageWidth={80}
+          expectedImageHeight={80}
+        />
+      </IntlProvider>,
+    );
+
+    expect(screen.getByAltText(uploadedLogo.name)).toBeInTheDocument();
+    expect(screen.queryByAltText(savedLogo.name)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/public/components/UI/Fields/AttachmentField/__tests__/AttachmentField.test.tsx
+++ b/frontend/src/public/components/UI/Fields/AttachmentField/__tests__/AttachmentField.test.tsx
@@ -122,6 +122,28 @@ describe('AttachmentField', () => {
     ]);
   });
 
+  it('should show files when the parent hydrates uploadedFiles after mount', () => {
+    const { rerender } = renderField({ uploadedFiles: [] });
+
+    expect(screen.queryByAltText(savedLogo.name)).not.toBeInTheDocument();
+    expect(screen.queryByAltText(savedLogo.url)).not.toBeInTheDocument();
+
+    rerender(
+      <IntlProvider locale="en" messages={enMessages}>
+        <AttachmentField
+          accountId={1}
+          uploadedFiles={[savedLogo]}
+          setUploadedFiles={jest.fn()}
+          acceptedType="image"
+          expectedImageWidth={80}
+          expectedImageHeight={80}
+        />
+      </IntlProvider>,
+    );
+
+    expect(screen.getByAltText(savedLogo.name)).toBeInTheDocument();
+  });
+
   it('should keep the local preview when the parent re-renders with the previously saved file', async () => {
     mockedUploadFiles.mockResolvedValue([uploadedLogo]);
     const { rerender, container } = renderField();

--- a/frontend/src/public/redux/auth/__tests__/reducer.test.ts
+++ b/frontend/src/public/redux/auth/__tests__/reducer.test.ts
@@ -9,6 +9,7 @@ import { INIT_STATE, reducer } from '../reducer';
 import {
   authUserFail,
   authUserSuccess,
+  editCurrentAccountSuccess,
   loginUser,
   registerUserSuccess,
   TAuthActions,
@@ -56,6 +57,20 @@ describe('auth reducer', () => {
     const result = reducer(INIT_STATE, action);
 
     expect(result).toEqual({ ...INIT_STATE, error: EAuthUserFailType.Common, loading: false });
+  });
+  it('upon successful account edit, stores the saved logos', () => {
+    const action = editCurrentAccountSuccess({
+      name: 'User Corp',
+      logoSm: 'https://cdn.pneumatic.app/logo-sm.png',
+      logoLg: 'https://cdn.pneumatic.app/logo-lg.png',
+    });
+    const state = { ...INIT_STATE, loading: true };
+
+    const result = reducer(state, action);
+
+    expect(result.account.logoSm).toBe('https://cdn.pneumatic.app/logo-sm.png');
+    expect(result.account.logoLg).toBe('https://cdn.pneumatic.app/logo-lg.png');
+    expect(result.loading).toBe(false);
   });
   it('upon successful user registration, returns a new state with user data', () => {
     const action = registerUserSuccess(mockUser);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Scoped to account settings UI, attachment preview state, and API typing; no auth or backend logic changes beyond typing saved logo URLs.
> 
> **Overview**
> Fixes **account logo** UX in company settings: previews show while data loads and after upload/delete, without flicker or reverting when other fields change.
> 
> **`ProfileAccount`** now runs hooks before the empty-state return so logos appear when account data hydrates. Form state resets from saved props after save; dirty state is derived from props vs. local state. Logo `AttachmentField`s get stable memoized file lists, dedicated upload handlers, and remount keys per account; saved URLs use the URL as file `id` so parent/child stay aligned.
> 
> **`AttachmentField`** keeps local upload/delete previews when the parent still passes stale `uploadedFiles`, using a pending-local-change flag and URL-based `getFilesSignature` sync. Preview grid gets **8px** top spacing per mockups.
> 
> **`editAccount`** response/updated-account types now include **`logoSm` / `logoLg`** so Redux can persist saved logos after edit; tests cover `ProfileAccount`, `AttachmentField`, and auth reducer behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb63407be4eebb2bdf1f71aaae38a0dd0d345c52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix logo preview sync in `ProfileAccount` and align `AttachmentField` with mockups
> - Adds nullable `small-logo` and `large-logo` fields to account edit response types in [editAccount.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/357/files#diff-66585bb775cbc120f9689307ecddad62883ce416d647e9213b378f12e6e006f2).
> - Refactors [ProfileAccount.tsx](https://github.com/pneumaticapp/pneumaticworkflow/pull/357/files#diff-680843dbe1ea5ab540c5388698446b40e8bd0812419edfd2317687b65f2f1f1e) to hydrate data after mount and track saved state via refs, preventing loss of local edits during unrelated re-renders.
> - Updates [AttachmentField.tsx](https://github.com/pneumaticapp/pneumaticworkflow/pull/357/files#diff-965bd8d191b2c24822e0210cf73d08f6df740fe09e8c37f2fa9db0b357faa292) to keep local file previews visible until the parent acknowledges the change, ignoring stale parent props using a new `getFilesSignature` helper.
> - Adds 8px top margin to the preview grid in [AttachmentField.css](https://github.com/pneumaticapp/pneumaticworkflow/pull/357/files#diff-d7d0ee2d5f742f14a708aec83ace8cc3c4e78ff0d658d115b0853d214d429685) to match mockups.
> - Behavioral Change: `getFileByUrl` now uses the source URL as the synthetic file identifier, and `ProfileAccount` uses account-specific keys to remount `AttachmentField` when the account changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eb63407.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->