### PR TITLE
49470 frontend [ fieldset ] Fix handle missing or null fieldsets

### DIFF
--- a/frontend/src/public/utils/__tests__/mapFieldsetsAPIToClient.test.ts
+++ b/frontend/src/public/utils/__tests__/mapFieldsetsAPIToClient.test.ts
@@ -8,6 +8,14 @@ describe('mapFieldsetBindingsToClient', () => {
     expect(mapFieldsetBindingsToClient([])).toEqual([]);
   });
 
+  it('returns an empty array when undefined or null is provided', () => {
+    const undefinedInput = undefined as unknown as Parameters<typeof mapFieldsetBindingsToClient>[0];
+    const nullInput = null as unknown as Parameters<typeof mapFieldsetBindingsToClient>[0];
+
+    expect(mapFieldsetBindingsToClient(undefinedInput)).toEqual([]);
+    expect(mapFieldsetBindingsToClient(nullInput)).toEqual([]);
+  });
+
   it('renames apiName to apiNameBinding and drops apiName', () => {
     const result = mapFieldsetBindingsToClient([makeFieldsetBinding({ apiName: 'catalog-abc' })]);
 
@@ -62,6 +70,14 @@ describe('mapFieldsetBindingsToClient', () => {
 describe('mapFieldsetTaskAPIToRuntime', () => {
   it('returns an empty array for empty input', () => {
     expect(mapFieldsetTaskAPIToRuntime([])).toEqual([]);
+  });
+
+  it('returns an empty array when undefined or null is provided in runtime', () => {
+    const undefinedInput = undefined as unknown as Parameters<typeof mapFieldsetTaskAPIToRuntime>[0];
+    const nullInput = null as unknown as Parameters<typeof mapFieldsetTaskAPIToRuntime>[0];
+
+    expect(mapFieldsetTaskAPIToRuntime(undefinedInput)).toEqual([]);
+    expect(mapFieldsetTaskAPIToRuntime(nullInput)).toEqual([]);
   });
 
   it('renames apiName to apiNameBinding and drops both id and apiName', () => {

--- a/frontend/src/public/utils/mapFieldsetsAPIToClient.ts
+++ b/frontend/src/public/utils/mapFieldsetsAPIToClient.ts
@@ -1,14 +1,14 @@
 import { IFieldsetBinding, IFieldsetBindingClient, IFieldsetTaskAPI, IFieldsetRuntime } from '../types/fieldset';
 
-export function mapFieldsetBindingsToClient(fieldsets: IFieldsetBinding[]): IFieldsetBindingClient[] {
-  return fieldsets.map(({ apiName, ...rest }) => ({
+export function mapFieldsetBindingsToClient(fieldsets: IFieldsetBinding[] = []): IFieldsetBindingClient[] {
+  return (fieldsets || []).map(({ apiName, ...rest }) => ({
     ...rest,
     apiNameBinding: apiName,
   }));
 }
 
-export function mapFieldsetTaskAPIToRuntime(fieldsets: IFieldsetTaskAPI[]): IFieldsetRuntime[] {
-  return fieldsets.map(({ id, apiName, ...rest }) => ({
+export function mapFieldsetTaskAPIToRuntime(fieldsets: IFieldsetTaskAPI[] = []): IFieldsetRuntime[] {
+  return (fieldsets || []).map(({ id, apiName, ...rest }) => ({
     ...rest,
     apiNameBinding: apiName,
   }));


### PR DESCRIPTION
## 1. Release notes

- Fixed an issue where loading process templates would fail when task `fieldsets` were missing or returned as `null` by the server.

---

## 2. Description (problem)

- **Problem:** When attempting to open certain templates (AI-generated, legacy, or system templates), the UI suffered a critical crash: `Failed to load template: TypeError: Cannot read properties of undefined (reading 'map') at mapFieldsetBindingsToClient`.
- **Where it occurred:** Template editor and creation screens (`/templates/edit/:id`, `/templates`), as well as workflow launch modals.
- **Root Cause:** Backend API responses for some tasks returned `"fieldsets": null` or omitted the property entirely, whereas the frontend expected a valid array and executed `.map()`.

---

## 3. Context

- **Task:** #49470
- **Area:** Template Editor, API template response normalization (`getNormalizedTemplate`).

---

## 4. Solution

- Added defensive fallback logic `(fieldsets || [])` in `mapFieldsetBindingsToClient` and runtime utility `mapFieldsetTaskAPIToRuntime`.
- Ensured that the frontend gracefully defaults to an empty array `[]` when receiving `undefined` or `null`.

---

## 5. Implementation details

- **`src/public/utils/mapFieldsetsAPIToClient.ts`**:
  - **Before:** Functions `mapFieldsetBindingsToClient` and `mapFieldsetTaskAPIToRuntime` called `fieldsets.map(...)` without validating array presence.
  - **After:** Added default parameter `fieldsets = []` and protective check `(fieldsets || []).map(...)`.

---

## 6. QA Testing Guide

### 6.1 Preconditions
- Open the application in a local or dev environment.

### 6.2 Positive Scenarios / Test Report

| Scenario | Description (Steps & Expected Result) | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| :--- | :--- | :--- | :--- | :--- | :--- |
| **Load Template with Fieldsets** | 1. Open a template containing fieldsets.<br>2. Verify tasks and fieldsets display.<br>**Expected:** Template opens correctly and fieldsets render. | [ ] | [ ] | [ ] | [ ] |
| **AI Template Generation** | 1. Generate a new template using AI.<br>2. Open generated template.<br>**Expected:** Template loads without console errors. | [ ] | [ ] | [ ] | [ ] |

### 6.3 Negative Scenarios & Edge Cases

| Scenario | Description (Steps & Expected Result) | Chrome Desktop | Safari Desktop | Chrome Mobile | Safari Mobile |
| :--- | :--- | :--- | :--- | :--- | :--- |
| **Load Template with fieldsets: null** | 1. Fetch a template where task API response contains `"fieldsets": null`.<br>2. Open template editor.<br>**Expected:** UI does not crash, template displays with empty fieldset list. | [ ] | [ ] | [ ] | [ ] |
| **Load Template with omitted fieldsets property** | 1. Fetch a template where task JSON lacks the `"fieldsets"` key.<br>2. Open template.<br>**Expected:** Template loads successfully. | [ ] | [ ] | [ ] | [ ] |

### 6.4 Verification Points
- Browser developer console is free of `TypeError: Cannot read properties of undefined (reading 'map')`.

### 6.5 API Verification
- **Incoming Responses:** When calling `GET /api/v1/templates/:id`, if the backend returns `"fieldsets": null`, frontend normalizes it to `[]`.

### 6.6 What Was NOT Tested
- Production environment testing (tested on local dev server).

---

## 7. Unit Tests

- **`src/public/utils/__tests__/mapFieldsetsAPIToClient.test.ts`**:
  - Added test `returns an empty array when undefined or null is provided` for `mapFieldsetBindingsToClient`.
  - Added test `returns an empty array when undefined or null is provided in runtime` for `mapFieldsetTaskAPIToRuntime`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive normalization in mapping utilities with unit test coverage; no auth or data-model changes.
> 
> **Overview**
> Prevents template load crashes when task **fieldsets** are `null` or omitted from API responses by hardening the fieldset API-to-client mappers.
> 
> **`mapFieldsetBindingsToClient`** and **`mapFieldsetTaskAPIToRuntime`** now default missing input to `[]` and use `(fieldsets || [])` before mapping, so callers no longer hit `Cannot read properties of undefined (reading 'map')`. Unit tests cover `null` and `undefined` for both helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 131d6c00b11c64fbe6bdcdde87c10be3d3392045. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `mapFieldsetBindingsToClient` and `mapFieldsetTaskAPIToRuntime` to handle null/undefined fieldsets
> Both mappers in [mapFieldsetsAPIToClient.ts](https://github.com/pneumaticapp/pneumaticworkflow/pull/364/files#diff-acd80aafdff3ed99d71e8481c0800802a2aed92e91944b3c3ba79651186a02f7) now default their array parameter to an empty array and fall back to it when the input is falsy. Previously, passing `undefined` or `null` attempted `.map()` on a non-array value.
> - Adds tests covering `undefined` and `null` inputs asserting empty-array results.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 131d6c0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->