### PR TITLE
38008 frontend [ highlights ] resolve date filter ranges in the profile timezone

### DIFF
--- a/frontend/src/public/components/Highlights/HighlightsFeed.tsx
+++ b/frontend/src/public/components/Highlights/HighlightsFeed.tsx
@@ -7,7 +7,7 @@ import { ERoutes } from '../../constants/routes';
 import { EHighlightsDateFilter, EHighlightsFilterType, IHighlightsItem } from '../../types/highlights';
 import { TITLES } from '../../constants/titles';
 import { history } from '../../utils/history';
-import { getHighlightsDateRange } from '../../utils/highlightsDateRange';
+import { getHighlightsDateRange, IHighlightsDateRange } from '../../utils/highlightsDateRange';
 import { UsersFilter } from './UsersFilter';
 import { ILoadHighlightsConfig } from '../../redux/highlights/actions';
 import { IHighlightsFilters } from '../../types/redux';
@@ -73,12 +73,13 @@ export function HighlightsFeed({
   loadTemplatesTitles,
   setFiltersChanged,
 }: IHighlightsFeedProps) {
-  const { useCallback, useEffect, useMemo, useState } = React;
+  const { useCallback, useEffect, useMemo, useRef, useState } = React;
   const { formatMessage } = useIntl();
   const { timezone, dateFdw } = useDatePickerSettings();
 
   const [isFirstFetch, setIsFirstFetch] = useState(true);
   const [isDateFilterReady, setIsDateFilterReady] = useState(true);
+  const pendingInitialRangeRef = useRef<IHighlightsDateRange | null>(null);
 
   useEffect(() => {
     document.title = TITLES.WorkflowHighlights;
@@ -88,6 +89,7 @@ export function HighlightsFeed({
     const currentRange = getHighlightsDateRange(timeRange, timezone, dateFdw);
 
     if (currentRange) {
+      pendingInitialRangeRef.current = currentRange;
       setFilters(currentRange);
     }
 
@@ -100,6 +102,18 @@ export function HighlightsFeed({
   }, []);
 
   useEffect(() => {
+    // Titles are fetched with takeEvery, so a request sent with the pre-recomputed range could resolve
+    // last and overwrite the right one. Wait for the props to carry the range the mount effect applied.
+    const pendingRange = pendingInitialRangeRef.current;
+
+    if (pendingRange) {
+      if (pendingRange.startDate !== startDate || pendingRange.endDate !== endDate) {
+        return;
+      }
+
+      pendingInitialRangeRef.current = null;
+    }
+
     loadTemplatesTitles({ eventDateFrom: startDate, eventDateTo: endDate });
   }, [endDate, startDate]);
 

--- a/frontend/src/public/components/Highlights/HighlightsFeed.tsx
+++ b/frontend/src/public/components/Highlights/HighlightsFeed.tsx
@@ -7,11 +7,11 @@ import { ERoutes } from '../../constants/routes';
 import { EHighlightsDateFilter, EHighlightsFilterType, IHighlightsItem } from '../../types/highlights';
 import { TITLES } from '../../constants/titles';
 import { history } from '../../utils/history';
-import { PROCESS_HIGHLIGHTS_DATE_RANGE_MAP } from '../../utils/dateTime';
+import { getHighlightsDateRange } from '../../utils/highlightsDateRange';
 import { UsersFilter } from './UsersFilter';
 import { ILoadHighlightsConfig } from '../../redux/highlights/actions';
 import { IHighlightsFilters } from '../../types/redux';
-import { INIT_FILTERS } from '../../redux/highlights/reducer';
+import { getInitHighlightsFilters } from '../../redux/highlights/reducer';
 import { isArrayWithItems } from '../../utils/helpers';
 import { TUserListItem } from '../../types/user';
 import { ITemplateTitleBaseWithCount } from '../../types/template';
@@ -26,6 +26,7 @@ import styles from './HighlightsFeed.css';
 import { EPageTitle } from '../../constants/defaultValues';
 import { PageTitle } from '../PageTitle/PageTitle';
 import { IGetHighlightsTitlesRequestConfig } from '../../api/getHighlightsTitles';
+import { useDatePickerSettings } from '../../hooks/useDatePickerSettings';
 
 export interface IHighlightsFeedProps {
   count: number;
@@ -74,12 +75,21 @@ export function HighlightsFeed({
 }: IHighlightsFeedProps) {
   const { useCallback, useEffect, useMemo, useState } = React;
   const { formatMessage } = useIntl();
+  const { timezone, dateFdw } = useDatePickerSettings();
 
   const [isFirstFetch, setIsFirstFetch] = useState(true);
   const [isDateFilterReady, setIsDateFilterReady] = useState(true);
 
   useEffect(() => {
     document.title = TITLES.WorkflowHighlights;
+
+    // The store and the query-string defaults are built without the profile timezone, and a tab left
+    // open overnight still holds the previous day, so a preset range is recomputed before the first fetch.
+    const currentRange = getHighlightsDateRange(timeRange, timezone, dateFdw);
+
+    if (currentRange) {
+      setFilters(currentRange);
+    }
 
     loadHighlights({ onScroll: true });
     setIsFirstFetch(false);
@@ -167,15 +177,11 @@ export function HighlightsFeed({
         return;
       }
 
-      setFilters({ timeRange: selectedTimeRange });
+      const newRange = getHighlightsDateRange(selectedTimeRange, timezone, dateFdw);
 
-      if (selectedTimeRange !== EHighlightsDateFilter.Custom) {
-        const { startDate: newStartDate, endDate: newEndDate } = PROCESS_HIGHLIGHTS_DATE_RANGE_MAP[selectedTimeRange];
-
-        setFilters({ startDate: newStartDate, endDate: newEndDate });
-      }
+      setFilters({ timeRange: selectedTimeRange, ...newRange });
     },
-    [timeRange],
+    [timeRange, timezone, dateFdw],
   );
 
   const handleApplyFilters = () => {
@@ -184,7 +190,9 @@ export function HighlightsFeed({
   };
 
   const handleClearFilters = () => {
-    setFilters(INIT_FILTERS);
+    const initFilters = getInitHighlightsFilters();
+
+    setFilters({ ...initFilters, ...getHighlightsDateRange(initFilters.timeRange, timezone, dateFdw) });
 
     loadHighlights({});
   };

--- a/frontend/src/public/components/Highlights/__tests__/HighlightsFeed.test.tsx
+++ b/frontend/src/public/components/Highlights/__tests__/HighlightsFeed.test.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { IntlProvider } from 'react-intl';
+
+import { HighlightsFeed, IHighlightsFeedProps } from '../HighlightsFeed';
+import { EHighlightsDateFilter } from '../../../types/highlights';
+import { enMessages } from '../../../lang/locales/en_US';
+import { ELocale } from '../../../types/redux';
+
+/** +05:00 all year: the profile timezone the reporter used, five hours ahead of the test clock. */
+const TIMEZONE = 'Asia/Yekaterinburg';
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: (selector: (state: unknown) => unknown) =>
+    selector({
+      authUser: {
+        timezone: TIMEZONE,
+        language: ELocale.English,
+        dateFdw: '1',
+      },
+    }),
+}));
+
+/** Wednesday, 27 Nov 2024, 15:03 in +05:00 — while the browser clock is still on 10:03 UTC. */
+const MIDDAY_IN_ZONE = '2024-11-27T10:03:00.000Z';
+
+const START_OF_TODAY_IN_ZONE = '2024-11-26T19:00:00.000Z';
+const END_OF_TODAY_IN_ZONE = '2024-11-27T18:59:59.000Z';
+
+let nowSpy: jest.SpyInstance;
+
+const renderFeed = (props: Partial<IHighlightsFeedProps> = {}) => {
+  const defaultProps: IHighlightsFeedProps = {
+    count: 0,
+    isFeedLoading: false,
+    isTemplatesTitlesLoading: false,
+    items: [],
+    workflowId: null,
+    users: [],
+    templatesTitles: [],
+    timeRange: EHighlightsDateFilter.Today,
+    // A stale range, as the store holds it after the bundle has been loaded on the previous day.
+    startDate: new Date('2024-11-25T00:00:00.000Z'),
+    endDate: new Date('2024-11-25T23:59:59.999Z'),
+    usersFilter: [],
+    templatesFilter: [],
+    filtersChanged: false,
+    loadHighlights: jest.fn(),
+    openWorkflowLogPopup: jest.fn(),
+    resetHightlightsStore: jest.fn(),
+    loadTemplatesTitles: jest.fn(),
+    setFilters: jest.fn(),
+    setFiltersChanged: jest.fn(),
+    ...props,
+  };
+
+  render(
+    <IntlProvider locale="en" messages={enMessages as unknown as Record<string, string>}>
+      <HighlightsFeed {...defaultProps} />
+    </IntlProvider>,
+  );
+
+  return defaultProps;
+};
+
+describe('HighlightsFeed date filters', () => {
+  beforeAll(() => {
+    nowSpy = jest.spyOn(Date, 'now');
+  });
+
+  beforeEach(() => {
+    nowSpy.mockReturnValue(new Date(MIDDAY_IN_ZONE).getTime());
+  });
+
+  afterAll(() => {
+    nowSpy.mockRestore();
+  });
+
+  it('recomputes the active preset in the profile timezone before the first fetch', () => {
+    const { setFilters, loadHighlights } = renderFeed();
+
+    expect(setFilters).toHaveBeenCalledWith({
+      startDate: new Date(START_OF_TODAY_IN_ZONE),
+      endDate: new Date(END_OF_TODAY_IN_ZONE),
+    });
+    expect(loadHighlights).toHaveBeenCalledWith({ onScroll: true });
+    expect((setFilters as jest.Mock).mock.invocationCallOrder[0]).toBeLessThan(
+      (loadHighlights as jest.Mock).mock.invocationCallOrder[0],
+    );
+  });
+
+  it('keeps a Custom range untouched on mount', () => {
+    const { setFilters } = renderFeed({ timeRange: EHighlightsDateFilter.Custom });
+
+    expect(setFilters).not.toHaveBeenCalled();
+  });
+
+  it('applies the profile timezone and the profile week start when a preset is picked', () => {
+    const { setFilters } = renderFeed();
+    (setFilters as jest.Mock).mockClear();
+
+    userEvent.click(screen.getByLabelText(enMessages['process-highlights.date-picker-week']));
+
+    // The profile starts weeks on Monday, so the range opens on Mon 25 Nov 00:00 +05:00.
+    expect(setFilters).toHaveBeenCalledTimes(1);
+    expect(setFilters).toHaveBeenCalledWith({
+      timeRange: EHighlightsDateFilter.Week,
+      startDate: new Date('2024-11-24T19:00:00.000Z'),
+      endDate: new Date('2024-12-01T18:59:59.000Z'),
+    });
+  });
+
+  it('closes a preset range on a whole second so it cannot round up into the next day', () => {
+    const { setFilters } = renderFeed();
+    (setFilters as jest.Mock).mockClear();
+
+    userEvent.click(screen.getByLabelText(enMessages['process-highlights.date-picker-yesterday']));
+
+    const [{ startDate, endDate }] = (setFilters as jest.Mock).mock.calls[0];
+
+    expect(startDate.toISOString()).toBe('2024-11-25T19:00:00.000Z');
+    expect(endDate.toISOString()).toBe('2024-11-26T18:59:59.000Z');
+    expect(endDate.getMilliseconds()).toBe(0);
+  });
+
+  it('switches to Custom without overwriting the picked range', () => {
+    const { setFilters } = renderFeed();
+    (setFilters as jest.Mock).mockClear();
+
+    userEvent.click(screen.getByLabelText(enMessages['process-highlights.date-picker-custom']));
+
+    expect(setFilters).toHaveBeenCalledWith({ timeRange: EHighlightsDateFilter.Custom });
+  });
+});

--- a/frontend/src/public/components/Highlights/__tests__/HighlightsFeed.test.tsx
+++ b/frontend/src/public/components/Highlights/__tests__/HighlightsFeed.test.tsx
@@ -5,6 +5,7 @@ import { IntlProvider } from 'react-intl';
 
 import { HighlightsFeed, IHighlightsFeedProps } from '../HighlightsFeed';
 import { EHighlightsDateFilter } from '../../../types/highlights';
+import { IHighlightsFilters } from '../../../types/redux';
 import { enMessages } from '../../../lang/locales/en_US';
 import { ELocale } from '../../../types/redux';
 
@@ -31,6 +32,10 @@ const END_OF_TODAY_IN_ZONE = '2024-11-27T18:59:59.000Z';
 
 let nowSpy: jest.SpyInstance;
 
+/**
+ * Mirrors the store round-trip: setFilters is recorded and also fed back as props, the way the
+ * connected component sees it. Without that the mount effect's correction would never reach the child.
+ */
 const renderFeed = (props: Partial<IHighlightsFeedProps> = {}) => {
   const defaultProps: IHighlightsFeedProps = {
     count: 0,
@@ -56,9 +61,36 @@ const renderFeed = (props: Partial<IHighlightsFeedProps> = {}) => {
     ...props,
   };
 
+  const Harness = () => {
+    const [range, setRange] = React.useState({
+      startDate: defaultProps.startDate,
+      endDate: defaultProps.endDate,
+    });
+
+    const handleSetFilters = (value: Partial<IHighlightsFilters>) => {
+      defaultProps.setFilters(value);
+
+      if (value.startDate || value.endDate) {
+        setRange((current) => ({
+          startDate: value.startDate ?? current.startDate,
+          endDate: value.endDate ?? current.endDate,
+        }));
+      }
+    };
+
+    return (
+      <HighlightsFeed
+        {...defaultProps}
+        startDate={range.startDate}
+        endDate={range.endDate}
+        setFilters={handleSetFilters}
+      />
+    );
+  };
+
   render(
     <IntlProvider locale="en" messages={enMessages as unknown as Record<string, string>}>
-      <HighlightsFeed {...defaultProps} />
+      <Harness />
     </IntlProvider>,
   );
 
@@ -89,6 +121,16 @@ describe('HighlightsFeed date filters', () => {
     expect((setFilters as jest.Mock).mock.invocationCallOrder[0]).toBeLessThan(
       (loadHighlights as jest.Mock).mock.invocationCallOrder[0],
     );
+  });
+
+  it('requests template titles once, with the corrected range', () => {
+    const { loadTemplatesTitles } = renderFeed();
+
+    expect(loadTemplatesTitles).toHaveBeenCalledTimes(1);
+    expect(loadTemplatesTitles).toHaveBeenCalledWith({
+      eventDateFrom: new Date(START_OF_TODAY_IN_ZONE),
+      eventDateTo: new Date(END_OF_TODAY_IN_ZONE),
+    });
   });
 
   it('keeps a Custom range untouched on mount', () => {

--- a/frontend/src/public/components/Highlights/container.ts
+++ b/frontend/src/public/components/Highlights/container.ts
@@ -1,4 +1,3 @@
-import { startOfToday, endOfToday, isValid } from 'date-fns';
 import { connect } from 'react-redux';
 import { AnyAction } from 'redux';
 
@@ -16,6 +15,8 @@ import { HighlightsFeed, IHighlightsFeedProps } from './HighlightsFeed';
 import { withSyncedQueryString } from '../../HOCs/withSyncedQueryString';
 import { EHighlightsDateFilter } from '../../types/highlights';
 import { getActiveUsers } from '../../utils/users';
+import { getTodayDateRange } from '../../utils/highlightsDateRange';
+import { parseDateQueryParam, serializeDateQueryParam } from './utils/dateQueryParam';
 
 type THighlightsFeedStoreProps = Pick<
   IHighlightsFeedProps,
@@ -97,40 +98,32 @@ const SyncedHiglights = withSyncedQueryString<THighlightsFeedStoreProps>([
   {
     propName: 'startDate',
     queryParamName: 'start-date',
-    defaultAction: setFilters({ startDate: startOfToday() }),
+    defaultAction: setFilters({ startDate: getTodayDateRange('').startDate }),
     createAction: (startDateQuery: string) => {
-      const formattedDateQuery = startDateQuery
-        .replace(/\(.*?\)/, '')
-        .replace('GMT ', 'GMT+')
-        .trim();
-      const startDate = new Date(formattedDateQuery);
+      const startDate = parseDateQueryParam(startDateQuery);
 
-      if (!isValid(startDate)) {
+      if (!startDate) {
         return { type: 'EMPTY_ACTION' } as AnyAction;
       }
 
       return setFilters({ startDate });
     },
-    getQueryParamByProp: (propValue: string) => propValue,
+    getQueryParamByProp: serializeDateQueryParam,
   },
   {
     propName: 'endDate',
     queryParamName: 'end-date',
-    defaultAction: setFilters({ endDate: endOfToday() }),
+    defaultAction: setFilters({ endDate: getTodayDateRange('').endDate }),
     createAction: (endDateQuery: string) => {
-      const formattedendDateQuery = endDateQuery
-        .replace(/\(.*?\)/, '')
-        .replace('GMT ', 'GMT+')
-        .trim();
-      const endDate = new Date(formattedendDateQuery);
+      const endDate = parseDateQueryParam(endDateQuery);
 
-      if (!isValid(endDate)) {
+      if (!endDate) {
         return { type: 'EMPTY_ACTION' } as AnyAction;
       }
 
       return setFilters({ endDate });
     },
-    getQueryParamByProp: (propValue: string) => propValue,
+    getQueryParamByProp: serializeDateQueryParam,
   },
   {
     propName: 'usersFilter',

--- a/frontend/src/public/components/Highlights/utils/__tests__/dateQueryParam.test.ts
+++ b/frontend/src/public/components/Highlights/utils/__tests__/dateQueryParam.test.ts
@@ -1,0 +1,40 @@
+import { parseDateQueryParam, serializeDateQueryParam } from '../dateQueryParam';
+import { getQueryStringByParams, getQueryStringParams } from '../../../../utils/history';
+
+describe('date query params', () => {
+  it('round-trips an instant through the query string without losing precision', () => {
+    const endOfDay = new Date('2024-11-27T18:59:59.000Z');
+
+    const search = getQueryStringByParams({ 'end-date': serializeDateQueryParam(endOfDay) });
+    const restored = parseDateQueryParam(getQueryStringParams(search)['end-date']);
+
+    expect(restored!.toISOString()).toBe(endOfDay.toISOString());
+  });
+
+  it('survives the query string turning "+" into a space, which broke the old text format', () => {
+    const date = new Date('2024-11-26T19:00:00.000Z');
+    const legacyParam = 'Wed Nov 27 2024 00:00:00 GMT+0500 (Yekaterinburg Standard Time)';
+
+    const legacySearch = getQueryStringByParams({ 'start-date': legacyParam });
+    const decodedLegacyParam = getQueryStringParams(legacySearch)['start-date'];
+
+    expect(decodedLegacyParam).toContain('GMT 0500');
+    expect(parseDateQueryParam(serializeDateQueryParam(date))!.toISOString()).toBe(date.toISOString());
+  });
+
+  it('still reads the legacy Date.toString() format so existing links keep working', () => {
+    const restored = parseDateQueryParam('Wed Nov 27 2024 00:00:00 GMT 0500 (Yekaterinburg Standard Time)');
+
+    expect(restored!.toISOString()).toBe('2024-11-26T19:00:00.000Z');
+  });
+
+  it('serializes an absent date to an empty param', () => {
+    expect(serializeDateQueryParam(null)).toBe('');
+    expect(serializeDateQueryParam(undefined)).toBe('');
+  });
+
+  it('returns null for an empty or unparsable param', () => {
+    expect(parseDateQueryParam('')).toBeNull();
+    expect(parseDateQueryParam('not-a-date')).toBeNull();
+  });
+});

--- a/frontend/src/public/components/Highlights/utils/dateQueryParam.ts
+++ b/frontend/src/public/components/Highlights/utils/dateQueryParam.ts
@@ -1,0 +1,29 @@
+/**
+ * Highlights keeps its date filters in the query string.
+ *
+ * They used to be serialized with `Date.prototype.toString()`, which loses milliseconds and whose
+ * `GMT+0500` suffix is decoded back as `GMT 0500`, because `getQueryStringByParams` does not encode
+ * its values and `getQueryStringParams` turns `+` into a space. A reload therefore returned a
+ * different instant than the one that was picked. Timestamps round-trip exactly and need no escaping.
+ */
+
+const LEGACY_GMT_SIGN_PATTERN = /GMT /;
+const LEGACY_TIMEZONE_NAME_PATTERN = /\(.*?\)/;
+
+export const serializeDateQueryParam = (date?: Date | null): string =>
+  date ? String(date.getTime()) : '';
+
+const restoreLegacyParam = (queryParam: string): string =>
+  queryParam.replace(LEGACY_TIMEZONE_NAME_PATTERN, '').replace(LEGACY_GMT_SIGN_PATTERN, 'GMT+').trim();
+
+/** Accepts the current timestamp format and the legacy `Date.toString()` one, so old links still open. */
+export const parseDateQueryParam = (queryParam: string): Date | null => {
+  if (!queryParam) {
+    return null;
+  }
+
+  const timestamp = Number(queryParam);
+  const date = Number.isFinite(timestamp) ? new Date(timestamp) : new Date(restoreLegacyParam(queryParam));
+
+  return Number.isNaN(date.getTime()) ? null : date;
+};

--- a/frontend/src/public/redux/highlights/reducer.ts
+++ b/frontend/src/public/redux/highlights/reducer.ts
@@ -1,20 +1,29 @@
 import produce from 'immer';
-import { endOfToday, startOfToday } from 'date-fns';
 
 import { IHighlightsStore, IHighlightsFilters } from '../../types/redux';
 import { IHighlightsItem, EHighlightsDateFilter } from '../../types/highlights';
 import { ITemplateTitleBaseWithCount } from '../../types/template';
+import { getTodayDateRange } from '../../utils/highlightsDateRange';
 
 import { THighlightsActions, EHighlightsActions } from './actions';
 import { EGeneralActions, TGeneralActions } from '../actions';
 
-export const INIT_FILTERS: IHighlightsFilters = {
-  timeRange: EHighlightsDateFilter.Today,
-  startDate: startOfToday(),
-  endDate: endOfToday(),
-  usersFilter: [],
-  templatesFilter: [],
-  filtersChanged: false,
+/**
+ * Built on every call: a module-level constant would freeze "today" at the moment the bundle loaded
+ * and keep serving it after midnight. The browser timezone is only a placeholder here — the reducer
+ * has no access to the profile one, so HighlightsFeed re-applies the range on mount.
+ */
+export const getInitHighlightsFilters = (): IHighlightsFilters => {
+  const { startDate, endDate } = getTodayDateRange('');
+
+  return {
+    timeRange: EHighlightsDateFilter.Today,
+    startDate,
+    endDate,
+    usersFilter: [],
+    templatesFilter: [],
+    filtersChanged: false,
+  };
 };
 
 const INIT_STATE: IHighlightsStore = {
@@ -24,7 +33,7 @@ const INIT_STATE: IHighlightsStore = {
   isTemplatesTitlesLoading: false,
   items: [] as IHighlightsItem[],
   templatesTitles: [] as ITemplateTitleBaseWithCount[],
-  filters: INIT_FILTERS,
+  filters: getInitHighlightsFilters(),
 };
 
 export const reducer = (state = INIT_STATE, action: THighlightsActions | TGeneralActions): IHighlightsStore => {
@@ -60,7 +69,7 @@ export const reducer = (state = INIT_STATE, action: THighlightsActions | TGenera
         draftState.filters.filtersChanged = true;
       });
     case EGeneralActions.ClearAppFilters:
-      return { ...state, filters: INIT_FILTERS };
+      return { ...state, filters: getInitHighlightsFilters() };
     default:
       return { ...state };
   }

--- a/frontend/src/public/utils/__tests__/highlightsDateRange.test.ts
+++ b/frontend/src/public/utils/__tests__/highlightsDateRange.test.ts
@@ -1,0 +1,154 @@
+import { getHighlightsDateRange, getTodayDateRange } from '../highlightsDateRange';
+import { EHighlightsDateFilter } from '../../types/highlights';
+
+/** +05:00 all year, so the expected instants stay readable and DST never enters the assertions. */
+const TIMEZONE = 'Asia/Yekaterinburg';
+const SUNDAY = '0';
+const MONDAY = '1';
+
+/** Wednesday, 27 Nov 2024, 15:03 in +05:00. */
+const MIDDAY_IN_ZONE = '2024-11-27T10:03:00.000Z';
+/** Still 27 Nov in UTC, but already 00:30 on 28 Nov in +05:00. */
+const AFTER_MIDNIGHT_IN_ZONE = '2024-11-27T19:30:00.000Z';
+
+let nowSpy: jest.SpyInstance;
+
+/** moment reads the clock through Date.now, so stubbing it is enough to pin "now". */
+const setNow = (iso: string) => {
+  nowSpy.mockReturnValue(new Date(iso).getTime());
+};
+
+const toISO = (date: Date) => date.toISOString();
+
+describe('getHighlightsDateRange', () => {
+  beforeAll(() => {
+    nowSpy = jest.spyOn(Date, 'now');
+  });
+
+  afterAll(() => {
+    nowSpy.mockRestore();
+  });
+
+  it('starts Today at midnight in the profile timezone, not at the current time', () => {
+    setNow(MIDDAY_IN_ZONE);
+
+    const range = getHighlightsDateRange(EHighlightsDateFilter.Today, TIMEZONE);
+
+    expect(toISO(range!.startDate)).toBe('2024-11-26T19:00:00.000Z');
+    expect(toISO(range!.endDate)).toBe('2024-11-27T18:59:59.000Z');
+  });
+
+  it('resolves Today against the profile timezone when the browser is still on the previous day', () => {
+    setNow(AFTER_MIDNIGHT_IN_ZONE);
+
+    const range = getHighlightsDateRange(EHighlightsDateFilter.Today, TIMEZONE);
+
+    expect(toISO(range!.startDate)).toBe('2024-11-27T19:00:00.000Z');
+    expect(toISO(range!.endDate)).toBe('2024-11-28T18:59:59.000Z');
+  });
+
+  it('ends Yesterday on the previous day, not at the start of today', () => {
+    setNow(MIDDAY_IN_ZONE);
+
+    const range = getHighlightsDateRange(EHighlightsDateFilter.Yesterday, TIMEZONE);
+
+    expect(toISO(range!.startDate)).toBe('2024-11-25T19:00:00.000Z');
+    expect(toISO(range!.endDate)).toBe('2024-11-26T18:59:59.000Z');
+  });
+
+  it('closes every range on a whole second so the timestamp cannot round up to the next day', () => {
+    setNow(MIDDAY_IN_ZONE);
+
+    const filters = [
+      EHighlightsDateFilter.Today,
+      EHighlightsDateFilter.Yesterday,
+      EHighlightsDateFilter.Week,
+      EHighlightsDateFilter.Month,
+    ];
+
+    filters.forEach((filter) => {
+      const { endDate } = getHighlightsDateRange(filter, TIMEZONE)!;
+
+      expect(endDate.getMilliseconds()).toBe(0);
+      expect(Math.floor(endDate.getTime() / 1000)).toBe(endDate.getTime() / 1000);
+    });
+  });
+
+  it('starts the Week on the day the profile calendar starts on', () => {
+    setNow(MIDDAY_IN_ZONE);
+
+    const mondayWeek = getHighlightsDateRange(EHighlightsDateFilter.Week, TIMEZONE, MONDAY);
+    const sundayWeek = getHighlightsDateRange(EHighlightsDateFilter.Week, TIMEZONE, SUNDAY);
+
+    expect(toISO(mondayWeek!.startDate)).toBe('2024-11-24T19:00:00.000Z');
+    expect(toISO(mondayWeek!.endDate)).toBe('2024-12-01T18:59:59.000Z');
+    expect(toISO(sundayWeek!.startDate)).toBe('2024-11-23T19:00:00.000Z');
+    expect(toISO(sundayWeek!.endDate)).toBe('2024-11-30T18:59:59.000Z');
+  });
+
+  it('falls back to a Sunday week start when the profile value is missing or unusable', () => {
+    setNow(MIDDAY_IN_ZONE);
+
+    const withoutFdw = getHighlightsDateRange(EHighlightsDateFilter.Week, TIMEZONE);
+    const withGarbageFdw = getHighlightsDateRange(EHighlightsDateFilter.Week, TIMEZONE, 'monday');
+
+    expect(toISO(withoutFdw!.startDate)).toBe('2024-11-23T19:00:00.000Z');
+    expect(toISO(withGarbageFdw!.startDate)).toBe('2024-11-23T19:00:00.000Z');
+  });
+
+  it('spans the calendar month in the profile timezone', () => {
+    setNow(MIDDAY_IN_ZONE);
+
+    const range = getHighlightsDateRange(EHighlightsDateFilter.Month, TIMEZONE);
+
+    expect(toISO(range!.startDate)).toBe('2024-10-31T19:00:00.000Z');
+    expect(toISO(range!.endDate)).toBe('2024-11-30T18:59:59.000Z');
+  });
+
+  it('leaves the range to the user for the Custom filter', () => {
+    setNow(MIDDAY_IN_ZONE);
+
+    expect(getHighlightsDateRange(EHighlightsDateFilter.Custom, TIMEZONE)).toBeNull();
+  });
+
+  it('re-reads the clock on every call instead of freezing the range at import time', () => {
+    setNow(MIDDAY_IN_ZONE);
+    const beforeMidnight = getHighlightsDateRange(EHighlightsDateFilter.Today, TIMEZONE);
+
+    setNow(AFTER_MIDNIGHT_IN_ZONE);
+    const afterMidnight = getHighlightsDateRange(EHighlightsDateFilter.Today, TIMEZONE);
+
+    expect(toISO(afterMidnight!.startDate)).not.toBe(toISO(beforeMidnight!.startDate));
+  });
+});
+
+describe('getTodayDateRange', () => {
+  beforeAll(() => {
+    nowSpy = jest.spyOn(Date, 'now');
+  });
+
+  afterAll(() => {
+    nowSpy.mockRestore();
+  });
+
+  it('matches the Today preset', () => {
+    setNow(MIDDAY_IN_ZONE);
+
+    const today = getTodayDateRange(TIMEZONE);
+    const preset = getHighlightsDateRange(EHighlightsDateFilter.Today, TIMEZONE)!;
+
+    expect(toISO(today.startDate)).toBe(toISO(preset.startDate));
+    expect(toISO(today.endDate)).toBe(toISO(preset.endDate));
+  });
+
+  it('falls back to the browser timezone when the profile has none yet', () => {
+    setNow(MIDDAY_IN_ZONE);
+
+    const { startDate, endDate } = getTodayDateRange('');
+
+    expect(startDate.getHours()).toBe(0);
+    expect(startDate.getMinutes()).toBe(0);
+    expect(endDate.getHours()).toBe(23);
+    expect(endDate.getSeconds()).toBe(59);
+  });
+});

--- a/frontend/src/public/utils/dateTime.ts
+++ b/frontend/src/public/utils/dateTime.ts
@@ -1,48 +1,16 @@
-/* eslint-disable indent */
 import moment, { duration as momentDuration } from 'moment';
 import 'moment-timezone';
 import 'moment-duration-format';
-import {
-  endOfMonth,
-  endOfToday,
-  endOfWeek,
-  endOfYesterday,
-  startOfMonth,
-  startOfToday,
-  startOfWeek,
-  startOfYesterday,
-  isAfter,
-  format,
-} from 'date-fns';
+import { isAfter, format } from 'date-fns';
 import { useIntl } from 'react-intl';
 
 import { IWorkflowDelay, IWorkflowTaskDelay, WorkflowWithDateFields, WorkflowWithTspFields } from '../types/workflow';
-import { EHighlightsDateFilter } from '../types/highlights';
 import { TaskWithDateFields, TaskWithTspFields } from '../types/tasks';
 import { getDate } from './strings';
 
 export const SEC_IN_DAY = 24 * 60 * 60;
 export const SEC_IN_HOUR = 60 * 60;
 export const SEC_IN_MINUTE = 60;
-
-export const PROCESS_HIGHLIGHTS_DATE_RANGE_MAP = {
-  [EHighlightsDateFilter.Today]: {
-    startDate: startOfToday(),
-    endDate: endOfToday(),
-  },
-  [EHighlightsDateFilter.Yesterday]: {
-    startDate: startOfYesterday(),
-    endDate: endOfYesterday(),
-  },
-  [EHighlightsDateFilter.Week]: {
-    startDate: startOfWeek(new Date()),
-    endDate: endOfWeek(new Date()),
-  },
-  [EHighlightsDateFilter.Month]: {
-    startDate: startOfMonth(new Date()),
-    endDate: endOfMonth(new Date()),
-  },
-};
 
 export const formatDateToQuery = (date?: Date | null) => {
   if (!date) return null;

--- a/frontend/src/public/utils/highlightsDateRange.ts
+++ b/frontend/src/public/utils/highlightsDateRange.ts
@@ -1,0 +1,76 @@
+import moment from 'moment-timezone';
+
+import { EHighlightsDateFilter } from '../types/highlights';
+
+export interface IHighlightsDateRange {
+  startDate: Date;
+  endDate: Date;
+}
+
+const DAYS_IN_WEEK = 7;
+
+/**
+ * The range picker stores the closing edge of a day as 23:59:59.000 (see normalizeDatePickerDate),
+ * so presets must produce the same shape or a custom range and a preset would not be comparable.
+ */
+const LAST_SECOND_OF_DAY = { hour: 23, minute: 59, second: 59, millisecond: 0 };
+
+const getNow = (timezone: string) => (timezone ? moment.tz(timezone) : moment());
+
+/** `dateFdw` comes from the profile as '0' (Sunday) or '1' (Monday). */
+const parseFirstDayOfWeek = (dateFdw?: string): number => {
+  const firstDayOfWeek = Number(dateFdw);
+
+  return Number.isInteger(firstDayOfWeek) && firstDayOfWeek >= 0 && firstDayOfWeek < DAYS_IN_WEEK
+    ? firstDayOfWeek
+    : 0;
+};
+
+const toDayRange = (dayStart: moment.Moment, lastDayStart: moment.Moment = dayStart): IHighlightsDateRange => ({
+  startDate: dayStart.toDate(),
+  endDate: lastDayStart.clone().set(LAST_SECOND_OF_DAY).toDate(),
+});
+
+/** Today in the given timezone. Split out so callers that only need it avoid a nullable result. */
+export const getTodayDateRange = (timezone: string): IHighlightsDateRange =>
+  toDayRange(getNow(timezone).startOf('day'));
+
+/**
+ * Build the [startDate, endDate] pair for a Highlights date preset.
+ *
+ * Always evaluated at call time and always in the user's profile timezone, so the range matches the
+ * calendar day the user actually sees rather than the browser's day at the moment the bundle loaded.
+ * Returns null for Custom, where the range belongs to the user.
+ */
+export const getHighlightsDateRange = (
+  filter: EHighlightsDateFilter,
+  timezone: string,
+  dateFdw?: string,
+): IHighlightsDateRange | null => {
+  const now = getNow(timezone);
+
+  switch (filter) {
+    case EHighlightsDateFilter.Today:
+      return toDayRange(now.startOf('day'));
+
+    case EHighlightsDateFilter.Yesterday:
+      return toDayRange(now.clone().subtract(1, 'day').startOf('day'));
+
+    case EHighlightsDateFilter.Week: {
+      const firstDayOfWeek = parseFirstDayOfWeek(dateFdw);
+      const daysSinceWeekStart = (now.day() - firstDayOfWeek + DAYS_IN_WEEK) % DAYS_IN_WEEK;
+      const weekStart = now.clone().startOf('day').subtract(daysSinceWeekStart, 'days');
+
+      return toDayRange(weekStart, weekStart.clone().add(DAYS_IN_WEEK - 1, 'days'));
+    }
+
+    case EHighlightsDateFilter.Month: {
+      const monthStart = now.clone().startOf('month');
+
+      return toDayRange(monthStart, monthStart.clone().endOf('month').startOf('day'));
+    }
+
+    default:
+      return null;
+  }
+};


### PR DESCRIPTION
### 1. Release notes

Fixed the Highlights **By time** filter. The `Today`, `Yesterday`, `Week` and `Month` presets are now resolved in the timezone from the user's profile and against the current clock, so they cover the calendar period the user actually sees. The end of a range is now always `23:59:59` of the last day, and the dates kept in the page URL survive a reload unchanged.

### 2. Context

**Issue:** 38008 — "highlights [frontend] Fix filter by time. Фильтр не учитывает часовой пояс пользователя."

**App Location:** Highlights page (`/highlights`) → left column → **By time** filter (`HighlightsFeed` → `DateFilter`). Affects the `date_after_tsp` / `date_before_tsp` parameters sent to `/highlights` and the `date_from_tsp` / `date_to_tsp` parameters sent to `/highlights/titles`.

**Related Changes:** The `Custom` branch of the filter was already made timezone-aware in an earlier change — `RangeDatePicker` normalizes picked days through `normalizeDatePickerDate` with the profile timezone, and the saga already maps `dateAfter: startDate` / `dateBefore: endDate` in the right order. This PR covers what was left: the presets, the initial state, and the URL round-trip.

### 3. Solution & Implementation Details

**Root cause.** The four presets came from `PROCESS_HIGHLIGHTS_DATE_RANGE_MAP` in `utils/dateTime.ts`:

```ts
export const PROCESS_HIGHLIGHTS_DATE_RANGE_MAP = {
  [EHighlightsDateFilter.Today]: { startDate: startOfToday(), endDate: endOfToday() },
  ...
};
```

Three separate defects live in those five lines:

1. **The browser timezone, not the profile one.** `date-fns` `startOfToday()` and friends resolve against the host clock. Everything else on the page — the range picker, the feed item dates — uses `authUser.timezone`. With a profile on `+05:00` and a browser on `GMT+0`, `Today` covered `00:00–23:59` UTC, which is `05:00`–`04:59` of the next day for the user.
2. **The object is a module-level literal**, so all four ranges are evaluated once, when the bundle first imports `utils/dateTime`. A tab left open past midnight keeps serving the previous day, and every re-selection of `Today` returns the same frozen pair. The same applies to `INIT_FILTERS` in the highlights reducer and to the `defaultAction`s in `container.ts`, which are also built at module scope.
3. **`endOf*` returns `23:59:59.999`.** `toTspDate` floors through `moment().unix()`, so today that lands on `:59` — but the millisecond tail is what makes the reported "the second date sometimes arrives as the next day at 00:00:00, one second later" possible, and it is what disagreed with the `23:59:59.000` the range picker stores for a custom range.

A fourth, independent defect explains the "dates change after a page reload" report. `container.ts` synced the two dates into the query string with an identity `getQueryParamByProp`, so a `Date` was serialized by `Date.prototype.toString()` — `Wed Nov 27 2024 00:00:00 GMT+0500 (Yekaterinburg Standard Time)`. `getQueryStringByParams` does not encode its values and `getQueryStringParams` replaces `+` with a space when decoding, so the offset came back as `GMT 0500`; the reader patched it with `.replace('GMT ', 'GMT+')` and dropped the `(...)` name with a regex. That round-trip loses milliseconds, depends on the browser's `toString()` wording, and silently produced a different instant than the one that was picked.

**Changes.**

1. New `src/public/utils/highlightsDateRange.ts`:
   - `getHighlightsDateRange(filter, timezone, dateFdw)` — builds the `[startDate, endDate]` pair for a preset **at call time** and **in the profile timezone**, via `moment-timezone`. Returns `null` for `Custom`, where the range belongs to the user.
   - `getTodayDateRange(timezone)` — the `Today` pair, split out so the reducer and the query-string defaults get a non-nullable result.
   - Every range closes at `23:59:59.000`, matching what `normalizeDatePickerDate` already stores for a custom range, so a preset and a hand-picked day are now the same shape.
   - `Week` honours the profile's first day of week (`dateFdw`, `'0'` Sunday / `'1'` Monday) instead of `date-fns`' Sunday default, so the preset agrees with the calendar the picker draws through `calendarStartDay`. An absent or unparsable value falls back to Sunday.
   - An empty timezone falls back to the browser one, which is all the reducer can do before the profile is loaded.
2. `utils/dateTime.ts` — `PROCESS_HIGHLIGHTS_DATE_RANGE_MAP` and its eight now-unused `date-fns` imports are gone. The file-level `/* eslint-disable indent */` was removed as well; the file lints clean without it.
3. `redux/highlights/reducer.ts` — `INIT_FILTERS` became `getInitHighlightsFilters()`, called for the initial state and for `ClearAppFilters`, so a cleared filter is today rather than the day the bundle loaded.
4. `components/Highlights/HighlightsFeed.tsx`:
   - Reads `timezone` and `dateFdw` from the profile via `useDatePickerSettings`.
   - On mount, recomputes the active preset before the first fetch. This is what repairs both remaining paths the component does not own: the reducer's initial state and the HOC's `defaultAction`s, neither of which can see the profile timezone. A `Custom` range is left alone.
   - The template-titles effect waits for the props to carry the range the mount effect applied. Recomputing on mount puts fresh `Date` objects in the store, so that effect would otherwise run twice — once with the pre-correction range — and `watchFetchTemplatesTitles` uses `takeEvery`, which cancels nothing: the stale request could resolve last and leave the Templates filter counts describing a different window than the feed. The gate is a ref holding the applied range rather than a boolean flag, so it does not depend on React batching the redux dispatch and the local state update into one render.
   - Picking a preset now dispatches a single `setFilters({ timeRange, startDate, endDate })` instead of two, with the range resolved through the new helper. For `Custom` the helper returns `null` and only `timeRange` is set.
   - `handleClearFilters` resolves its range the same way instead of reusing a frozen constant.
5. New `components/Highlights/utils/dateQueryParam.ts` — `serializeDateQueryParam` / `parseDateQueryParam` move the two dates through the query string as millisecond timestamps, which need no escaping and round-trip exactly. `parseDateQueryParam` still accepts the legacy `Date.toString()` text (including the `GMT `-for-`GMT+` mangling), so links and bookmarks that already exist keep opening on the range they encode.
6. `components/Highlights/container.ts` uses those two helpers for `start-date` and `end-date` and drops the inline regex parsing.

`DateFilter`, `RangeDatePicker`, `normalizeDatePickerDate`, the highlights saga and both API query builders are unchanged.

### 4. What to Test

#### 4.1 Preconditions

- A user with highlight events spread over at least the current month, including events near local midnight at both ends of a day.
- Profile → Locale set to a timezone that differs from the machine's, e.g. profile `GMT+05:00` while the OS is on `GMT+00:00`. The reverse pair is worth one pass too.
- Both values of Profile → **First day of the week** (Sunday and Monday).

#### 4.2 Positive Scenarios / Testing Report

| # | Steps | Expected result | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
|---|---|---|---|---|---|---|
| 1 | Profile `+05:00`, machine `GMT+0`. Highlights → **By time** → `Today` → Apply. Inspect the `/highlights` request | `date_after_tsp` is 00:00:00 and `date_before_tsp` is 23:59:59 of the current day **in `+05:00`**, and the first is smaller than the second | [ ] | [ ] | [ ] | [ ] |
| 2 | Same, `Yesterday` | The range spans the previous calendar day in `+05:00` and ends at 23:59:59 of that day, not at 00:00:00 of today | [ ] | [ ] | [ ] | [ ] |
| 3 | Same, `Week`, with the profile week starting on Monday | The range opens on Monday 00:00 and closes on Sunday 23:59:59, in `+05:00` | [ ] | [ ] | [ ] | [ ] |
| 4 | Switch the profile first day of the week to Sunday, reload, pick `Week` | The range opens on Sunday and closes on Saturday | [ ] | [ ] | [ ] | [ ] |
| 5 | Same, `Month` | The range spans the first to the last day of the current month in `+05:00` | [ ] | [ ] | [ ] | [ ] |
| 6 | `Custom` → pick the same day twice → Apply | Unchanged from before: 00:00:00 to 23:59:59 of that day in the profile timezone | [ ] | [ ] | [ ] | [ ] |
| 7 | Set a `Custom` range, Apply, then reload the page | The same two dates come back in the picker and in the request; the URL carries two numeric `start-date` / `end-date` params | [ ] | [ ] | [ ] | [ ] |
| 8 | Set a filter, copy the URL, open it in a new tab | The `Custom` range is restored exactly; a preset resolves to the current period | [ ] | [ ] | [ ] | [ ] |
| 9 | Check the `/highlights/titles` request behind the Templates filter list | `date_from_tsp` / `date_to_tsp` match the `/highlights` range | [ ] | [ ] | [ ] | [ ] |

#### 4.3 Negative Scenarios & Edge Cases

| # | Steps | Expected result | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
|---|---|---|---|---|---|---|
| 1 | Leave the page open past local midnight, then click `Today` (or reload) | The range is the new day, not the day the tab was opened | [ ] | [ ] | [ ] | [ ] |
| 2 | Open an old bookmark whose URL carries the legacy text dates (`start-date=Wed%20Nov%2027%202024%2000:00:00%20GMT+0500%20(...)`) | The range is still restored; no crash and no silently empty feed | [ ] | [ ] | [ ] | [ ] |
| 3 | Hand-edit `start-date` in the URL to garbage and reload | The parameter is ignored, the store keeps its range, no console error | [ ] | [ ] | [ ] | [ ] |
| 4 | Pick `Custom`, select only a start date | **Apply filters** stays disabled until the second date is picked (unchanged) | [ ] | [ ] | [ ] | [ ] |
| 5 | Press **Clear** after any filter | Falls back to `Today` in the profile timezone, resolved against the current clock | [ ] | [ ] | [ ] | [ ] |
| 6 | Profile on a timezone with DST (e.g. `Europe/London`), pick `Week` over the spring-forward Sunday | The range still opens at local 00:00 and closes at local 23:59:59; the week is not 23 or 25 hours out | [ ] | [ ] | [ ] | [ ] |
| 7 | Switch the profile timezone in another tab, then reload Highlights | Presets follow the new timezone | [ ] | [ ] | [ ] | [ ] |

#### 4.4 Verification Points

- In DevTools → Network, `date_before_tsp - date_after_tsp` is `86399` for a single-day preset, and `date_before_tsp % 60 === 59`.
- Neither timestamp ends on a whole minute boundary that would indicate a `23:59:59.999` rounding up to the next midnight.
- The URL contains `start-date`/`end-date` as bare integers, with no spaces, parentheses or `GMT` text.
- `date_after_tsp` is always strictly smaller than `date_before_tsp`, for every preset and for a single-day custom range.

#### 4.5 API Verification

No API contract change. The same four parameters are sent to the same two endpoints; only their values are corrected.

- `GET /highlights?...&date_after_tsp=<start>&date_before_tsp=<end>` — both are second-precision Unix timestamps, `start` at local midnight and `end` at local `23:59:59`.
- `GET /highlights/titles?date_from_tsp=<start>&date_to_tsp=<end>` — same pair, driven by the same store fields.

#### 4.6 What Was NOT Tested

- No manual browser verification was performed. Every box in 4.2 and 4.3 is unchecked; the root cause and the fix were derived from the code and covered by unit tests only.
- No cross-browser or mobile verification (Safari, mobile Safari, mobile Chrome).
- No verification against a real backend — the returned event set was not compared with the requested window, so "the feed shows exactly the events of that day" is unproven end to end.
- DST behaviour is exercised only through `moment-timezone` in unit tests, on a fixed `Asia/Yekaterinburg` (+05:00, no DST) clock. Scenario 4.3.6 has not been run.
- The legacy URL format is covered by a unit test but was not opened in a browser.
- `withSyncedQueryString` was deliberately not touched. Two pre-existing oddities remain in it: `componentDidMount` calls `handleUpdateLocation()` in the same tick as the dispatches that sync the store, so it pushes the pre-sync props into the URL; and `handleUpdateState` is dead code, never wired to `componentDidUpdate`. The HOC is shared by several pages, so changing it is out of this task's scope.

### 5. Affected Areas

| Area | Impact | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
|---|---|---|---|---|---|
| Highlights → By time → `Today` / `Yesterday` / `Week` / `Month` | Fixed: profile timezone, current clock, `23:59:59` end, profile week start | [ ] | [ ] | [ ] | [ ] |
| Highlights → By time → `Custom` | Unchanged behaviour; the stored shape now matches the presets | [ ] | [ ] | [ ] | [ ] |
| Highlights → Clear filters | Fixed: falls back to the current day in the profile timezone | [ ] | [ ] | [ ] | [ ] |
| Highlights URL (`start-date` / `end-date`) | Format change to numeric timestamps; legacy links still parse | [ ] | [ ] | [ ] | [ ] |
| Highlights → Templates filter counts (`/highlights/titles`) | Fixed: one request, with the corrected range; no stale response can win | [ ] | [ ] | [ ] | [ ] |
| `utils/dateTime.ts` | `PROCESS_HIGHLIGHTS_DATE_RANGE_MAP` removed (no other consumers); no behaviour change for its remaining exports | [ ] | [ ] | [ ] | [ ] |

### 6. Unit Tests

- **New** `src/public/utils/__tests__/highlightsDateRange.test.ts` — 11 tests on a clock pinned through `Date.now` (moment reads it there), with the profile on `Asia/Yekaterinburg`: `Today` starting at local midnight rather than at the current time; `Today` resolving to the profile day while the browser is still on the previous one; `Yesterday` ending on the previous day instead of at the start of today; every preset closing on a whole second with zero milliseconds; `Week` honouring Monday vs Sunday and falling back to Sunday for a missing or unparsable `dateFdw`; `Month` spanning the calendar month; `Custom` returning `null`; and the clock being re-read on every call rather than frozen at import. Plus two tests pinning `getTodayDateRange` to the `Today` preset and to the browser-timezone fallback.
- **New** `src/public/components/Highlights/utils/__tests__/dateQueryParam.test.ts` — 5 tests: an exact round-trip through the real `getQueryStringByParams` / `getQueryStringParams` pair; a demonstration that those helpers turn `GMT+0500` into `GMT 0500`, which is what broke the old text format; the legacy format still parsing; empty serialization; and `null` for an empty or unparsable param.
- **New** `src/public/components/Highlights/__tests__/HighlightsFeed.test.tsx` — 6 tests with the profile on `+05:00` and the clock on `10:03Z`. The harness feeds `setFilters` back in as props, mirroring the store round-trip, so the mount correction actually reaches the component. Covered: the mount effect recomputing a stale preset before `loadHighlights` (asserted on invocation order); `loadTemplatesTitles` firing exactly once and with the corrected range (this one fails without the ref gate, verified by reverting it); a `Custom` range left untouched on mount; picking `Week` producing a single `setFilters` with a Monday-start range in the profile timezone; `Yesterday` closing at `23:59:59.000`; and `Custom` setting only `timeRange`.

Full suite: **247 suites / 1682 tests passing**. `npx tsc --noEmit -p tsconfig.json` reports no errors under `src/` (the remaining output is pre-existing `node_modules` type conflicts on `@types/react` / `@types/enzyme` / `react-datepicker` / `webpack`). ESLint clean on `utils/dateTime.ts`, `utils/highlightsDateRange.ts`, `components/Highlights` and `redux/highlights`. The `A worker process has failed to exit gracefully` warning at the end of the run is pre-existing and unrelated.

### 7. Commits

- `0cbe43389` — `38008 fix(highlights): resolve date filter ranges in the profile timezone`
- `20e2abcc9` — `38008 fix(highlights): fetch template titles once with the corrected range`

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes filter boundaries and URL date serialization for Highlights; legacy query strings still parse, but bookmarked timestamp format differs and wrong ranges could affect feed/API queries if timezone logic regresses.
> 
> **Overview**
> Highlights preset date filters (**Today**, **Yesterday**, **Week**, **Month**) now compute **start/end** in the user’s **profile timezone** and **first day of week**, instead of browser-local `date-fns` ranges frozen at bundle load. A new **`getHighlightsDateRange`** / **`getTodayDateRange`** module replaces **`PROCESS_HIGHLIGHTS_DATE_RANGE_MAP`**; preset end times align to **23:59:59.000** so they match the date picker.
> 
> **`HighlightsFeed`** recomputes the active preset on mount (fixes stale “today” after overnight tabs), when switching presets, and when clearing filters, using **`useDatePickerSettings`**. Template titles wait until Redux props reflect the corrected range so an older request cannot win.
> 
> **`start-date` / `end-date`** query params now serialize as **millisecond timestamps** via **`parseDateQueryParam` / `serializeDateQueryParam`** (legacy **`Date.toString()`** links still parse). **`INIT_FILTERS`** becomes **`getInitHighlightsFilters()`** so defaults are computed at call time. Tests cover timezone/week boundaries, mount behavior, and query round-trips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20e2abcc902623dfe73d1253aadb72c9def36fa8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resolve Highlights date filter ranges in the user's profile timezone
> - Adds `getHighlightsDateRange` and `getTodayDateRange` in [highlightsDateRange.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/359/files#diff-30817941b753f1f7f012075af4fc5eb5c651abb317af515d718a9644f789f39f) to compute preset ranges (Today, Yesterday, Week, Month) in the user's timezone with correct first-day-of-week semantics and end-of-day closure at 23:59:59.000
> - Updates [HighlightsFeed.tsx](https://github.com/pneumaticapp/pneumaticworkflow/pull/359/files#diff-736f1548ab2a40c011749ec36376744d36df34351994c0cf958d996b7c3eb800) to recompute the active preset range using profile timezone and week-start before the first highlights fetch, and delays `loadTemplatesTitles` until props reflect the corrected range to avoid races
> - Replaces static `INIT_FILTERS` with `getInitHighlightsFilters()` in [reducer.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/359/files#diff-9f75c946e109b26d068558eaf0236c4f53389072ec1a709d773878daecb1d259) so initial and cleared filter dates are computed at call time instead of bundle load time
> - Serializes date query params as millisecond timestamps in [dateQueryParam.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/359/files#diff-85c550e48e385293632e5543a2c824ffc14588a2f6c691c545de4f9b21a74ae0); `parseDateQueryParam` still accepts legacy `Date.toString()` format with space-decoded timezone suffix normalization
> - Risk: query param format changes from `Date.toString()` to timestamp strings — existing URLs with legacy date strings still parse, but newly generated URLs use the timestamp format and invalid values now dispatch `EMPTY_ACTION` instead of defaulting
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 20e2abc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->