### PR TITLE
49477 storage [ PostgreSQL ] Combine two postgresql containers into one

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Shell scripts are executed by Linux (containers, servers) and by Git Bash.
+# A CRLF checkout on Windows breaks them: the carriage return becomes part of
+# the interpreter path, so the file cannot be executed at all.
+*.sh text eol=lf

--- a/default.env
+++ b/default.env
@@ -207,7 +207,7 @@
 # FILE_POSTGRES_USER=pneumatic
 # FILE_POSTGRES_PASSWORD=pneumatic
 # FILE_POSTGRES_DB=pneumatic
-# FILE_POSTGRES_HOST=file-postgres
+# FILE_POSTGRES_HOST=postgres
 # FILE_POSTGRES_PORT=5432
 
 # --- File Service Storage: Local (SeaweedFS) ---

--- a/docker-compose.src.yml
+++ b/docker-compose.src.yml
@@ -13,11 +13,19 @@ services:
       POSTGRES_REPLICA_USER: ${POSTGRES_REPLICA_USER:-postgres_user}
       POSTGRES_REPLICA_PASSWORD: ${POSTGRES_REPLICA_PASSWORD:-postgres_password}
       POSTGRES_REPLICA_DB: ${POSTGRES_REPLICA_DB:-postgres_db}
+      FILE_POSTGRES_USER: ${FILE_POSTGRES_USER:-pneumatic}
+      FILE_POSTGRES_PASSWORD: ${FILE_POSTGRES_PASSWORD:-pneumatic}
+      FILE_POSTGRES_DB: ${FILE_POSTGRES_DB:-pneumatic}
     volumes:
       - ./postgres/data:/var/lib/postgresql/data:rw
       - ./postgres/backups:/backups:rw
+      - ./scripts/postgres-init:/docker-entrypoint-initdb.d:ro
     expose:
       - 5432
+    healthcheck:
+      test: ["CMD", "pg_isready", "-h", "localhost"]
+      interval: 5s
+      start_period: 60s
     networks:
       - pneumatic
     restart: always
@@ -170,7 +178,7 @@ services:
       FILE_POSTGRES_USER: ${FILE_POSTGRES_USER:-pneumatic}
       FILE_POSTGRES_PASSWORD: ${FILE_POSTGRES_PASSWORD:-pneumatic}
       FILE_POSTGRES_DB: ${FILE_POSTGRES_DB:-pneumatic}
-      FILE_POSTGRES_HOST: ${FILE_POSTGRES_HOST:-file-postgres}
+      FILE_POSTGRES_HOST: ${FILE_POSTGRES_HOST:-postgres}
       FILE_POSTGRES_PORT: ${FILE_POSTGRES_PORT:-5432}
     expose:
       - 8000
@@ -297,7 +305,7 @@ services:
       FILE_POSTGRES_USER: ${FILE_POSTGRES_USER:-pneumatic}
       FILE_POSTGRES_PASSWORD: ${FILE_POSTGRES_PASSWORD:-pneumatic}
       FILE_POSTGRES_DB: ${FILE_POSTGRES_DB:-pneumatic}
-      FILE_POSTGRES_HOST: ${FILE_POSTGRES_HOST:-file-postgres}
+      FILE_POSTGRES_HOST: ${FILE_POSTGRES_HOST:-postgres}
       FILE_POSTGRES_PORT: ${FILE_POSTGRES_PORT:-5432}
     volumes:
       - ./backend:/pneumatic_backend
@@ -417,7 +425,7 @@ services:
       FILE_POSTGRES_USER: ${FILE_POSTGRES_USER:-pneumatic}
       FILE_POSTGRES_PASSWORD: ${FILE_POSTGRES_PASSWORD:-pneumatic}
       FILE_POSTGRES_DB: ${FILE_POSTGRES_DB:-pneumatic}
-      FILE_POSTGRES_HOST: ${FILE_POSTGRES_HOST:-file-postgres}
+      FILE_POSTGRES_HOST: ${FILE_POSTGRES_HOST:-postgres}
       FILE_POSTGRES_PORT: ${FILE_POSTGRES_PORT:-5432}
     volumes:
       - ./backend:/pneumatic_backend
@@ -520,7 +528,7 @@ services:
       POSTGRES_USER: ${FILE_POSTGRES_USER:-pneumatic}
       POSTGRES_PASSWORD: ${FILE_POSTGRES_PASSWORD:-pneumatic}
       POSTGRES_DB: ${FILE_POSTGRES_DB:-pneumatic}
-      POSTGRES_HOST: ${FILE_POSTGRES_HOST:-file-postgres}
+      POSTGRES_HOST: ${FILE_POSTGRES_HOST:-postgres}
       POSTGRES_PORT: ${FILE_POSTGRES_PORT:-5432}
       STORAGE_TYPE: ${FILE_STORAGE_TYPE:-local}
       SEAWEEDFS_S3_ENDPOINT: ${FILE_SEAWEEDFS_S3_ENDPOINT:-http://seaweedfs-filer:8333}
@@ -544,30 +552,12 @@ services:
       sh -c "poetry run alembic -c src/shared_kernel/database/alembic.ini upgrade head &&
              poetry run uvicorn src.main:app --host 0.0.0.0 --port ${FILE_PORT:-8000} --workers ${FILE_WORKERS:-1}"
     depends_on:
-      file-postgres:
+      postgres:
         condition: service_healthy
       redis:
         condition: service_started
     expose:
       - 8000
-    networks:
-      - pneumatic
-    restart: always
-
-  file-postgres:
-    image: postgres:15-bookworm
-    container_name: pneumatic-file-postgres
-    environment:
-      POSTGRES_DB: ${FILE_POSTGRES_DB:-pneumatic}
-      POSTGRES_USER: ${FILE_POSTGRES_USER:-pneumatic}
-      POSTGRES_PASSWORD: ${FILE_POSTGRES_PASSWORD:-pneumatic}
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U pneumatic -d pneumatic"]
-      interval: 5s
-      timeout: 5s
-      retries: 5
-    volumes:
-      - ./file-postgres/data:/var/lib/postgresql/data:rw
     networks:
       - pneumatic
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,11 +13,19 @@ services:
       POSTGRES_REPLICA_USER: ${POSTGRES_REPLICA_USER:-postgres_user}
       POSTGRES_REPLICA_PASSWORD: ${POSTGRES_REPLICA_PASSWORD:-postgres_password}
       POSTGRES_REPLICA_DB: ${POSTGRES_REPLICA_DB:-postgres_db}
+      FILE_POSTGRES_USER: ${FILE_POSTGRES_USER:-pneumatic}
+      FILE_POSTGRES_PASSWORD: ${FILE_POSTGRES_PASSWORD:-pneumatic}
+      FILE_POSTGRES_DB: ${FILE_POSTGRES_DB:-pneumatic}
     volumes:
       - ./postgres/data:/var/lib/postgresql/data:rw
       - ./postgres/backups:/backups:rw
+      - ./scripts/postgres-init:/docker-entrypoint-initdb.d:ro
     expose:
       - 5432
+    healthcheck:
+      test: ["CMD", "pg_isready", "-h", "localhost"]
+      interval: 5s
+      start_period: 60s
     networks:
       - pneumatic
     restart: always
@@ -170,7 +178,7 @@ services:
       FILE_POSTGRES_USER: ${FILE_POSTGRES_USER:-pneumatic}
       FILE_POSTGRES_PASSWORD: ${FILE_POSTGRES_PASSWORD:-pneumatic}
       FILE_POSTGRES_DB: ${FILE_POSTGRES_DB:-pneumatic}
-      FILE_POSTGRES_HOST: ${FILE_POSTGRES_HOST:-file-postgres}
+      FILE_POSTGRES_HOST: ${FILE_POSTGRES_HOST:-postgres}
       FILE_POSTGRES_PORT: ${FILE_POSTGRES_PORT:-5432}
     volumes:
       - ./backend:/pneumatic_backend
@@ -295,7 +303,7 @@ services:
       FILE_POSTGRES_USER: ${FILE_POSTGRES_USER:-pneumatic}
       FILE_POSTGRES_PASSWORD: ${FILE_POSTGRES_PASSWORD:-pneumatic}
       FILE_POSTGRES_DB: ${FILE_POSTGRES_DB:-pneumatic}
-      FILE_POSTGRES_HOST: ${FILE_POSTGRES_HOST:-file-postgres}
+      FILE_POSTGRES_HOST: ${FILE_POSTGRES_HOST:-postgres}
       FILE_POSTGRES_PORT: ${FILE_POSTGRES_PORT:-5432}
     volumes:
       - ./backend:/pneumatic_backend
@@ -415,7 +423,7 @@ services:
       FILE_POSTGRES_USER: ${FILE_POSTGRES_USER:-pneumatic}
       FILE_POSTGRES_PASSWORD: ${FILE_POSTGRES_PASSWORD:-pneumatic}
       FILE_POSTGRES_DB: ${FILE_POSTGRES_DB:-pneumatic}
-      FILE_POSTGRES_HOST: ${FILE_POSTGRES_HOST:-file-postgres}
+      FILE_POSTGRES_HOST: ${FILE_POSTGRES_HOST:-postgres}
       FILE_POSTGRES_PORT: ${FILE_POSTGRES_PORT:-5432}
     volumes:
       - ./backend:/pneumatic_backend
@@ -516,7 +524,7 @@ services:
       POSTGRES_USER: ${FILE_POSTGRES_USER:-pneumatic}
       POSTGRES_PASSWORD: ${FILE_POSTGRES_PASSWORD:-pneumatic}
       POSTGRES_DB: ${FILE_POSTGRES_DB:-pneumatic}
-      POSTGRES_HOST: ${FILE_POSTGRES_HOST:-file-postgres}
+      POSTGRES_HOST: ${FILE_POSTGRES_HOST:-postgres}
       POSTGRES_PORT: ${FILE_POSTGRES_PORT:-5432}
       STORAGE_TYPE: ${FILE_STORAGE_TYPE:-local}
       SEAWEEDFS_S3_ENDPOINT: ${FILE_SEAWEEDFS_S3_ENDPOINT:-http://seaweedfs-filer:8333}
@@ -541,32 +549,12 @@ services:
       sh -c "poetry run alembic -c src/shared_kernel/database/alembic.ini upgrade head &&
              poetry run uvicorn src.main:app --host 0.0.0.0 --port ${FILE_PORT:-8000} --workers ${FILE_WORKERS:-1}"
     depends_on:
-      file-postgres:
+      postgres:
         condition: service_healthy
       redis:
         condition: service_started
     expose:
       - 8000
-    networks:
-      - pneumatic
-    restart: always
-
-  file-postgres:
-    image: postgres:15-bookworm
-    container_name: pneumatic-file-postgres
-    environment:
-      POSTGRES_DB: ${FILE_POSTGRES_DB:-pneumatic}
-      POSTGRES_USER: ${FILE_POSTGRES_USER:-pneumatic}
-      POSTGRES_PASSWORD: ${FILE_POSTGRES_PASSWORD:-pneumatic}
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U pneumatic -d pneumatic"]
-      interval: 5s
-      timeout: 5s
-      retries: 5
-    expose:
-      - 5432
-    volumes:
-      - ./file-postgres/data:/var/lib/postgresql/data:rw
     networks:
       - pneumatic
     restart: always

--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -13,11 +13,21 @@ services:
       POSTGRES_REPLICA_USER: ${POSTGRES_REPLICA_USER:-postgres_user}
       POSTGRES_REPLICA_PASSWORD: ${POSTGRES_REPLICA_PASSWORD:-postgres_password}
       POSTGRES_REPLICA_DB: ${POSTGRES_REPLICA_DB:-postgres_db}
+      FILE_POSTGRES_USER: ${FILE_POSTGRES_USER:-pneumatic}
+      FILE_POSTGRES_PASSWORD: ${FILE_POSTGRES_PASSWORD:-pneumatic}
+      FILE_POSTGRES_DB: ${FILE_POSTGRES_DB:-pneumatic}
     volumes:
       - ../postgres/data:/var/lib/postgresql/data:rw
       - ../postgres/backups:/backups:rw
+      - ../scripts/postgres-init:/docker-entrypoint-initdb.d:ro
     expose:
       - 5432
+    ports:
+      - "5433:5432"
+    healthcheck:
+      test: ["CMD", "pg_isready", "-h", "localhost"]
+      interval: 5s
+      start_period: 60s
     networks:
       - pneumatic
     restart: always
@@ -418,7 +428,7 @@ services:
       POSTGRES_USER: ${FILE_POSTGRES_USER:-pneumatic}
       POSTGRES_PASSWORD: ${FILE_POSTGRES_PASSWORD:-pneumatic}
       POSTGRES_DB: ${FILE_POSTGRES_DB:-pneumatic}
-      POSTGRES_HOST: ${FILE_POSTGRES_HOST:-file-postgres}
+      POSTGRES_HOST: ${FILE_POSTGRES_HOST:-postgres}
       POSTGRES_PORT: ${FILE_POSTGRES_PORT:-5432}
       STORAGE_TYPE: ${FILE_STORAGE_TYPE:-local}
       SEAWEEDFS_S3_ENDPOINT: ${FILE_SEAWEEDFS_S3_ENDPOINT:-http://seaweedfs-filer:8333}
@@ -440,24 +450,12 @@ services:
     ports:
       - "8002:8000"
     depends_on:
-      - file-postgres
-      - redis
-      - seaweedfs-filer
-    networks:
-      - pneumatic
-    restart: always
-
-  file-postgres:
-    image: postgres:15-bookworm
-    container_name: pneumatic-file-postgres
-    environment:
-      POSTGRES_DB: ${FILE_POSTGRES_DB:-pneumatic}
-      POSTGRES_USER: ${FILE_POSTGRES_USER:-pneumatic}
-      POSTGRES_PASSWORD: ${FILE_POSTGRES_PASSWORD:-pneumatic}
-    ports:
-      - "5433:5432"
-    volumes:
-      - ../file-postgres/data:/var/lib/postgresql/data:rw
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_started
+      seaweedfs-filer:
+        condition: service_started
     networks:
       - pneumatic
     restart: always

--- a/scripts/migrate_file_db.sh
+++ b/scripts/migrate_file_db.sh
@@ -1,0 +1,404 @@
+#!/bin/bash
+
+# =============================================================================
+# Move the file service database into the shared "pneumatic-postgres" container
+#
+# Earlier versions ran the file service database in a separate container
+# ("pneumatic-file-postgres", data in "file-postgres/data"). It now lives in
+# "pneumatic-postgres" as a separate database, provisioned by
+# "scripts/postgres-init/create-file-service-db.sh" when that container
+# initialises its data directory. An installation that is being upgraded already
+# has an initialised data directory, so run this script once. It:
+#   1. dumps the legacy database into "postgres/backups" (if there is one)
+#   2. creates the file service role and database in "pneumatic-postgres"
+#   3. restores the dump there (the target database is overwritten)
+#   4. removes the legacy container and starts the stack
+# The legacy data directory "file-postgres/data" is left untouched.
+#
+# Upgrading from a version without a file service works too: there is nothing
+# to copy, so the script only creates the database.
+# =============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+BACKUPS_DIR="$PROJECT_DIR/postgres/backups"
+LEGACY_DATA_DIR="$PROJECT_DIR/file-postgres/data"
+
+LEGACY_CONTAINER="pneumatic-file-postgres"
+TEMP_CONTAINER="pneumatic-file-postgres-migration"
+TARGET_CONTAINER="pneumatic-postgres"
+FILE_SERVICE_CONTAINER="pneumatic-file-service"
+NGINX_CONTAINER="pneumatic-nginx"
+POSTGRES_IMAGE="postgres:15-bookworm"
+INIT_SCRIPT="/docker-entrypoint-initdb.d/create-file-service-db.sh"
+
+# =============================================================================
+# Color output helpers
+# =============================================================================
+
+RED='\033[0;31m'
+ORANGE='\033[0;33m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+print_error()   { echo -e "${RED}$1${NC}"; }
+print_warning() { echo -e "${ORANGE}$1${NC}"; }
+print_info()    { echo -e "${GREEN}$1${NC}"; }
+
+TEMP_CONTAINER_CREATED=false
+FILE_SERVICE_STOPPED=false
+
+fail() {
+  print_error "$1"
+  if [ "$TEMP_CONTAINER_CREATED" = true ]; then
+    docker rm -f "$TEMP_CONTAINER" > /dev/null 2>&1
+  fi
+  if [ "$FILE_SERVICE_STOPPED" = true ]; then
+    # Deliberately not restarted: the database may be half copied, and serving
+    # files from it would be worse than serving none.
+    print_warning "Container \"$FILE_SERVICE_CONTAINER\" is still stopped. Fix the problem and run this script again, or start it with: docker start $FILE_SERVICE_CONTAINER"
+  fi
+  exit 1
+}
+
+# Row count of every table in the file service database, one "table=count" line
+# each. The copy is verified against this rather than against a single table, so
+# that a partial restore cannot pass unnoticed. Returns non-zero when the
+# database cannot be read at all, which is different from it having no tables.
+table_counts() {
+  local out
+  out=$(docker exec "$1" psql -U "$FILE_POSTGRES_USER" -d "$FILE_POSTGRES_DB" -tAc "
+    SELECT tablename || '=' || (xpath('/row/c/text()',
+             query_to_xml(format('SELECT count(*) AS c FROM public.%I', tablename), false, true, '')))[1]::text
+      FROM pg_tables
+     WHERE schemaname = 'public'
+     ORDER BY tablename" 2>&1) || { printf '%s\n' "$out" >&2; return 1; }
+  printf '%s' "$out" | tr -d '\r' | sed '/^$/d'
+}
+
+# Same counts on one line, for reporting.
+format_counts() {
+  if [ -z "$1" ]; then
+    echo "no tables"
+  else
+    echo "$1" | tr '\n' ' ' | sed 's/[[:space:]]*$//'
+  fi
+}
+
+confirm() {
+  while true; do
+    read -r -p "$1 (y/n): " answer || fail "No input received, aborting."
+    case "$answer" in
+      y) return 0 ;;
+      n) print_warning "Operation cancelled."; exit 0 ;;
+      *) ;;
+    esac
+  done
+}
+
+# =============================================================================
+# Section 1: Locate the legacy file service database
+# =============================================================================
+
+# 1.1 Without a reachable Docker daemon every check below would report the wrong
+# thing, so stop here instead.
+if ! docker info > /dev/null 2>&1; then
+  fail "Docker is not available. Start Docker and run this script again."
+fi
+
+if docker container inspect "$LEGACY_CONTAINER" > /dev/null 2>&1; then
+  LEGACY_SOURCE="container"
+  print_info "Found legacy container \"$LEGACY_CONTAINER\""
+elif [ -f "$LEGACY_DATA_DIR/PG_VERSION" ]; then
+  LEGACY_SOURCE="data-dir"
+  print_info "Found legacy data directory \"file-postgres/data\" (container \"$LEGACY_CONTAINER\" no longer exists)"
+else
+  LEGACY_SOURCE="none"
+  print_info "No legacy file service database found. The file service database will only be created."
+fi
+echo ""
+
+# =============================================================================
+# Section 2: Select docker-compose configuration
+# =============================================================================
+
+print_info "Select the docker-compose configuration you run Pneumatic with:"
+echo ""
+echo "  1. Root (from sources)"
+echo "  2. Root (stable)"
+echo "  3. Root (latest)"
+echo "  4. Frontend"
+echo ""
+
+while true; do
+  read -r -p "Enter configuration number (1-4): " COMPOSE_FILE || fail "No input received, aborting."
+
+  if ! [[ "$COMPOSE_FILE" =~ ^[0-9]+$ ]]; then
+    print_error "Enter the configuration number"
+    continue
+  fi
+
+  if [ "$COMPOSE_FILE" -lt 1 ] || [ "$COMPOSE_FILE" -gt 4 ]; then
+    print_error "Entered number does not match any configuration from the list"
+    continue
+  fi
+
+  break
+done
+
+COMPOSE_TAG=""
+case "$COMPOSE_FILE" in
+  1) COMPOSE_LABEL="Root (from sources)"; ENV_FILE="$PROJECT_DIR/.env";          COMPOSE_ARGS=('-f' "$PROJECT_DIR/docker-compose.src.yml") ;;
+  2) COMPOSE_LABEL="Root (stable)";       ENV_FILE="$PROJECT_DIR/.env";          COMPOSE_ARGS=('-f' "$PROJECT_DIR/docker-compose.yml"); COMPOSE_TAG="stable" ;;
+  3) COMPOSE_LABEL="Root (latest)";       ENV_FILE="$PROJECT_DIR/.env";          COMPOSE_ARGS=('-f' "$PROJECT_DIR/docker-compose.yml"); COMPOSE_TAG="latest" ;;
+  4) COMPOSE_LABEL="Frontend";            ENV_FILE="$PROJECT_DIR/frontend/.env"; COMPOSE_ARGS=('-f' "$PROJECT_DIR/frontend/docker-compose.yml") ;;
+esac
+
+# Compose resolves .env from the compose file's directory; pass the selected file explicitly.
+if [ -f "$ENV_FILE" ]; then
+  COMPOSE_ARGS=('--env-file' "$ENV_FILE" "${COMPOSE_ARGS[@]}")
+fi
+
+compose() {
+  if [ -n "$COMPOSE_TAG" ]; then
+    TAG="$COMPOSE_TAG" docker compose "${COMPOSE_ARGS[@]}" "$@"
+  else
+    docker compose "${COMPOSE_ARGS[@]}" "$@"
+  fi
+}
+
+echo ""
+print_info "Selected configuration: $COMPOSE_LABEL"
+echo ""
+
+# =============================================================================
+# Section 3: Read .env file and extract database configuration
+# =============================================================================
+
+POSTGRES_USER="postgres_user"
+POSTGRES_DB="postgres_db"
+FILE_POSTGRES_USER="pneumatic"
+FILE_POSTGRES_PASSWORD="pneumatic"
+FILE_POSTGRES_DB="pneumatic"
+
+if [ -f "$ENV_FILE" ]; then
+  while IFS='=' read -r key value || [ -n "$key" ]; do
+    key=$(echo "$key" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+    value=$(echo "$value" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+
+    [ -z "$key" ] && continue
+    [[ "$key" == \#* ]] && continue
+
+    value=$(echo "$value" | sed 's/[[:space:]]\+#.*$//;s/[[:space:]]*$//')
+    # docker compose strips surrounding quotes from .env values, so do the same
+    value=$(printf '%s' "$value" | sed -e 's/^"\(.*\)"$/\1/' -e "s/^'\(.*\)'\$/\1/")
+
+    case "$key" in
+      POSTGRES_USER)          POSTGRES_USER="$value" ;;
+      POSTGRES_DB)            POSTGRES_DB="$value" ;;
+      FILE_POSTGRES_USER)     FILE_POSTGRES_USER="$value" ;;
+      FILE_POSTGRES_PASSWORD) FILE_POSTGRES_PASSWORD="$value" ;;
+      FILE_POSTGRES_DB)       FILE_POSTGRES_DB="$value" ;;
+    esac
+  done < "$ENV_FILE"
+else
+  print_warning "No .env file found at $ENV_FILE, using default database configuration."
+fi
+
+# =============================================================================
+# Section 4: Confirm migration
+# =============================================================================
+
+# 4.1 The file service database is dropped and recreated below, so it must not
+# be the backend database.
+if [ "$FILE_POSTGRES_DB" = "$POSTGRES_DB" ]; then
+  fail "FILE_POSTGRES_DB and POSTGRES_DB are both \"$FILE_POSTGRES_DB\". This script recreates the file service database, which would destroy the backend database. Give the file service a database of its own in $ENV_FILE."
+fi
+
+if [ "$LEGACY_SOURCE" != "none" ]; then
+  print_warning "The file service database will be copied into container \"$TARGET_CONTAINER\" (database \"$FILE_POSTGRES_DB\", role \"$FILE_POSTGRES_USER\")."
+  print_warning "Any data already in that target database will be overwritten."
+  print_warning "The file service will be stopped while the migration runs."
+  confirm "Continue?"
+  echo ""
+fi
+
+# =============================================================================
+# Section 5: Dump the legacy database
+# =============================================================================
+
+if [ "$LEGACY_SOURCE" != "none" ]; then
+
+  # 5.1 Make the legacy database reachable
+  if [ "$LEGACY_SOURCE" = "container" ]; then
+    SOURCE_CONTAINER="$LEGACY_CONTAINER"
+    if [ "$(docker container inspect -f '{{.State.Running}}' "$LEGACY_CONTAINER")" != "true" ]; then
+      output=$(docker start "$LEGACY_CONTAINER" 2>&1) || fail "$output"
+      print_info "Legacy container \"$LEGACY_CONTAINER\" started"
+    fi
+  else
+    # The legacy container is gone: run a temporary PostgreSQL on the old data directory.
+    SOURCE_CONTAINER="$TEMP_CONTAINER"
+    docker rm -f "$TEMP_CONTAINER" > /dev/null 2>&1
+    MOUNT_SRC="$LEGACY_DATA_DIR"
+    if command -v cygpath > /dev/null 2>&1; then
+      MOUNT_SRC="$(cygpath -w "$LEGACY_DATA_DIR")"
+    fi
+    output=$(MSYS_NO_PATHCONV=1 docker run -d --name "$TEMP_CONTAINER" \
+      -v "$MOUNT_SRC:/var/lib/postgresql/data" \
+      -e POSTGRES_PASSWORD="$FILE_POSTGRES_PASSWORD" \
+      "$POSTGRES_IMAGE" 2>&1) || fail "$output"
+    TEMP_CONTAINER_CREATED=true
+    print_info "Temporary container \"$TEMP_CONTAINER\" started on \"file-postgres/data\""
+  fi
+
+  # 5.2 Wait for the legacy database to become available
+  print_info "Waiting for the legacy database to become available..."
+  MAX_RETRIES=30
+  RETRY_COUNT=0
+  while true; do
+    docker exec "$SOURCE_CONTAINER" pg_isready -U "$FILE_POSTGRES_USER" -d "$FILE_POSTGRES_DB" > /dev/null 2>&1
+    if [ $? -eq 0 ]; then
+      print_info "Legacy database is ready"
+      break
+    fi
+
+    RETRY_COUNT=$((RETRY_COUNT + 1))
+    if [ "$RETRY_COUNT" -ge "$MAX_RETRIES" ]; then
+      fail "Legacy database is not available after ${MAX_RETRIES} seconds"
+    fi
+
+    sleep 1
+  done
+
+  SOURCE_COUNTS=$(table_counts "$SOURCE_CONTAINER") || fail "Could not read the tables of the legacy database \"$FILE_POSTGRES_DB\". Nothing has been changed."
+  print_info "Legacy database contains: $(format_counts "$SOURCE_COUNTS")"
+
+  # 5.3 Save a plain SQL dump into postgres/backups
+  mkdir -p "$BACKUPS_DIR"
+  DUMP_FILENAME="pneumatic-file-postgres-$(date +%Y-%m-%d_%H-%M-%S).sql"
+  print_info "Dumping legacy database to \"postgres/backups/$DUMP_FILENAME\"..."
+  docker exec "$SOURCE_CONTAINER" pg_dump -U "$FILE_POSTGRES_USER" --no-owner --no-privileges "$FILE_POSTGRES_DB" > "$BACKUPS_DIR/$DUMP_FILENAME"
+  if [ $? -ne 0 ] || [ ! -s "$BACKUPS_DIR/$DUMP_FILENAME" ]; then
+    rm -f "$BACKUPS_DIR/$DUMP_FILENAME"
+    fail "Failed to dump the legacy database"
+  fi
+  print_info "Dump saved"
+  echo ""
+
+fi
+
+# =============================================================================
+# Section 6: Create the file service database in pneumatic-postgres
+# =============================================================================
+
+# 6.1 Stop the file service so nothing writes to the database during the swap
+if docker container inspect "$FILE_SERVICE_CONTAINER" > /dev/null 2>&1; then
+  docker stop "$FILE_SERVICE_CONTAINER" > /dev/null 2>&1
+  FILE_SERVICE_STOPPED=true
+  print_info "Container \"$FILE_SERVICE_CONTAINER\" stopped"
+fi
+
+# 6.2 Start the shared database container
+output=$(compose up -d postgres 2>&1) || fail "$output"
+
+print_info "Waiting for container \"$TARGET_CONTAINER\" to become available..."
+MAX_RETRIES=60
+RETRY_COUNT=0
+while true; do
+  docker exec "$TARGET_CONTAINER" pg_isready -h localhost -U "$POSTGRES_USER" > /dev/null 2>&1
+  if [ $? -eq 0 ]; then
+    print_info "Container \"$TARGET_CONTAINER\" is ready"
+    break
+  fi
+
+  RETRY_COUNT=$((RETRY_COUNT + 1))
+  if [ "$RETRY_COUNT" -ge "$MAX_RETRIES" ]; then
+    fail "Container \"$TARGET_CONTAINER\" is not available after ${MAX_RETRIES} seconds"
+  fi
+
+  sleep 1
+done
+
+# 6.3 Run the same provisioning script the container runs on a fresh data directory
+# MSYS_NO_PATHCONV keeps Git Bash on Windows from rewriting the container path.
+output=$(MSYS_NO_PATHCONV=1 docker exec "$TARGET_CONTAINER" sh "$INIT_SCRIPT" 2>&1) || fail "$output"
+print_info "Role \"$FILE_POSTGRES_USER\" and database \"$FILE_POSTGRES_DB\" are present in \"$TARGET_CONTAINER\""
+echo ""
+
+# =============================================================================
+# Section 7: Restore the dump into pneumatic-postgres
+# =============================================================================
+
+if [ "$LEGACY_SOURCE" != "none" ]; then
+
+  # 7.1 Guard against overwriting records created after the upgrade
+  # alembic_version only records the schema version, it is not data worth keeping.
+  TARGET_ROWS=$(table_counts "$TARGET_CONTAINER" | grep -v '^alembic_version=' | awk -F= '{sum += $2} END {print sum + 0}')
+  if [ "$TARGET_ROWS" -gt 0 ]; then
+    print_warning "WARNING: database \"$FILE_POSTGRES_DB\" in \"$TARGET_CONTAINER\" already contains $TARGET_ROWS record(s)."
+    print_warning "They will be replaced by the contents of the legacy database."
+    confirm "Overwrite them?"
+  fi
+
+  # 7.2 Recreate the target database through the provisioning script, so that it
+  # ends up with the same owner and privileges as on a fresh installation
+  output=$(docker exec "$TARGET_CONTAINER" dropdb -U "$POSTGRES_USER" --force --if-exists "$FILE_POSTGRES_DB" 2>&1) || fail "$output"
+  output=$(MSYS_NO_PATHCONV=1 docker exec "$TARGET_CONTAINER" sh "$INIT_SCRIPT" 2>&1) || fail "$output"
+  print_info "Database \"$FILE_POSTGRES_DB\" recreated"
+
+  # 7.3 Restore the dump as the file service role so it owns every object
+  print_info "Restoring \"$DUMP_FILENAME\" into \"$TARGET_CONTAINER\"..."
+  output=$(docker exec -i "$TARGET_CONTAINER" psql -q -v ON_ERROR_STOP=1 -U "$FILE_POSTGRES_USER" -d "$FILE_POSTGRES_DB" < "$BACKUPS_DIR/$DUMP_FILENAME" 2>&1) || fail "$output"
+
+  RESTORED_COUNTS=$(table_counts "$TARGET_CONTAINER") || fail "Could not read the restored database. The dump is kept at \"postgres/backups/$DUMP_FILENAME\"."
+  if [ "$RESTORED_COUNTS" = "$SOURCE_COUNTS" ]; then
+    print_info "Restore complete, every table matches: $(format_counts "$RESTORED_COUNTS")"
+  else
+    print_error "Legacy database: $(format_counts "$SOURCE_COUNTS")"
+    print_error "Target database: $(format_counts "$RESTORED_COUNTS")"
+    fail "The copy does not match the legacy database. The dump is kept at \"postgres/backups/$DUMP_FILENAME\"."
+  fi
+  echo ""
+
+  # =============================================================================
+  # Section 8: Remove the legacy container
+  # =============================================================================
+
+  if [ "$LEGACY_SOURCE" = "container" ]; then
+    docker rm -f "$LEGACY_CONTAINER" > /dev/null 2>&1
+    print_info "Legacy container \"$LEGACY_CONTAINER\" removed"
+  else
+    docker rm -f "$TEMP_CONTAINER" > /dev/null 2>&1
+    TEMP_CONTAINER_CREATED=false
+    print_info "Temporary container \"$TEMP_CONTAINER\" removed"
+  fi
+  print_warning "The directory \"file-postgres/data\" was left in place. Delete it once you have verified that file uploads and downloads work."
+  echo ""
+
+fi
+
+# =============================================================================
+# Section 9: Start containers
+# =============================================================================
+
+output=$(compose up -d 2>&1) || fail "$output"
+print_info "Containers successfully started"
+
+# 9.1 Nginx resolves the file service address once at startup. The file service
+# container was recreated above, so reload nginx to pick up its new address.
+if docker container inspect "$NGINX_CONTAINER" > /dev/null 2>&1; then
+  if docker exec "$NGINX_CONTAINER" nginx -s reload > /dev/null 2>&1; then
+    print_info "Nginx configuration reloaded"
+  else
+    print_warning "Could not reload nginx. If file downloads return 502, run: docker restart $NGINX_CONTAINER"
+  fi
+fi
+
+echo ""
+if [ "$LEGACY_SOURCE" = "none" ]; then
+  print_info "Done! Database \"$FILE_POSTGRES_DB\" is ready in \"$TARGET_CONTAINER\". There was nothing to copy."
+else
+  print_info "Done! The file service database now lives in \"$TARGET_CONTAINER\". Backup of the legacy database: postgres/backups/$DUMP_FILENAME"
+fi
+echo ""

--- a/scripts/migrate_file_db.sh
+++ b/scripts/migrate_file_db.sh
@@ -47,6 +47,7 @@ print_info()    { echo -e "${GREEN}$1${NC}"; }
 
 TEMP_CONTAINER_CREATED=false
 FILE_SERVICE_STOPPED=false
+LEGACY_STOPPED=false
 
 fail() {
   print_error "$1"
@@ -58,7 +59,34 @@ fail() {
     # files from it would be worse than serving none.
     print_warning "Container \"$FILE_SERVICE_CONTAINER\" is still stopped. Fix the problem and run this script again, or start it with: docker start $FILE_SERVICE_CONTAINER"
   fi
+  if [ "$LEGACY_STOPPED" = true ]; then
+    print_warning "Legacy container \"$LEGACY_CONTAINER\" is stopped but still holds the original data."
+  fi
   exit 1
+}
+
+# Cancelling is only offered while nothing has been overwritten yet, so put the
+# stack back the way it was found rather than leaving the file service down.
+cancel() {
+  print_warning "Operation cancelled."
+  if [ "$TEMP_CONTAINER_CREATED" = true ]; then
+    docker rm -f "$TEMP_CONTAINER" > /dev/null 2>&1
+  fi
+  if [ "$LEGACY_STOPPED" = true ]; then
+    if docker start "$LEGACY_CONTAINER" > /dev/null 2>&1; then
+      print_info "Legacy container \"$LEGACY_CONTAINER\" started again"
+    else
+      print_warning "Could not start \"$LEGACY_CONTAINER\" again. Start it with: docker start $LEGACY_CONTAINER"
+    fi
+  fi
+  if [ "$FILE_SERVICE_STOPPED" = true ]; then
+    if docker start "$FILE_SERVICE_CONTAINER" > /dev/null 2>&1; then
+      print_info "Container \"$FILE_SERVICE_CONTAINER\" started again"
+    else
+      print_warning "Could not start \"$FILE_SERVICE_CONTAINER\" again. Start it with: docker start $FILE_SERVICE_CONTAINER"
+    fi
+  fi
+  exit 0
 }
 
 # Row count of every table in the file service database, one "table=count" line
@@ -90,7 +118,7 @@ confirm() {
     read -r -p "$1 (y/n): " answer || fail "No input received, aborting."
     case "$answer" in
       y) return 0 ;;
-      n) print_warning "Operation cancelled."; exit 0 ;;
+      n) cancel ;;
       *) ;;
     esac
   done
@@ -224,12 +252,21 @@ if [ "$LEGACY_SOURCE" != "none" ]; then
 fi
 
 # =============================================================================
-# Section 5: Dump the legacy database
+# Section 5: Stop the file service and dump the legacy database
 # =============================================================================
+
+# 5.1 Stop the file service before the legacy database is read. Stopping it
+# afterwards would leave a window in which an upload lands in the old database
+# and never reaches the new one.
+if docker container inspect "$FILE_SERVICE_CONTAINER" > /dev/null 2>&1; then
+  output=$(docker stop "$FILE_SERVICE_CONTAINER" 2>&1) || fail "Could not stop \"$FILE_SERVICE_CONTAINER\": $output"
+  FILE_SERVICE_STOPPED=true
+  print_info "Container \"$FILE_SERVICE_CONTAINER\" stopped"
+fi
 
 if [ "$LEGACY_SOURCE" != "none" ]; then
 
-  # 5.1 Make the legacy database reachable
+  # 5.2 Make the legacy database reachable
   if [ "$LEGACY_SOURCE" = "container" ]; then
     SOURCE_CONTAINER="$LEGACY_CONTAINER"
     if [ "$(docker container inspect -f '{{.State.Running}}' "$LEGACY_CONTAINER")" != "true" ]; then
@@ -252,7 +289,7 @@ if [ "$LEGACY_SOURCE" != "none" ]; then
     print_info "Temporary container \"$TEMP_CONTAINER\" started on \"file-postgres/data\""
   fi
 
-  # 5.2 Wait for the legacy database to become available
+  # 5.3 Wait for the legacy database to become available
   print_info "Waiting for the legacy database to become available..."
   MAX_RETRIES=30
   RETRY_COUNT=0
@@ -274,7 +311,7 @@ if [ "$LEGACY_SOURCE" != "none" ]; then
   SOURCE_COUNTS=$(table_counts "$SOURCE_CONTAINER") || fail "Could not read the tables of the legacy database \"$FILE_POSTGRES_DB\". Nothing has been changed."
   print_info "Legacy database contains: $(format_counts "$SOURCE_COUNTS")"
 
-  # 5.3 Save a plain SQL dump into postgres/backups
+  # 5.4 Save a plain SQL dump into postgres/backups
   mkdir -p "$BACKUPS_DIR"
   DUMP_FILENAME="pneumatic-file-postgres-$(date +%Y-%m-%d_%H-%M-%S).sql"
   print_info "Dumping legacy database to \"postgres/backups/$DUMP_FILENAME\"..."
@@ -284,6 +321,15 @@ if [ "$LEGACY_SOURCE" != "none" ]; then
     fail "Failed to dump the legacy database"
   fi
   print_info "Dump saved"
+
+  # 5.5 The legacy database has been read, so stop its container. It publishes
+  # the same host port as the shared database container does in the frontend
+  # configuration, and the next step could not bind that port otherwise.
+  if [ "$LEGACY_SOURCE" = "container" ]; then
+    output=$(docker stop "$LEGACY_CONTAINER" 2>&1) || fail "Could not stop \"$LEGACY_CONTAINER\": $output"
+    LEGACY_STOPPED=true
+    print_info "Legacy container \"$LEGACY_CONTAINER\" stopped"
+  fi
   echo ""
 
 fi
@@ -292,14 +338,7 @@ fi
 # Section 6: Create the file service database in pneumatic-postgres
 # =============================================================================
 
-# 6.1 Stop the file service so nothing writes to the database during the swap
-if docker container inspect "$FILE_SERVICE_CONTAINER" > /dev/null 2>&1; then
-  docker stop "$FILE_SERVICE_CONTAINER" > /dev/null 2>&1
-  FILE_SERVICE_STOPPED=true
-  print_info "Container \"$FILE_SERVICE_CONTAINER\" stopped"
-fi
-
-# 6.2 Start the shared database container
+# 6.1 Start the shared database container
 output=$(compose up -d postgres 2>&1) || fail "$output"
 
 print_info "Waiting for container \"$TARGET_CONTAINER\" to become available..."
@@ -320,7 +359,7 @@ while true; do
   sleep 1
 done
 
-# 6.3 Run the same provisioning script the container runs on a fresh data directory
+# 6.2 Run the same provisioning script the container runs on a fresh data directory
 # MSYS_NO_PATHCONV keeps Git Bash on Windows from rewriting the container path.
 output=$(MSYS_NO_PATHCONV=1 docker exec "$TARGET_CONTAINER" sh "$INIT_SCRIPT" 2>&1) || fail "$output"
 print_info "Role \"$FILE_POSTGRES_USER\" and database \"$FILE_POSTGRES_DB\" are present in \"$TARGET_CONTAINER\""
@@ -334,7 +373,10 @@ if [ "$LEGACY_SOURCE" != "none" ]; then
 
   # 7.1 Guard against overwriting records created after the upgrade
   # alembic_version only records the schema version, it is not data worth keeping.
-  TARGET_ROWS=$(table_counts "$TARGET_CONTAINER" | grep -v '^alembic_version=' | awk -F= '{sum += $2} END {print sum + 0}')
+  # Read separately from the sum: inside a pipeline the exit status would be
+  # awk's, so an unreadable database would look empty and skip the warning.
+  TARGET_COUNTS=$(table_counts "$TARGET_CONTAINER") || fail "Could not read the target database \"$FILE_POSTGRES_DB\". Nothing has been overwritten."
+  TARGET_ROWS=$(printf '%s\n' "$TARGET_COUNTS" | grep -v '^alembic_version=' | awk -F= '{sum += $2} END {print sum + 0}')
   if [ "$TARGET_ROWS" -gt 0 ]; then
     print_warning "WARNING: database \"$FILE_POSTGRES_DB\" in \"$TARGET_CONTAINER\" already contains $TARGET_ROWS record(s)."
     print_warning "They will be replaced by the contents of the legacy database."

--- a/scripts/migrate_file_db.sh
+++ b/scripts/migrate_file_db.sh
@@ -48,46 +48,72 @@ print_info()    { echo -e "${GREEN}$1${NC}"; }
 TEMP_CONTAINER_CREATED=false
 FILE_SERVICE_STOPPED=false
 LEGACY_STOPPED=false
+# Set once the target database is about to be dropped. Up to that point every
+# exit can put the stack back; after it the copy may be incomplete.
+TARGET_MUTATED=false
 
-fail() {
-  print_error "$1"
+# Puts the containers back the way they were found. Only correct while
+# TARGET_MUTATED is false.
+restore_stack() {
+  local legacy_back=true
+
   if [ "$TEMP_CONTAINER_CREATED" = true ]; then
     docker rm -f "$TEMP_CONTAINER" > /dev/null 2>&1
+    TEMP_CONTAINER_CREATED=false
   fi
-  if [ "$FILE_SERVICE_STOPPED" = true ]; then
-    # Deliberately not restarted: the database may be half copied, and serving
-    # files from it would be worse than serving none.
-    print_warning "Container \"$FILE_SERVICE_CONTAINER\" is still stopped. Fix the problem and run this script again, or start it with: docker start $FILE_SERVICE_CONTAINER"
-  fi
-  if [ "$LEGACY_STOPPED" = true ]; then
-    print_warning "Legacy container \"$LEGACY_CONTAINER\" is stopped but still holds the original data."
-  fi
-  exit 1
-}
 
-# Cancelling is only offered while nothing has been overwritten yet, so put the
-# stack back the way it was found rather than leaving the file service down.
-cancel() {
-  print_warning "Operation cancelled."
-  if [ "$TEMP_CONTAINER_CREATED" = true ]; then
-    docker rm -f "$TEMP_CONTAINER" > /dev/null 2>&1
-  fi
   if [ "$LEGACY_STOPPED" = true ]; then
     if docker start "$LEGACY_CONTAINER" > /dev/null 2>&1; then
+      LEGACY_STOPPED=false
       print_info "Legacy container \"$LEGACY_CONTAINER\" started again"
     else
-      print_warning "Could not start \"$LEGACY_CONTAINER\" again. Start it with: docker start $LEGACY_CONTAINER"
+      legacy_back=false
+      print_warning "Could not start \"$LEGACY_CONTAINER\" again, \"$TARGET_CONTAINER\" now holds the host port it publishes."
     fi
   fi
+
   if [ "$FILE_SERVICE_STOPPED" = true ]; then
-    if docker start "$FILE_SERVICE_CONTAINER" > /dev/null 2>&1; then
+    if [ "$legacy_back" = false ]; then
+      # Starting it now would only crash-loop against a database that is gone.
+      print_warning "Container \"$FILE_SERVICE_CONTAINER\" is left stopped, because the database it is configured for is not running."
+      print_warning "To finish the migration instead, run this script again. To go back, stop \"$TARGET_CONTAINER\", then start \"$LEGACY_CONTAINER\" and \"$FILE_SERVICE_CONTAINER\"."
+    elif docker start "$FILE_SERVICE_CONTAINER" > /dev/null 2>&1; then
+      FILE_SERVICE_STOPPED=false
       print_info "Container \"$FILE_SERVICE_CONTAINER\" started again"
     else
       print_warning "Could not start \"$FILE_SERVICE_CONTAINER\" again. Start it with: docker start $FILE_SERVICE_CONTAINER"
     fi
   fi
+}
+
+fail() {
+  print_error "$1"
+  if [ "$TARGET_MUTATED" = true ]; then
+    if [ "$TEMP_CONTAINER_CREATED" = true ]; then
+      docker rm -f "$TEMP_CONTAINER" > /dev/null 2>&1
+    fi
+    # Deliberately not restarted: the target database may be half copied, and
+    # serving files from it would be worse than serving none.
+    print_warning "Container \"$FILE_SERVICE_CONTAINER\" is left stopped, because \"$FILE_POSTGRES_DB\" may be partially restored. The dump is kept in postgres/backups."
+    if [ "$LEGACY_STOPPED" = true ]; then
+      print_warning "Legacy container \"$LEGACY_CONTAINER\" is stopped but still holds the original data."
+    fi
+  else
+    print_warning "Nothing has been overwritten, putting the containers back."
+    restore_stack
+  fi
+  exit 1
+}
+
+cancel() {
+  print_warning "Operation cancelled."
+  restore_stack
   exit 0
 }
+
+# Ctrl+C during the dump, a readiness loop or the restore would otherwise leave
+# containers stopped and the temporary one running.
+trap 'trap - INT TERM; echo ""; fail "Interrupted."' INT TERM
 
 # Row count of every table in the file service database, one "table=count" line
 # each. The copy is verified against this rather than against a single table, so
@@ -385,6 +411,7 @@ if [ "$LEGACY_SOURCE" != "none" ]; then
 
   # 7.2 Recreate the target database through the provisioning script, so that it
   # ends up with the same owner and privileges as on a fresh installation
+  TARGET_MUTATED=true
   output=$(docker exec "$TARGET_CONTAINER" dropdb -U "$POSTGRES_USER" --force --if-exists "$FILE_POSTGRES_DB" 2>&1) || fail "$output"
   output=$(MSYS_NO_PATHCONV=1 docker exec "$TARGET_CONTAINER" sh "$INIT_SCRIPT" 2>&1) || fail "$output"
   print_info "Database \"$FILE_POSTGRES_DB\" recreated"

--- a/scripts/postgres-init/create-file-service-db.sh
+++ b/scripts/postgres-init/create-file-service-db.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+# =============================================================================
+# Provision the file service database next to the backend database
+#
+# The file service keeps its data in its own database and under its own role,
+# inside the shared "pneumatic-postgres" container. This script creates both if
+# they are missing and does nothing if they already exist.
+#
+# It runs automatically from /docker-entrypoint-initdb.d when the PostgreSQL
+# data directory is initialised. On an installation whose data directory
+# already exists it can be executed by hand at any time:
+#
+#   docker exec pneumatic-postgres sh /docker-entrypoint-initdb.d/create-file-service-db.sh
+#
+# (scripts/migrate_file_db.sh does exactly that when upgrading.)
+# =============================================================================
+
+set -e
+
+FILE_POSTGRES_USER="${FILE_POSTGRES_USER:-pneumatic}"
+FILE_POSTGRES_PASSWORD="${FILE_POSTGRES_PASSWORD:-pneumatic}"
+FILE_POSTGRES_DB="${FILE_POSTGRES_DB:-pneumatic}"
+
+# Connects over the local socket, where the image trusts every user, so this
+# works both during initialisation and inside an already running container.
+psql -v ON_ERROR_STOP=1 --no-password \
+  --username "${POSTGRES_USER:-postgres}" \
+  --dbname postgres \
+  -v file_user="$FILE_POSTGRES_USER" \
+  -v file_password="$FILE_POSTGRES_PASSWORD" \
+  -v file_db="$FILE_POSTGRES_DB" <<'SQL'
+SELECT format('CREATE ROLE %I LOGIN PASSWORD %L', :'file_user', :'file_password')
+  WHERE NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = :'file_user') \gexec
+SELECT format('CREATE DATABASE %I OWNER %I', :'file_db', :'file_user')
+  WHERE NOT EXISTS (SELECT 1 FROM pg_database WHERE datname = :'file_db') \gexec
+-- Only the owner and superusers reach the file service data, the way they did
+-- when it lived in a container of its own. Restricted to a database the file
+-- service role owns, so that pointing FILE_POSTGRES_DB at an existing database,
+-- the backend one included, cannot take privileges away from it.
+SELECT format('REVOKE CONNECT ON DATABASE %I FROM PUBLIC', :'file_db')
+  FROM pg_database
+ WHERE datname = :'file_db' AND pg_get_userbyid(datdba) = :'file_user' \gexec
+SQL
+
+echo "File service database \"$FILE_POSTGRES_DB\" is ready"


### PR DESCRIPTION
## 1. Description (problem)

The file service ran against its own PostgreSQL database in a separate container, `pneumatic-file-postgres`, alongside the main `pneumatic-postgres` container that serves the backend database. That meant two PostgreSQL processes, two data volumes, and two places to back up and monitor for what is, in effect, a single installation. This showed up in the deployment configuration (`docker-compose.yml`, `docker-compose.src.yml`, `frontend/docker-compose.yml`) and in the `file-postgres/` directory, not in the UI — end users never saw it.

## 2. Context

The goal was to reduce the number of running PostgreSQL processes to one, while keeping backend and file service data logically separated as distinct databases and roles inside a single cluster. Constraint: the change had to work both for fresh installs (self-hosted, `start.sh`) and for installations already running, where the old container could hold real file history.

## 3. Solution

The file service database now lives inside the shared `pneumatic-postgres` container as a separate database with its own role, with no shared privileges with the backend database. Creating the database and role is handed to PostgreSQL's own image-initialization mechanism (`/docker-entrypoint-initdb.d/`) rather than to a separate one-shot container — this is the single place that will need a change later when moving to one shared database, instead of three places across three compose files. For installations already running the old separate database, a migration script moves the data over once, during the upgrade.

## 4. Implementation Details

- **`scripts/postgres-init/create-file-service-db.sh`** — mounted into `/docker-entrypoint-initdb.d/` on the `postgres` container. Runs automatically when a new cluster is initialized. Idempotent: creates the role and database only if they don't already exist. Revokes `CONNECT` from `PUBLIC` on the file service database, but only when that database is actually owned by the file service role — a guard against `FILE_POSTGRES_DB` being misconfigured to point at an existing database (e.g. the backend one), so the script can't strip privileges from a database it didn't create.
- The shared **`postgres`** service in all three compose files now has a healthcheck (`pg_isready -h localhost`, `start_period: 60s`) — it previously had no readiness check at all. `file-service` (and anything else that used to) now waits on `postgres: service_healthy` instead of the health of the separate `file-postgres`.
- The **`file-postgres`** container and service have been **removed** from `docker-compose.yml`, `docker-compose.src.yml`, and `frontend/docker-compose.yml`.
- `FILE_POSTGRES_HOST` default changed from `file-postgres` to `postgres` for `backend`, `celery`, `celery-beat`, and `file-service` in all three files; `default.env` updated to match.
- `frontend/docker-compose.yml`: the shared `postgres` now publishes port `5433:5432` on the host — that port used to belong to `file-postgres` specifically, and is needed for running the file service locally outside its container.
- **`scripts/migrate_file_db.sh`** — a new script for existing installations. It locates the old database (a running `pneumatic-file-postgres` container, or a leftover `file-postgres/data` directory), runs `pg_dump` into `postgres/backups/`, provisions the target database through the same provisioning script (so privileges match a fresh install), restores the dump, and verifies row counts per table before and after — across every table, not just one. It stops before any destructive action if `FILE_POSTGRES_DB` equals `POSTGRES_DB`, since otherwise the script's `dropdb` step would delete the backend database. After the file service container is recreated it reloads `nginx`, since nginx caches the upstream IP and would otherwise serve 502s.
- **`.gitattributes`** (`*.sh text eol=lf`) — without it, on Windows with the default `core.autocrlf=true` (a Git for Windows system setting, not a personal one), the provisioning script gets checked out with CRLF line endings. The PostgreSQL image's entrypoint then fails to execute it (`cannot execute: required file not found`), and because the entrypoint runs with `set -e`, the whole database container crashes. That breaks the very first run of the project on Windows entirely, not just the file service.
- The `file-postgres/data/` directory is not deleted automatically by the migration script — only a warning to remove it manually once verified.

## 5. What to Test

### 5.1 Preconditions

- Docker Desktop, branch `storage/configuration/49477__combine_two_postgresql_containers_into_one`.
- For upgrade scenarios — a working installation with the old `pneumatic-file-postgres` container or a leftover `file-postgres/data` directory from a previous version.
- For the fresh-install scenario — an empty or missing `postgres/data` directory.
- No second user is required; every scenario is run by a single operator on the host.

### 5.2 Positive Scenarios

1. Remove (or rename) `postgres/data`, run `docker compose -f docker-compose.src.yml up -d`. Expected: the `postgres` container becomes `healthy` only after initialization completes, `file-service` starts without restarts, and `alembic` applies both migrations from scratch.
2. Request `GET /files/openapi.json` through nginx. Expected: HTTP 200.
3. Request `GET /files/<any_id>` without a token. Expected: HTTP 401.
4. Run `docker compose up -d` again. Expected: no containers are recreated, the file service's `RestartCount` does not increase.
5. On an installation with the old `pneumatic-file-postgres` container, run `scripts/migrate_file_db.sh` and pick the relevant compose file. Expected: a dump is saved under `postgres/backups/`, per-table row counts match before and after, the old container is removed, nginx is reloaded, and `/files/openapi.json` returns 200.
6. Run the same script on an installation with no file service at all (no container, no directory). Expected: the script reports there is nothing to migrate and simply creates the database, with no errors.

### 5.3 Negative Scenarios and Edge Cases

1. Set `FILE_POSTGRES_DB` equal to `POSTGRES_DB` in `.env` and run `scripts/migrate_file_db.sh`. Expected: the script stops with a clear error before making any changes to containers, and the backend database is untouched.
2. Stop Docker Desktop and run `scripts/migrate_file_db.sh`. Expected: the script immediately reports Docker is unavailable, rather than failing on the first command with a confusing error.
3. Interrupt `scripts/migrate_file_db.sh` during the dump-restore step (e.g. kill the container manually). Expected: the script reports the file service is left stopped and how to start it manually; the dump under `postgres/backups/` is preserved.
4. Check out the previous commit on Windows with default Git settings and bring the stack up from scratch. Expected (this is the regression the PR fixes): without `.gitattributes`, the `postgres` container crash-loops due to CRLF in the provisioning script. With this PR, it starts normally.

### 5.4 Verification Points

- `docker ps -a` — status and `RestartCount` of every `pneumatic-*` container.
- `psql` against `pneumatic-postgres`: `select datname, pg_get_userbyid(datdba), datacl from pg_database` — the file service database (`pneumatic`) is owned by the `pneumatic` role with `PUBLIC` access revoked; the backend database is unchanged.
- Row counts in `files` (file service) and in any backend tables match the pre-upgrade state.
- `postgres/backups/` contains a timestamped dump.
- `pneumatic-nginx` logs show no fresh `502`s on `/files/*` after the migration.

### 5.5 API Checks

Not applicable — the HTTP API contracts of the file service and backend are unchanged; only the database's location and provisioning changed.

### 5.6 What Was NOT Tested

- Not tested on macOS/Linux hosts — all checks were run on Windows with Docker Desktop, which is also where the CRLF regression was found.
- Not tested in production, only locally.
- The interactive `start.sh` fresh-install flow was not exercised end to end (the `docker compose up` logic was checked, but not the script's interactive prompts).
- Locales were not touched and were not tested.

## 6. Testing Affected Areas (dependencies)

- **`backend/src/processes/management/commands/sync_files_to_file_service.py`** and **`run_file_migration.py`** — use `FILE_POSTGRES_*` for direct backend access to the file service database. Verify the connection still works with the same environment variables, just with `postgres` as the host instead of `file-postgres`.
- **`storage/src/.env`** (local, non-containerized file service development) — expects host port `5433`. Verify a connection from the host on `5433` reaches the file service database through the shared container.
- **`scripts/postgres_terminal.sh`, `scripts/create_backup.sh`, `scripts/restore_backup.sh`** — operate on the backend database in the same `pneumatic-postgres` container. Not changed in behavior, but worth running once since this container now also holds the file service database.
- **`nginx/templates/nginx.conf.template`** — has a static upstream for `pneumatic-file-service`. Any recreation of the file service container (not just through the migration script) can leave nginx pointed at a stale IP — requires `docker exec pneumatic-nginx nginx -s reload`.

## 7. Refactoring

Yes. The first version of this change created the file service database through a one-shot init container, with the same command duplicated across all three compose files — a future move to a single shared database would have meant editing three places. This was extracted into a single script, `scripts/postgres-init/create-file-service-db.sh`, mounted via a volume — the next schema change only needs one file edited. Startup ordering was also changed from relying on container start order to an explicit healthcheck with `depends_on: condition: service_healthy`.

In addition to the main functionality, verify:
- Behavior on repeated restarts of the `postgres` container is unchanged (data and privileges persist).
- Other places that reference `FILE_POSTGRES_HOST` (see section 6) are not broken by the new default.

## 8. Commits with Fixes

- `51a310c3` — `49477 refactor(docker): merge file service database into pneumatic-postgres`

## 9. Release Notes

The backend and file service now share a single PostgreSQL container with two separate databases, instead of two separate containers. New installations are configured automatically. Existing installations should run `scripts/migrate_file_db.sh` once before upgrading, to move the file service data over.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Deployment and database topology change with a destructive migration path if env vars are wrong; safeguards exist but operators must run migrate_file_db.sh on existing installs.
> 
> **Overview**
> **Collapses the dedicated `file-postgres` container into the existing `postgres` service**, so the file service uses a separate database and role in the same PostgreSQL instance as the backend.
> 
> Compose files (`docker-compose.yml`, `docker-compose.src.yml`, `frontend/docker-compose.yml`) **drop the `file-postgres` service**, change default **`FILE_POSTGRES_HOST` to `postgres`**, mount **`scripts/postgres-init`** for first-boot provisioning, and add a **`postgres` healthcheck** so `file-service` waits on **`service_healthy`**. In **`frontend/docker-compose.yml`**, host port **5433** moves from the removed container to shared **`postgres`**.
> 
> **`create-file-service-db.sh`** provisions the file-service role/database idempotently (including revoking `PUBLIC` connect when it owns the DB). **`migrate_file_db.sh`** is the one-time upgrade path: dump legacy data to **`postgres/backups`**, restore into shared postgres with per-table row-count verification, tear down the old container, and reload nginx. **`.gitattributes`** forces **LF** on **`*.sh`** so init scripts run on Windows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89639b7b27d798f9c9fd0f7b58564a573b6864dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Combine `file-postgres` and `postgres` containers into a single shared PostgreSQL service
> - Removes the standalone `file-postgres` service from all compose files and moves file-service database credentials and init scripts into the shared `postgres` container
> - Updates `FILE_POSTGRES_HOST` and `POSTGRES_HOST` defaults from `file-postgres` to `postgres` across backend, celery worker, celery beat, and file service in [docker-compose.yml](https://github.com/pneumaticapp/pneumaticworkflow/pull/365/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3), [docker-compose.src.yml](https://github.com/pneumaticapp/pneumaticworkflow/pull/365/files#diff-f11168a69acca5524406d63f8be3493d9ca6df2b7f36502a45741fa7eee098aa), and [frontend/docker-compose.yml](https://github.com/pneumaticapp/pneumaticworkflow/pull/365/files#diff-1e95c17bec7bd3a8469a19e10405f0f4a25e5c23460ec46d396446161b6a2c73)
> - Adds [create-file-service-db.sh](https://github.com/pneumaticapp/pneumaticworkflow/pull/365/files#diff-cc5a47d0e3c988deff07b739543159b6ab4c8110b6a260c52513eb2f9fd3aabe), an idempotent init script that creates the file-service role and database in the shared container
> - Adds [migrate_file_db.sh](https://github.com/pneumaticapp/pneumaticworkflow/pull/365/files#diff-75fc12196b58b027ba8023c716e00bcfe85e0bc0513fc0d68ec3c58f02cc22cb), an interactive migration script that dumps the legacy file-service database, provisions the target in the shared container, restores the dump, verifies row counts, removes the legacy container, and restarts the stack
> - Adds `*.sh` LF line-ending enforcement in [.gitattributes](https://github.com/pneumaticapp/pneumaticworkflow/pull/365/files#diff-618cd5b83d62060ba3d027e314a21ceaf75d36067ff820db126642944145393e)
> - Behavioral Change: existing deployments with a running `file-postgres` container must run the migration script before upgrading; services now depend on the shared `postgres` health check instead of `file-postgres`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 89639b7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->