### PR TITLE
33942 frontend [ workflows ] test cover the no-redirect path for embedded workflow runs

### DIFF
--- a/frontend/src/public/components/WorkflowEditPopup/__tests__/WorkflowEditPopup.test.tsx
+++ b/frontend/src/public/components/WorkflowEditPopup/__tests__/WorkflowEditPopup.test.tsx
@@ -361,6 +361,30 @@ describe('WorkflowEditPopup', () => {
     });
   });
 
+  describe('Sub-workflow run', () => {
+    it('keeps ancestorTaskId in the submitted payload, so the saga skips the redirect', () => {
+      const workflow = { ...baseWorkflow, ancestorTaskId: 77 };
+
+      renderWithIntl(<WorkflowEditPopup {...baseProps} workflow={workflow} />);
+
+      userEvent.click(screen.getByRole('button', { name: START_LABEL }));
+
+      expect(baseProps.onRunWorkflow).toHaveBeenCalledWith(
+        expect.objectContaining({ ancestorTaskId: 77 }),
+      );
+    });
+
+    it('submits no ancestorTaskId for a standalone run', () => {
+      renderWithIntl(<WorkflowEditPopup {...baseProps} workflow={baseWorkflow} />);
+
+      userEvent.click(screen.getByRole('button', { name: START_LABEL }));
+
+      expect(baseProps.onRunWorkflow).toHaveBeenCalledWith(
+        expect.not.objectContaining({ ancestorTaskId: expect.anything() }),
+      );
+    });
+  });
+
   describe('Template description', () => {
     it('renders template description via RichText', () => {
       const workflow = {

--- a/frontend/src/public/redux/dashboard/__tests__/saga.test.ts
+++ b/frontend/src/public/redux/dashboard/__tests__/saga.test.ts
@@ -152,7 +152,10 @@ describe('openRunWorflowByTemplateDataSaga — fieldset selections enrichment', 
       throw new Error('Expected openRunWorkflowModal PUT not found');
     }
 
-    const { loadedFieldsets } = openModalPut.payload.action.payload;
+    const { loadedFieldsets, ancestorTaskId } = openModalPut.payload.action.payload;
+
+    // Keeps the run-workflow saga on its sub-workflow branch, which skips the redirect.
+    expect(ancestorTaskId).toBe(99);
 
     expect(loadedFieldsets).toEqual(
       expect.arrayContaining([

--- a/frontend/src/public/redux/runWorkflowModal/__tests__/saga.test.ts
+++ b/frontend/src/public/redux/runWorkflowModal/__tests__/saga.test.ts
@@ -1,0 +1,79 @@
+import { expectSaga } from 'redux-saga-test-plan';
+import * as matchers from 'redux-saga-test-plan/matchers';
+import { StaticProvider } from 'redux-saga-test-plan/providers';
+
+import * as runProcessApi from '../../../api/runProcess';
+import { history } from '../../../utils/history';
+import { getAuthUser, getIsAdmin, getUsers } from '../../selectors/user';
+import { runWorkflow } from '../actions';
+import { rootSaga } from '../saga';
+import { ERoutes } from '../../../constants/routes';
+import { EWorkflowTaskStatus } from '../../../types/workflow';
+import { loadCurrentTask } from '../../actions';
+import { IRunWorkflow } from '../../../components/WorkflowEditPopup/types';
+
+jest.mock('../../../utils/history', () => ({
+  history: { push: jest.fn(), replace: jest.fn() },
+}));
+
+jest.mock('../../../components/UI/Notifications', () => ({
+  NotificationManager: { success: jest.fn(), warning: jest.fn() },
+}));
+
+const ANCESTOR_TASK_ID = 77;
+const CURRENT_USER_ID = 5;
+
+const buildWorkflow = (overrides: Partial<IRunWorkflow> = {}): IRunWorkflow =>
+  ({
+    id: 1,
+    name: 'Workflow',
+    tasksCount: 1,
+    performersCount: 1,
+    kickoff: { description: '', fields: [], fieldsets: [] },
+    ...overrides,
+  } as IRunWorkflow);
+
+/** One active task assigned to somebody else, so the redirect target is the workflows list. */
+const runProcessResponse = {
+  name: 'Workflow',
+  status: 0,
+  tasks: [{ status: EWorkflowTaskStatus.Active, performers: [{ sourceId: 999 }] }],
+};
+
+const provideCommon = (): StaticProvider[] => [
+  [matchers.select.selector(getUsers), []],
+  [matchers.select.selector(getIsAdmin), true],
+  [matchers.select.selector(getAuthUser), { authUser: { id: CURRENT_USER_ID } }],
+];
+
+describe('runWorkflow saga', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(runProcessApi, 'runProcess').mockResolvedValue(runProcessResponse as any);
+  });
+
+  it('does not navigate away when the workflow is started as a sub-workflow', () => {
+    const workflow = buildWorkflow({ ancestorTaskId: ANCESTOR_TASK_ID });
+
+    return expectSaga(rootSaga)
+      .provide(provideCommon())
+      .put(loadCurrentTask({ taskId: ANCESTOR_TASK_ID }))
+      .dispatch(runWorkflow(workflow))
+      .silentRun()
+      .then(() => {
+        expect(history.push).not.toHaveBeenCalled();
+      });
+  });
+
+  it('navigates to the workflows list when a standalone workflow is started', () => {
+    const workflow = buildWorkflow();
+
+    return expectSaga(rootSaga)
+      .provide(provideCommon())
+      .dispatch(runWorkflow(workflow))
+      .silentRun()
+      .then(() => {
+        expect(history.push).toHaveBeenCalledWith(ERoutes.WorkflowsInProgress);
+      });
+  });
+});


### PR DESCRIPTION
### 1. Release notes

The behaviour is already correct: running an embedded workflow from a task card does not navigate the user away to the task list or the workflow list. No production change was needed — this PR adds the regression coverage that pins the behaviour so it cannot be broken silently.

### 2. Context

**Issue:** 33942 — "Embedded Workflows - Switch off redirect for running embedded workflows." Reported as: starting a workflow redirects the user to the task list or the workflow list; that logic must be disabled when starting a sub-workflow. The report also asks for the fix to be verified separately in the Pneumatic build and in the INK build.

**App Location:** task card (`/tasks/:id`) → **Run Embedded Workflow** button (the `task.delegate` label) → template picker panel → run modal → **Run Now**.

**Related Changes:** none.

### 3. Solution & Implementation Details

**What the investigation found.** The requested logic is already implemented. Running a workflow goes through exactly one path, `runWorkflowModal/saga.ts`, and it already branches:

```ts
if (workflow.ancestorTaskId) {
  yield put(loadCurrentTask({ taskId: workflow.ancestorTaskId }));
} else {
  history.push(nextRoute);
}
```

`git log -L 52,58:src/public/redux/runWorkflowModal/saga.ts` dates that block to `685f9eba3` (2024-11-06), the initial import of the code rather than a later fix. So the guard has been present in the open-source Pneumatic repository from the start.

**The `ancestorTaskId` chain** was traced end to end; the field survives every hop:

1. `TaskActions.tsx:139` — `openSelectTemplateModal({ ancestorTaskId: taskId })`;
2. `selectTemplateModal/reducer.ts` — stores `ancestorTaskId`;
3. `SelectTemplateModal.tsx:67` — `openRunWorkflowModalSideMenu({ templateData, ...(ancestorTaskId && { ancestorTaskId }) })`;
4. `dashboard/saga.ts` → `openRunWorflowByTemplateDataSaga` — forwards `ancestorTaskId` into `openRunWorkflowModal`;
5. `runWorkflowModal/reducer.ts` — keeps the payload as `workflow`;
6. `WorkflowEditPopup.tsx:215` — `onRunWorkflow({ ...workflow, ... })`, so the field survives the payload rebuild;
7. `runWorkflowModal/saga.ts` — takes the sub-workflow branch and calls `loadCurrentTask` instead of `history.push`.

**Why there is no code change.** The tests were written against unmodified source and passed on the first run. Inventing a change to justify closing the ticket would fix nothing while putting working logic at risk of regression.

**What was added.** Coverage of the three most fragile links in that chain — the places where `ancestorTaskId` could go missing without anyone noticing:

- the run saga itself (the redirect branch);
- `WorkflowEditPopup`, which builds a fresh payload object on submit;
- `openRunWorflowByTemplateDataSaga`, which copies the field from one action into another.

### 4. What to Test

#### 4.1 Preconditions

- A user with an active task they are a performer on (the **Run Embedded Workflow** button only renders when `viewMode !== Guest`).
- At least one template available to run.

#### 4.2 Positive Scenarios / Testing Report

| # | Steps | Expected result | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
|---|---|---|---|---|---|---|
| 1 | Open `/tasks/:id` → **Run Embedded Workflow** → pick a template → **Run Now** | The URL stays `/tasks/:id`; no redirect to `/tasks` or `/workflows`; the task card reloads and the sub-workflow appears in the embedded workflows block | [ ] | [ ] | [ ] | [ ] |
| 2 | Run a workflow from the left menu (not tied to a task), as the performer of the first task | Redirects to `/tasks` — behaviour unchanged | [ ] | [ ] | [ ] | [ ] |
| 3 | Same, but the first task's performer is somebody else and the runner is an admin | Redirects to `/workflows` (in progress) — behaviour unchanged | [ ] | [ ] | [ ] | [ ] |
| 4 | Run a second sub-workflow from the same task | Both sub-workflows are listed in the embedded block; still no redirect | [ ] | [ ] | [ ] | [ ] |
| 5 | Run a workflow from the Dashboard (Quick buttons / Breakdown card) | Redirect happens — behaviour unchanged | [ ] | [ ] | [ ] | [ ] |

#### 4.3 Negative Scenarios & Edge Cases

| # | Steps | Expected result | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
|---|---|---|---|---|---|---|
| 1 | Run a sub-workflow from a template with required kick-off fields, filling them in | No redirect; the sub-workflow is created with the submitted values | [ ] | [ ] | [ ] | [ ] |
| 2 | Run a sub-workflow and immediately close the task card | No console errors, no unexpected navigation | [ ] | [ ] | [ ] | [ ] |
| 3 | Run a sub-workflow while `GET /tasks/{id}` fails (e.g. drop the network right after `POST .../run`) | The error handler at `task/saga.ts:157` fires `history.replace('/tasks')`. Indistinguishable from the original bug from the outside, but it is a different branch — not the post-run redirect logic | [ ] | [ ] | [ ] | [ ] |
| 4 | Open a task card in Guest mode | The button is not rendered; the scenario is unreachable | [ ] | [ ] | [ ] | [ ] |

#### 4.4 Verification Points

- In DevTools → Network, the `POST /templates/{id}/run` body carries `ancestor_task_id`.
- The address bar does not change after the response.
- A `GET /tasks/{id}` follows (the card reloading), rather than a navigation to a list.

#### 4.5 API Verification

No API change. `POST /templates/{id}/run` accepts `ancestor_task_id` as before; the frontend sends it and the backend creates a sub-workflow bound to the ancestor task.

#### 4.6 What Was NOT Tested

- **Scenario 4.2.1 was confirmed manually in a browser**: a sub-workflow was started from the `First Step` task card, the page stayed on `/tasks/:id`, and the sub-workflow appeared in the embedded workflows block. The specific browser was not recorded, so no column is ticked.
- The remaining scenarios in 4.2 and 4.3 were not run manually — they are covered by unit tests only.
- No cross-browser or mobile verification (Safari, mobile Safari, mobile Chrome).
- **The INK build was not verified.** This repository contains no build-variant switch and no INK-specific code: `MCS_RUN_ENV` only accepts `local` / `staging` / `prod`, and `config/common.json` holds nothing but the `api` and `exposedToBrowser` keys. The INK check has to happen in its own repository; this PR does not close that half of the ticket.
- Scenario 4.3.3 (a failing `GET /tasks/{id}`) was not reproduced; the branch is described from the code.

### 5. Affected Areas

| Area | Impact | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
|---|---|---|---|---|---|
| Task card → running an embedded workflow | Behaviour unchanged; now pinned by tests | [ ] | [ ] | [ ] | [ ] |
| Running a workflow from the menu / Dashboard / workflows list | Behaviour unchanged; the redirect is preserved and covered by a test | [ ] | [ ] | [ ] | [ ] |
| Production code | Not modified | — | — | — | — |

### 6. Unit Tests

- **New** `src/public/redux/runWorkflowModal/__tests__/saga.test.ts` — 2 tests: with `ancestorTaskId` the saga dispatches `loadCurrentTask` and does **not** call `history.push`; without it, it navigates to `ERoutes.WorkflowsInProgress`. `history` and `NotificationManager` are mocked and `runProcess` is stubbed.
- **Updated** `src/public/components/WorkflowEditPopup/__tests__/WorkflowEditPopup.test.tsx` — 2 tests that the popup keeps `ancestorTaskId` in the submitted payload and does not add it for a standalone run. This is the most exposed link, since `handleRunWorkflow` constructs a fresh object.
- **Updated** `src/public/redux/dashboard/__tests__/saga.test.ts` — the existing test already passed `ancestorTaskId: 99` but asserted only on `loadedFieldsets`; it now also asserts the field reaches `openRunWorkflowModal`.

All three pass against unmodified production code, which is itself the evidence that the fix is in place.

Full suite: **245 suites / 1664 tests passing**. `npx tsc --noEmit -p tsconfig.json` reports no errors under `src/` (the remaining output is pre-existing `node_modules` type conflicts on `@types/react` / `@types/enzyme` / `react-datepicker` / `webpack`). ESLint clean on `redux/runWorkflowModal`, `redux/dashboard` and `components/WorkflowEditPopup`. The `A worker process has failed to exit gracefully` warning is pre-existing and unrelated.

### 7. Commits

- `fe381e36e` — `33942 test(workflows): cover the no-redirect path for embedded workflow runs`

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only changes with no production logic modified.
> 
> **Overview**
> Adds **automated test coverage** for starting a workflow as a **sub-workflow** (with `ancestorTaskId`) versus a **standalone** run, so the “stay on the parent task / no redirect” path does not regress.
> 
> **`WorkflowEditPopup`** tests assert Start submits `ancestorTaskId` when present and omits it for a normal run. The **dashboard** side-menu saga test now expects `ancestorTaskId` (e.g. `99`) on the `openRunWorkflowModal` payload alongside enriched fieldsets. A new **`runWorkflowModal` saga** suite verifies that with `ancestorTaskId` the saga dispatches `loadCurrentTask` and does **not** call `history.push`, while standalone runs still navigate to **Workflows in progress**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe381e36e2f2c080b7a85db8353d9e0b134da680. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tests covering no-redirect path for embedded workflow runs
> - Adds `WorkflowEditPopup` tests verifying that sub-workflow start callbacks include `ancestorTaskId` and standalone start callbacks omit it
> - Extends the dashboard enrichment saga test to assert `ancestorTaskId` survives the fieldset-selection enrichment step
> - Adds a new `runWorkflowModal` saga test suite with mocked navigation, selectors, and process API; verifies sub-workflow runs dispatch `loadCurrentTask` and skip navigation while standalone runs push the workflows-in-progress route
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fe381e3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->