### PR TITLE
37813 frontend [ dashboard ] skip template integrations request for non-admin users

### DIFF
--- a/frontend/src/public/redux/selectors/__tests__/user.test.ts
+++ b/frontend/src/public/redux/selectors/__tests__/user.test.ts
@@ -2,6 +2,7 @@ import { ELoggedState, IApplicationState, IAuthUser } from '../../../types/redux
 import { ESubscriptionPlan } from '../../../types/account';
 import { EUserStatus } from '../../../types/user';
 import {
+  getCanAccessTemplateIntegrations,
   getCanAccessWorkflows,
   getHasExtendedInterface,
   getHasBasicInterface,
@@ -76,6 +77,32 @@ describe('user selectors', () => {
       const state = createMockState({ isAdmin: undefined });
 
       expect(getIsAdmin(state)).toBe(false);
+    });
+  });
+
+  describe('getCanAccessTemplateIntegrations', () => {
+    it('returns true when user is admin', () => {
+      const state = createMockState({ isAdmin: true, isAccountOwner: false });
+
+      expect(getCanAccessTemplateIntegrations(state)).toBe(true);
+    });
+
+    it('returns true when user is the account owner without the admin flag', () => {
+      const state = createMockState({ isAdmin: false, isAccountOwner: true });
+
+      expect(getCanAccessTemplateIntegrations(state)).toBe(true);
+    });
+
+    it('returns false when user is neither admin nor account owner', () => {
+      const state = createMockState({ isAdmin: false, isAccountOwner: false });
+
+      expect(getCanAccessTemplateIntegrations(state)).toBe(false);
+    });
+
+    it('returns false when both flags are undefined', () => {
+      const state = createMockState({ isAdmin: undefined, isAccountOwner: undefined });
+
+      expect(getCanAccessTemplateIntegrations(state)).toBe(false);
     });
   });
 

--- a/frontend/src/public/redux/selectors/user.ts
+++ b/frontend/src/public/redux/selectors/user.ts
@@ -25,6 +25,10 @@ export const getIsBlocked = ({
 
 export const getIsAdmin = ({ authUser }: IApplicationState) => authUser.isAdmin || false;
 
+/** Mirrors UserIsAdminOrAccountOwner on /templates/integrations, which 403s for anyone else. */
+export const getCanAccessTemplateIntegrations = ({ authUser }: IApplicationState) =>
+  (authUser?.isAdmin || authUser?.isAccountOwner) || false;
+
 export const getCanAccessWorkflows = ({ authUser }: IApplicationState) => 
   (authUser?.isAdmin || authUser?.hasWorkflowViewerAccess || authUser?.hasWorkflowStarterAccess) || false;
 

--- a/frontend/src/public/redux/templates/__tests__/saga.test.ts
+++ b/frontend/src/public/redux/templates/__tests__/saga.test.ts
@@ -7,11 +7,17 @@ import * as getTemplatesApi from '../../../api/getTemplates';
 import { IGetTemplatesResponsePaginated } from '../../../api/getTemplates';
 import * as getSystemTemplatesApi from '../../../api/getSystemTemplates';
 import * as getSystemTemplatesCategoriesApi from '../../../api/getSystemTemplatesCategories';
+import * as getTemplatesIntegrationsStatsApi from '../../../api/getTemplatesIntegrationsStats';
 import { ETemplatesSorting } from '../../../types/workflow';
 import { LIMIT_LOAD_TEMPLATES, LIMIT_LOAD_SYSTEMS_TEMPLATES } from '../../../constants/defaultValues';
-import { getIsAdmin } from '../../selectors/user';
+import { getCanAccessTemplateIntegrations, getIsAdmin } from '../../selectors/user';
 import { getTemplatesSystemList } from '../../selectors/templates';
-import { fetchTemplatesSystem, fetchTemplatesSystemCategories, handleLoadTemplateVariables } from '../saga';
+import {
+  fetchTemplatesSystem,
+  fetchTemplatesSystemCategories,
+  handleLoadTemplateVariables,
+  loadTemplateIntegrationsStatsSaga,
+} from '../saga';
 import { getTemplateFields } from '../../../api/getTemplateFields';
 import { buildRuntimeMergedOutputParts } from '../../../components/TemplateEdit/TaskOutputFlow/mergeTaskOutputFlow';
 
@@ -117,6 +123,34 @@ describe('templates saga', () => {
         .run()
         .then(() => {
           expect(getCategoriesMock).not.toHaveBeenCalled();
+        });
+    });
+  });
+
+  describe('loadTemplateIntegrationsStatsSaga', () => {
+    const action = { payload: { templates: [1, 2] } };
+
+    it('does not call the integrations stats API for a user who is neither admin nor account owner', () => {
+      const getStatsMock = jest.spyOn(getTemplatesIntegrationsStatsApi, 'getTemplatesIntegrationsStats');
+
+      return expectSaga(loadTemplateIntegrationsStatsSaga as any, action)
+        .provide([[matchers.select.selector(getCanAccessTemplateIntegrations), false]])
+        .run()
+        .then(() => {
+          expect(getStatsMock).not.toHaveBeenCalled();
+        });
+    });
+
+    it('calls the integrations stats API when the user may access integrations', () => {
+      const getStatsMock = jest
+        .spyOn(getTemplatesIntegrationsStatsApi, 'getTemplatesIntegrationsStats')
+        .mockResolvedValue([]);
+
+      return expectSaga(loadTemplateIntegrationsStatsSaga as any, action)
+        .provide([[matchers.select.selector(getCanAccessTemplateIntegrations), true]])
+        .run()
+        .then(() => {
+          expect(getStatsMock).toHaveBeenCalledWith({ templates: [1, 2] });
         });
     });
   });

--- a/frontend/src/public/redux/templates/saga.ts
+++ b/frontend/src/public/redux/templates/saga.ts
@@ -39,7 +39,7 @@ import { LIMIT_LOAD_SYSTEMS_TEMPLATES, LIMIT_LOAD_TEMPLATES, varibleIdRegex } fr
 import { SYSTEM_MERGED_OUTPUTS } from '../../components/Workflows/WorkflowsTablePage/WorkflowsTable/constants';
 import { NotificationManager } from '../../components/UI/Notifications';
 import { isRequestCanceled } from '../../utils/isRequestCanceled';
-import { getIsAdmin } from '../selectors/user';
+import { getCanAccessTemplateIntegrations, getIsAdmin } from '../selectors/user';
 
 export function* fetchTemplatesSystem() {
   const isAdmin: ReturnType<typeof getIsAdmin> = yield select(getIsAdmin);
@@ -189,6 +189,14 @@ export function* handleLoadTemplateVariables(templateId: number) {
 }
 
 export function* loadTemplateIntegrationsStatsSaga({ payload: { templates } }: TLoadTemplateIntegrationsStats) {
+  const canAccessIntegrations: ReturnType<typeof getCanAccessTemplateIntegrations> = yield select(
+    getCanAccessTemplateIntegrations,
+  );
+
+  if (!canAccessIntegrations) {
+    return;
+  }
+
   try {
     const stats: TTemplateIntegrationStatsApi[] = yield call(getTemplatesIntegrationsStats, { templates });
     yield put(setTemplateIntegrationsStats(stats));


### PR DESCRIPTION
### 1. Release notes

A user who is neither an account admin nor the account owner no longer triggers a `GET /templates/integrations` request that can only come back `403`. The Dashboard, the templates list and the template editor stop making the call for them; nothing changes visually, because the forbidden response left the data empty anyway.

### 2. Context

**Issue:** 37813 — "Если авторизоваться неадмином и зайти на dashboard то в консоли будет запрос `GET /templates/integrations` со статусом 403, убрать этот запрос для неадмина."

**App Location:** Dashboard (`/`) → Breakdown cards. The request is dispatched from `fetchDashboardData` once the breakdown items are loaded. The same action is also dispatched from `redux/template/saga.ts` after a template loads in the editor, so the fix covers those paths too.

**Related Changes:** none. `redux/templates/saga.ts` already guards `fetchTemplatesSystem` and `fetchTemplatesSystemCategories` the same way; this follows that established shape.

### 3. Solution & Implementation Details

**Root cause.** `TemplateIntegrationsViewSet` (`backend/src/processes/views/template.py:1108`) is protected by `UserIsAdminOrAccountOwner`, which is `request.user.is_admin or request.user.is_account_owner` (`backend/src/accounts/permissions.py:65-68`). The frontend never checked that before dispatching, so `loadTemplateIntegrationsStats` went out for every user. Confirmed live against the running stack:

```
GET /templates/integrations?template_id=426   non-admin → HTTP 403
GET /templates/integrations?template_id=426   admin     → HTTP 200
```

The failure was invisible in the UI because `loadTemplateIntegrationsStatsSaga` swallows the error into `logger.info`, and `TemplateIntegrationsIndicator` falls back to its `disconnectedIndicator` whenever the store holds no stats. So the only symptom was the red entry in the console.

**Changes.**

1. New selector in `redux/selectors/user.ts`:

   ```ts
   export const getCanAccessTemplateIntegrations = ({ authUser }: IApplicationState) =>
     (authUser?.isAdmin || authUser?.isAccountOwner) || false;
   ```

   It mirrors `UserIsAdminOrAccountOwner` exactly. The neighbouring guards in this saga use the existing `getIsAdmin`, which would have been simpler to reuse, but `isAdmin` alone is narrower than the endpoint: an account owner without the admin flag is allowed by the backend and would have silently lost their integration indicators. No such user exists in the current database, which is precisely why the mismatch would have gone unnoticed.

2. `redux/templates/saga.ts` — `loadTemplateIntegrationsStatsSaga` selects that flag and returns before the API call when it is false, matching the `fetchTemplatesSystem` / `fetchTemplatesSystemCategories` pattern already in the file.

The guard sits in the saga rather than at the dispatch sites: `getTemplatesIntegrationsStats` has exactly one caller, so one check covers the Dashboard, the template editor and any future dispatcher. `useTemplateIntegrationsList` only reads the store and issues no request, so it needed no change.

### 4. What to Test

#### 4.1 Preconditions

- Two accounts on the same instance: one user with **Admin** rights (or the account owner), one regular user with neither.
- At least two templates with workflows in progress, so the Dashboard renders Breakdown cards — the request only fires when `breakdownItems` is non-empty.
- At least one template with a connected integration (Zapier / API key / webhook), so the "connected" indicator is distinguishable from the "not connected" one.

#### 4.2 Positive Scenarios / Testing Report

| # | Steps | Expected result | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
|---|---|---|---|---|---|---|
| 1 | Log in as a regular user → Dashboard → DevTools Network, filter `integrations` | No `GET /templates/integrations` request at all, and no `403` in the console | [ ] | [ ] | [ ] | [ ] |
| 2 | Log in as an admin → Dashboard → same filter | The request fires once and returns `200` | [ ] | [ ] | [ ] | [ ] |
| 3 | As an admin, look at a Breakdown card for a template with a connected integration | The "connected" indicator and its tooltip listing the integrations are shown, as before | [ ] | [ ] | [ ] | [ ] |
| 4 | As the **account owner** (if the account has an owner without the admin flag) → Dashboard | The request fires and returns `200`; indicators behave as for an admin | [ ] | [ ] | [ ] | [ ] |
| 5 | As an admin, open a template in the editor (`/templates/{id}`) | `GET /templates/integrations` still fires from the editor path and returns `200` | [ ] | [ ] | [ ] | [ ] |
| 6 | As a regular user, open a template they can access in the editor | No integrations request | [ ] | [ ] | [ ] | [ ] |

#### 4.3 Negative Scenarios & Edge Cases

| # | Steps | Expected result | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
|---|---|---|---|---|---|---|
| 1 | As a regular user, look at a Breakdown card for a template that **does** have integrations | The "not connected" indicator is shown — unchanged from current behaviour, since the `403` already left the stats empty | [ ] | [ ] | [ ] | [ ] |
| 2 | Dashboard with no workflows in progress (no Breakdown cards), any role | No integrations request; `fetchDashboardData` skips it on an empty list | [ ] | [ ] | [ ] | [ ] |
| 3 | Promote a regular user to Admin in another tab, then reload the Dashboard as that user | The request now fires and the indicators populate | [ ] | [ ] | [ ] | [ ] |
| 4 | Demote an admin to a regular user, then reload the Dashboard | The request stops firing; indicators fall back to "not connected" | [ ] | [ ] | [ ] | [ ] |
| 5 | Regular user on Templates list (`/templates`) | `TemplateCardFooter` renders its indicator from the store only; no request | [ ] | [ ] | [ ] | [ ] |

#### 4.4 Verification Points

- DevTools → Network filtered on `integrations`: zero entries for a regular user on the Dashboard, exactly one `200` for an admin.
- Console has no `403` and no `fetch templates integrations stats error` line for a regular user.
- Redux `templates.templatesIntegrationsStats` stays `{}` for a regular user and is populated for an admin.

#### 4.5 API Verification

No API change. `GET /templates/integrations?template_id=<ids>` keeps its contract; the frontend simply stops calling it when the caller cannot pass `UserIsAdminOrAccountOwner`.

Verified directly against the running stack: the same URL returns `403` with a non-admin token and `200` with an admin token. The temporary non-admin token minted for that check was revoked afterwards (`PneumaticToken.expire_token`, confirmed by a subsequent `401`).

#### 4.6 What Was NOT Tested

- No manual browser verification was performed. Every box in 4.2 and 4.3 is unchecked; the fix is covered by unit tests and by the direct API check above.
- No cross-browser or mobile verification (Safari, mobile Safari, mobile Chrome).
- Scenario 4.2.4 (account owner **without** the admin flag) could not be exercised: no such user exists in the local database — `is_account_owner=True, is_admin=False` returns zero rows. That branch is covered only by the selector unit test.
- Scenarios 4.3.3 and 4.3.4 (role changed mid-session) were not run. Note the flag is read from `authUser` at request time, so it follows whatever the store holds after the role change propagates; no fresh handling was added for that.

### 5. Affected Areas

| Area | Impact | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
|---|---|---|---|---|---|
| Dashboard → Breakdown cards, regular user | Fixed: no forbidden request; indicators unchanged ("not connected") | [ ] | [ ] | [ ] | [ ] |
| Dashboard → Breakdown cards, admin / account owner | Unchanged | [ ] | [ ] | [ ] | [ ] |
| Template editor (`redux/template/saga.ts` dispatcher) | Same guard applies: no request for a regular user | [ ] | [ ] | [ ] | [ ] |
| Templates list → `TemplateCardFooter` indicator | Reads the store only; unchanged | [ ] | [ ] | [ ] | [ ] |
| `IntegrateButton` / `TemplateIntegrationsStats` | Read the store only; unchanged | [ ] | [ ] | [ ] | [ ] |

### 6. Unit Tests

- **Updated** `src/public/redux/templates/__tests__/saga.test.ts` — a new `loadTemplateIntegrationsStatsSaga` block with 2 tests, matching the `expectSaga` + `matchers.select.selector` style already used for the non-admin guards in this file: the API is not called when `getCanAccessTemplateIntegrations` is `false`, and is called with the right payload when it is `true`.
- **Updated** `src/public/redux/selectors/__tests__/user.test.ts` — 4 tests for the new selector: admin, **account owner without the admin flag**, neither, and both flags undefined. The second is the case that distinguishes this selector from reusing `getIsAdmin`.

Full suite: **244 suites / 1666 tests passing** (6 new). `npx tsc --noEmit -p tsconfig.json` reports no errors under `src/` (the remaining output is pre-existing `node_modules` type conflicts on `@types/react` / `@types/enzyme` / `react-datepicker` / `webpack`). ESLint clean on `redux/templates` and `redux/selectors`. The `A worker process has failed to exit gracefully` warning at the end of the run is pre-existing and unrelated.

### 7. Commits

- `8b8a511a4` — `37813 fix(dashboard): skip template integrations request for non-admin users`



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontend-only authorization guard before an existing API call; admins and account owners keep the same behavior, with tests covering the new paths.
> 
> **Overview**
> Stops **`GET /templates/integrations`** from running for users who are neither **admin** nor **account owner**, matching backend `UserIsAdminOrAccountOwner` and avoiding console **403**s with no UI change (stats were already empty).
> 
> Adds **`getCanAccessTemplateIntegrations`** in `redux/selectors/user.ts` and an early return in **`loadTemplateIntegrationsStatsSaga`** before `getTemplatesIntegrationsStats`, so Dashboard, templates list, and template editor paths that still dispatch the action no longer hit the API for regular users. Unit tests cover the selector (including account owner without admin) and saga skip/call behavior.
> 
> `ConditionValueField.tsx` only drops a stray **`eslint-disable indent`** comment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59fcba4e217288df3d63d14cefb722c70868ec00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip template integrations stats request for non-admin users in dashboard
> - Adds `getCanAccessTemplateIntegrations` selector in [user.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/360/files#diff-42c371620aa6d185be6460ca28d16d186a832c7aee8dfab743b8a472d16f23ed) that returns true when `authUser.isAdmin` or `authUser.isAccountOwner` is set, matching the server-side authorization rule
> - Updates `loadTemplateIntegrationsStatsSaga` in [saga.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/360/files#diff-ac4231bbcd6e21662266a768141440046a134365c43293c3a3c01f06319400fc) to read that selector and return early before the API call when access is denied
> - Adds tests for both the selector (admin, account-owner, non-privileged, undefined flags) and the saga (skips API on denied access, calls it on allowed access)
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 59fcba4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->