### PR TITLE
🔧 49454 frontend [ template ] The application crashes when selecting “check if” on the date field.

### DIFF
--- a/frontend/src/public/components/KickoffOutputs/TextOutput.tsx
+++ b/frontend/src/public/components/KickoffOutputs/TextOutput.tsx
@@ -10,7 +10,7 @@ export function TextOutput({ name, value }: IExtraField) {
   const renderValue = () => {
     return (
       <span className={styles['output__text']}>
-        <RichText text={value as string} />
+        <RichText text={value == null ? '' : String(value)} />
       </span>
     );
   };

--- a/frontend/src/public/components/TemplateEdit/TaskForm/Conditions/ConditionValueField/ConditionValueField.tsx
+++ b/frontend/src/public/components/TemplateEdit/TaskForm/Conditions/ConditionValueField/ConditionValueField.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable indent */
-import React, { useState, ReactNode, ChangeEvent } from 'react';
+import React, { ReactNode, ChangeEvent } from 'react';
 import { useSelector } from 'react-redux';
 import classnames from 'classnames';
 import { useIntl } from 'react-intl';
@@ -13,7 +13,7 @@ import { getUserFullName } from '../../../../../utils/users';
 import { EConditionOperators, TConditionRule } from '../types';
 import { OPERATORS_WITHOUT_VALUE } from '..';
 import { DatePickerCustom } from '../../../../UI/form/DatePicker';
-import { toTspDate } from '../../../../../utils/dateTime';
+import { parseUnixSeconds, toTspDate } from '../../../../../utils/dateTime';
 import { getFormattedDropdownOption } from '../utils/getFormattedDropdownOption';
 import styles from '../Conditions.css';
 import { EStartingType } from '../utils/getDropdownOperators';
@@ -95,11 +95,12 @@ export function ConditionValueField({
         value: item.value,
         label: item.value,
       }));
-
     } else if (variable?.selections?.length) {
-      dropdownSelections = variable.selections.map((selectionValue) => ({ value: selectionValue, label: selectionValue }));
+      dropdownSelections = variable.selections.map((selectionValue) => ({
+        value: selectionValue,
+        label: selectionValue,
+      }));
     } else {
-
       return null;
     }
 
@@ -151,9 +152,9 @@ export function ConditionValueField({
       value: `group-${group.id}`,
     }));
     const dropdownEntities = [...labelGroups, ...labelUsers];
-    const selectedEntity = dropdownEntities.find(
-      (entity) => entity.id === Number(rule.value) && entity.entityType === rule.fieldType,
-    ) || null;
+    const selectedEntity =
+      dropdownEntities.find((entity) => entity.id === Number(rule.value) && entity.entityType === rule.fieldType) ||
+      null;
 
     return (
       <DropdownList
@@ -162,7 +163,7 @@ export function ConditionValueField({
         placeholder={formatMessage({ id: 'templates.conditions.value-placeholder' })}
         value={selectedEntity}
         onChange={(option: IDropdownUser) => {
-          const kind = (option as any).entityType === 'user' ? 'user' : 'group';
+          const kind = option.entityType === 'user' ? 'user' : 'group';
           changeRuleValue(option.id, kind);
         }}
         isClearable={false}
@@ -182,20 +183,15 @@ export function ConditionValueField({
   }
 
   function renderDateField() {
-    const [selectedDate, setSelectedDate] = useState<number | null>(rule.value as number);
+    const unixSeconds = parseUnixSeconds(rule.value);
 
-    const handleChangeDate = (date: Date) => {
+    const handleChangeDate = (date: Date | null) => {
       if (!date) {
         changeRuleValue('');
-        setSelectedDate(null);
-
         return;
       }
 
-      const unixTime = toTspDate(date);
-
-      changeRuleValue(unixTime);
-      setSelectedDate(unixTime);
+      changeRuleValue(toTspDate(date));
     };
 
     return (
@@ -203,7 +199,7 @@ export function ConditionValueField({
         disabled={isDisabled}
         onChange={handleChangeDate}
         placeholderText={formatMessage({ id: 'templates.conditions.value-placeholder' })}
-        selected={selectedDate ? new Date(selectedDate * 1000) : null}
+        selected={unixSeconds !== null ? new Date(unixSeconds * 1000) : null}
         showPopperArrow={false}
       />
     );

--- a/frontend/src/public/components/TemplateEdit/TaskForm/Conditions/ConditionValueField/__tests__/ConditionValueField.test.tsx
+++ b/frontend/src/public/components/TemplateEdit/TaskForm/Conditions/ConditionValueField/__tests__/ConditionValueField.test.tsx
@@ -1,4 +1,39 @@
 /// <reference types="jest" />
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+
+import { enMessages } from '../../../../../../lang/locales/en_US';
+import { EExtraFieldType } from '../../../../../../types/template';
+import { TTaskVariable } from '../../../../types';
+import { EConditionLogicOperations, EConditionOperators, TConditionRule } from '../../types';
+import { ConditionValueField } from '../ConditionValueField';
+
+jest.mock('react-redux', () => {
+  const actual = jest.requireActual('react-redux');
+
+  return {
+    ...actual,
+    useSelector: jest.fn((selector: (state: { groups: { list: unknown[] } }) => unknown) =>
+      selector({ groups: { list: [] } }),
+    ),
+    useDispatch: () => jest.fn(),
+  };
+});
+
+jest.mock('../../../../../Field', () => ({
+  Field: () => null,
+}));
+
+jest.mock('../../utils/useLazyDataset', () => ({
+  useLazyDataset: jest.fn(() => undefined),
+}));
+
+jest.mock('../../../../../UI/form/DatePicker', () => ({
+  DatePickerCustom: ({ selected }: { selected: Date | null }) => (
+    <span data-testid="condition-date-picker">{selected ? 'has-date' : 'empty'}</span>
+  ),
+}));
 
 type TConditionEntity = {
   id: number;
@@ -21,6 +56,38 @@ const findSelectedEntity = (
     (entity) => entity.id === Number(rule.value) && entity.entityType === rule.fieldType,
   ) || null;
 
+const dateVariable: TTaskVariable = {
+  title: 'Deadline',
+  apiName: 'date-deadline',
+  type: EExtraFieldType.Date,
+};
+
+const makeDateRule = (overrides: Partial<TConditionRule> = {}): TConditionRule => ({
+  ruleApiName: 'rule-1',
+  predicateApiName: 'pred-1',
+  logicOperation: EConditionLogicOperations.And,
+  field: dateVariable.apiName,
+  fieldType: EExtraFieldType.Date,
+  operator: null,
+  value: undefined,
+  ...overrides,
+} as TConditionRule);
+
+const renderValueField = (props: Partial<React.ComponentProps<typeof ConditionValueField>> = {}) =>
+  render(
+    <IntlProvider locale="en" messages={enMessages}>
+      <ConditionValueField
+        variable={dateVariable}
+        operator={null}
+        rule={makeDateRule()}
+        users={[]}
+        isDisabled={false}
+        changeRuleValue={jest.fn()}
+        {...props}
+      />
+    </IntlProvider>,
+  );
+
 describe('ConditionValueField user/group selection logic', () => {
   const dropdownEntities = buildDropdownEntities();
 
@@ -41,5 +108,57 @@ describe('ConditionValueField user/group selection logic', () => {
     const groupEntity = dropdownEntities.find((entity) => entity.entityType === 'group');
 
     expect(groupEntity?.id === rule.value && groupEntity?.entityType === rule.fieldType).toBe(false);
+  });
+});
+
+describe('ConditionValueField date field', () => {
+  it('does not crash when a date field is selected before an operator', () => {
+    expect(() => renderValueField()).not.toThrow();
+    expect(screen.queryByTestId('condition-date-picker')).not.toBeInTheDocument();
+  });
+
+  it('shows the date picker after choosing an operator with a value', () => {
+    const { rerender } = renderValueField();
+
+    rerender(
+      <IntlProvider locale="en" messages={enMessages}>
+        <ConditionValueField
+          variable={dateVariable}
+          operator={EConditionOperators.Equal}
+          rule={makeDateRule({ operator: EConditionOperators.Equal })}
+          users={[]}
+          isDisabled={false}
+          changeRuleValue={jest.fn()}
+        />
+      </IntlProvider>,
+    );
+
+    expect(screen.getByTestId('condition-date-picker')).toHaveTextContent('empty');
+  });
+
+  it('does not crash when switching from equals to exists', () => {
+    const { rerender } = renderValueField({
+      operator: EConditionOperators.Equal,
+      rule: makeDateRule({ operator: EConditionOperators.Equal, value: 1718409600 }),
+    });
+
+    expect(screen.getByTestId('condition-date-picker')).toHaveTextContent('has-date');
+
+    expect(() =>
+      rerender(
+        <IntlProvider locale="en" messages={enMessages}>
+          <ConditionValueField
+            variable={dateVariable}
+            operator={EConditionOperators.Exist}
+            rule={makeDateRule({ operator: EConditionOperators.Exist })}
+            users={[]}
+            isDisabled={false}
+            changeRuleValue={jest.fn()}
+          />
+        </IntlProvider>,
+      ),
+    ).not.toThrow();
+
+    expect(screen.queryByTestId('condition-date-picker')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/public/utils/__tests__/dateTime.test.ts
+++ b/frontend/src/public/utils/__tests__/dateTime.test.ts
@@ -4,6 +4,8 @@ import {
   formatDuration,
   getSeconds,
   parseDuration,
+  parseUnixSeconds,
+  toDateString,
 } from '../dateTime';
 
 describe('dateTime', () => {
@@ -53,6 +55,36 @@ describe('dateTime', () => {
       const expected = '12 07:00:00';
 
       expect(result).toEqual(expected);
+    });
+  });
+
+  describe('parseUnixSeconds', () => {
+    it('returns finite numbers as unix seconds', () => {
+      expect(parseUnixSeconds(1718409600)).toBe(1718409600);
+    });
+
+    it('parses numeric strings', () => {
+      expect(parseUnixSeconds('1718409600')).toBe(1718409600);
+    });
+
+    it('returns null for formatted dates and empty values', () => {
+      expect(parseUnixSeconds('Jun 15, 2024')).toBeNull();
+      expect(parseUnixSeconds('')).toBeNull();
+      expect(parseUnixSeconds(null)).toBeNull();
+    });
+  });
+
+  describe('toDateString', () => {
+    it('formats a unix timestamp number', () => {
+      expect(toDateString(1718409600, 'UTC')).toMatch(/15, 2024/);
+    });
+
+    it('formats a unix timestamp string', () => {
+      expect(toDateString('1718409600', 'UTC')).toMatch(/15, 2024/);
+    });
+
+    it('returns null for invalid values instead of throwing', () => {
+      expect(toDateString('not-a-date', 'UTC')).toBeNull();
     });
   });
 });

--- a/frontend/src/public/utils/__tests__/mappers.dateFields.test.ts
+++ b/frontend/src/public/utils/__tests__/mappers.dateFields.test.ts
@@ -1,0 +1,38 @@
+import { EExtraFieldType } from '../../types/template';
+import { makeExtraField } from '../../__stubs__/fields.factory';
+import { mapTspToString } from '../mappers';
+
+describe('mapTspToString', () => {
+  it('formats numeric unix date fields', () => {
+    const output = [
+      makeExtraField({
+        type: EExtraFieldType.Date,
+        value: 1718409600,
+      }),
+    ];
+
+    expect(mapTspToString(output, 'UTC')[0].value).toMatch(/15, 2024/);
+  });
+
+  it('formats string unix date fields', () => {
+    const output = [
+      makeExtraField({
+        type: EExtraFieldType.Date,
+        value: '1718409600',
+      }),
+    ];
+
+    expect(mapTspToString(output, 'UTC')[0].value).toMatch(/15, 2024/);
+  });
+
+  it('leaves non-date fields unchanged', () => {
+    const output = [
+      makeExtraField({
+        type: EExtraFieldType.String,
+        value: 'keep-me',
+      }),
+    ];
+
+    expect(mapTspToString(output, 'UTC')[0].value).toBe('keep-me');
+  });
+});

--- a/frontend/src/public/utils/dateTime.ts
+++ b/frontend/src/public/utils/dateTime.ts
@@ -156,11 +156,26 @@ export const isExpired = (deadlineDateISO: string | null, compareDateISO?: strin
 export const DATE_STRING_MOMENT_TEMPLATE = 'MMM DD, YYYY';
 export const DATE_STRING_FNS_TEMPLATE = 'MMM dd, yyyy';
 
+const UNIX_SECONDS_RE = /^[0-9]+(\.[0-9]+)?$/;
+
+export const parseUnixSeconds = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string' && UNIX_SECONDS_RE.test(value)) {
+    return Number(value);
+  }
+
+  return null;
+};
+
 export const getEndOfDayTsp = (date: string | Date): number | null => {
   if (!date) return null;
 
-  if (typeof date === 'string' && /^[0-9]+(\.[0-9]+)?$/.test(date)) {
-    return +date;
+  const unixSeconds = parseUnixSeconds(date);
+  if (unixSeconds !== null) {
+    return unixSeconds;
   }
   const momentDate = moment(date);
 
@@ -173,8 +188,9 @@ export const getEndOfDayTsp = (date: string | Date): number | null => {
 
 export const toDate = (date: number | string | null): Date | null => {
   if (!date) return null;
-  if (typeof date === 'number' || (typeof date === 'string' && /^[0-9]+(\.[0-9]+)?$/.test(date))) {
-    return moment(+date * 1000).toDate();
+  const unixSeconds = parseUnixSeconds(date);
+  if (unixSeconds !== null) {
+    return moment(unixSeconds * 1000).toDate();
   }
   if (typeof date === 'string') {
     return moment(date).toDate();
@@ -183,18 +199,30 @@ export const toDate = (date: number | string | null): Date | null => {
 };
 
 export const toDateString = (date: Date | number | string, timezone?: string): string | null => {
-  if (!date) return null;
+  if (!date && date !== 0) return null;
 
+  const zone = timezone || 'UTC';
   let momentDate;
+
   if (date instanceof Date) {
-    momentDate = moment(date);
+    momentDate = moment(date).tz(zone);
   } else {
-    momentDate = moment.tz(+date * 1000, timezone || 'UTC');
+    const unixSeconds = parseUnixSeconds(date);
+    if (unixSeconds !== null) {
+      momentDate = moment.tz(unixSeconds * 1000, zone);
+    } else if (typeof date === 'string') {
+      const isoDate = moment.utc(date, moment.ISO_8601, true);
+      const formattedDate = moment(date, DATE_STRING_MOMENT_TEMPLATE, true);
+      momentDate = isoDate.isValid() ? isoDate.tz(zone) : formattedDate;
+    } else {
+      return null;
+    }
   }
 
   if (!momentDate.isValid()) {
-    throw new Error(`toDateString: Invalid data format. Received: date: ${date}, timezone: ${timezone}`);
+    return null;
   }
+
   return momentDate.format(DATE_STRING_MOMENT_TEMPLATE);
 };
 

--- a/frontend/src/public/utils/mappers.ts
+++ b/frontend/src/public/utils/mappers.ts
@@ -236,10 +236,20 @@ export const mapBackandworkflowLogToRedux = (workflowLog: IWorkflowLogItem[], ti
 };
 
 export const mapTspToString = (output: IExtraField[], timezone: string): IExtraField[] => {
-  return output.map((item) => ({
-    ...item,
-    value: item.type === 'date' && typeof item.value === 'string' ? toDateString(item.value, timezone) : item.value,
-  }));
+  return output.map((item) => {
+    if (item.type !== 'date' || item.value == null || item.value === '') {
+      return item;
+    }
+
+    if (typeof item.value !== 'string' && typeof item.value !== 'number') {
+      return item;
+    }
+
+    return {
+      ...item,
+      value: toDateString(item.value, timezone),
+    };
+  });
 };
 
 export const formatTaskDatesForRedux = <T extends TFormatTaskDates>(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches shared date formatting used in Redux mappers and template conditions; behavior changes from throwing to returning null on invalid dates could affect edge-case display.
> 
> **Overview**
> Fixes the template **“check if”** crash on date fields by making condition value rendering safe when the operator is missing or changes (e.g. equals → exists).
> 
> **ConditionValueField** no longer keeps date state in a hook inside `renderDateField`; it derives the picker value from `parseUnixSeconds(rule.value)` and writes back via `toTspDate`. User/group dropdown typing drops an `any` cast on `entityType`.
> 
> Shared date utilities add **`parseUnixSeconds`** and route `getEndOfDayTsp` / `toDate` through it. **`toDateString`** accepts numeric and string unix timestamps, tolerates more string shapes, and returns `null` instead of throwing on bad input.
> 
> **`mapTspToString`** formats date kickoff/output values when they are numbers or unix strings, not only pre-formatted strings. **`TextOutput`** coerces nullish values before `RichText` so formatted dates display reliably.
> 
> Tests cover date condition flows, `parseUnixSeconds` / `toDateString`, and `mapTspToString` for numeric date fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c0979f128711400b10a809d4f3744695d18732b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix app crash when selecting "check if" on date fields and unsafe value rendering in templates
> - Fixes a React hook-order crash in `ConditionValueField` by removing a conditional `useState` and deriving the date picker value directly from `parseUnixSeconds` when rendering date conditions.
> - Fixes a crash in `TextOutput` by explicitly stringifying field values before rendering, converting nullish values to empty strings instead of asserting they are strings.
> - Adds the `parseUnixSeconds` utility to robustly parse numeric timestamps, and updates `toDateString` and `mapTspToString` to handle numeric inputs and invalid values safely.
> - Risk: `toDateString` now returns `null` for invalid or unsupported values instead of throwing an error, changing behavior for callers that catch exceptions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7c0979f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->