### PR TITLE
49563 frontend [ CI/CD ] Fix Prettier and Stylelint errors on master after lint stack migration

### DIFF
--- a/frontend/src/public/components/RichEditor/components/EditorToolbar/EditorToolbar.tsx
+++ b/frontend/src/public/components/RichEditor/components/EditorToolbar/EditorToolbar.tsx
@@ -193,7 +193,6 @@ export function EditorToolbar({
             ))}
           </>
         )}
-
       </div>
     </div>
   );

--- a/frontend/src/public/components/RichEditor/components/LexicalEditorContent/LexicalEditorContent.css
+++ b/frontend/src/public/components/RichEditor/components/LexicalEditorContent/LexicalEditorContent.css
@@ -22,13 +22,13 @@
 }
 
 .controls-wrapper {
-  margin-top: 1rem;
   display: flex;
   flex-wrap: wrap;
   gap: 0.8rem;
   align-items: center;
   justify-content: space-between;
   width: 100%;
+  margin-top: 1rem;
 }
 
 .content-editable {

--- a/frontend/src/public/components/TemplateEdit/TaskForm/Conditions/ConditionValueField/__tests__/ConditionValueField.test.tsx
+++ b/frontend/src/public/components/TemplateEdit/TaskForm/Conditions/ConditionValueField/__tests__/ConditionValueField.test.tsx
@@ -57,16 +57,17 @@ const dateVariable: TTaskVariable = {
   type: EExtraFieldType.Date,
 };
 
-const makeDateRule = (overrides: Partial<TConditionRule> = {}): TConditionRule => ({
-  ruleApiName: 'rule-1',
-  predicateApiName: 'pred-1',
-  logicOperation: EConditionLogicOperations.And,
-  field: dateVariable.apiName,
-  fieldType: EExtraFieldType.Date,
-  operator: null,
-  value: undefined,
-  ...overrides,
-} as TConditionRule);
+const makeDateRule = (overrides: Partial<TConditionRule> = {}): TConditionRule =>
+  ({
+    ruleApiName: 'rule-1',
+    predicateApiName: 'pred-1',
+    logicOperation: EConditionLogicOperations.And,
+    field: dateVariable.apiName,
+    fieldType: EExtraFieldType.Date,
+    operator: null,
+    value: undefined,
+    ...overrides,
+  }) as TConditionRule;
 
 const renderValueField = (props: Partial<React.ComponentProps<typeof ConditionValueField>> = {}) =>
   render(

--- a/frontend/src/public/components/UI/Fields/AttachmentField/AttachmentField.tsx
+++ b/frontend/src/public/components/UI/Fields/AttachmentField/AttachmentField.tsx
@@ -186,9 +186,9 @@ export function AttachmentField({
   };
 
   const handleDeleteFile = (id: string) => () => {
-    const newUploadedFiles = filesToUploadRef.current.map((file) => (
-      file.id === id ? { ...file, isRemoved: true } : file
-    ));
+    const newUploadedFiles = filesToUploadRef.current.map((file) =>
+      file.id === id ? { ...file, isRemoved: true } : file,
+    );
     applyLocalFiles(newUploadedFiles);
   };
 

--- a/frontend/src/public/components/UI/Fields/AttachmentField/__tests__/AttachmentField.test.tsx
+++ b/frontend/src/public/components/UI/Fields/AttachmentField/__tests__/AttachmentField.test.tsx
@@ -60,9 +60,7 @@ const uploadedLogo: TUploadedFile = {
   size: 20,
 };
 
-const renderField = (
-  props: Partial<React.ComponentProps<typeof AttachmentField>> = {},
-) => {
+const renderField = (props: Partial<React.ComponentProps<typeof AttachmentField>> = {}) => {
   const setUploadedFiles = props.setUploadedFiles || jest.fn();
 
   return {
@@ -117,9 +115,7 @@ describe('AttachmentField', () => {
     await waitFor(() => {
       expect(screen.queryByAltText(savedLogo.name)).not.toBeInTheDocument();
     });
-    expect(setUploadedFiles).toHaveBeenCalledWith([
-      expect.objectContaining({ id: savedLogo.id, isRemoved: true }),
-    ]);
+    expect(setUploadedFiles).toHaveBeenCalledWith([expect.objectContaining({ id: savedLogo.id, isRemoved: true })]);
   });
 
   it('should show files when the parent hydrates uploadedFiles after mount', () => {
@@ -162,18 +158,19 @@ describe('AttachmentField', () => {
       fireEvent.change(fileInput, { target: { files: [file] } });
     });
 
-    const renderWithFiles = (files: TUploadedFile[]) => rerender(
-      <IntlProvider locale="en" messages={enMessages}>
-        <AttachmentField
-          accountId={1}
-          uploadedFiles={files}
-          setUploadedFiles={jest.fn()}
-          acceptedType="image"
-          expectedImageWidth={80}
-          expectedImageHeight={80}
-        />
-      </IntlProvider>,
-    );
+    const renderWithFiles = (files: TUploadedFile[]) =>
+      rerender(
+        <IntlProvider locale="en" messages={enMessages}>
+          <AttachmentField
+            accountId={1}
+            uploadedFiles={files}
+            setUploadedFiles={jest.fn()}
+            acceptedType="image"
+            expectedImageWidth={80}
+            expectedImageHeight={80}
+          />
+        </IntlProvider>,
+      );
 
     renderWithFiles([{ ...uploadedLogo, id: uploadedLogo.url, name: '' }]);
     renderWithFiles([storedLogo]);


### PR DESCRIPTION
Co-authored-by: Cursor <cursoragent@cursor.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to formatting and CSS property order with no logic or API changes.
> 
> **Overview**
> This PR applies **formatting-only** fixes so CI passes after the frontend lint stack migration—no intended runtime or test behavior changes.
> 
> **Stylelint:** In `LexicalEditorContent.css`, `margin-top` on `.controls-wrapper` was moved to the end of the rule block to satisfy declaration ordering.
> 
> **Prettier:** Whitespace and wrapping were normalized in `EditorToolbar.tsx`, `AttachmentField.tsx` (delete handler `map` callback), and test helpers/expectations in `ConditionValueField.test.tsx` and `AttachmentField.test.tsx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bc7c73d789a61666956b5e964156941c92cd59f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Prettier and Stylelint formatting errors after lint stack migration
> Applies formatter-driven reformatting to several frontend files to clear lint errors on master. Changes cover CSS declaration ordering in [LexicalEditorContent.css](https://github.com/pneumaticapp/pneumaticworkflow/pull/367/files#diff-d8a268dff8834c0ad586bcfe07f957ff0f138b203f76169c58db6eb95aea7b12) and code formatting in [ConditionValueField.test.tsx](https://github.com/pneumaticapp/pneumaticworkflow/pull/367/files#diff-b499ba176d2a675cc07808ad5db38f8ccbd8cd29479725f2bc78516482a40308) and [AttachmentField.tsx](https://github.com/pneumaticapp/pneumaticworkflow/pull/367/files#diff-965bd8d191b2c24822e0210cf73d08f6df740fe09e8c37f2fa9db0b357faa292) plus its tests. No runtime behavior or logic changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9bc7c73.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->